### PR TITLE
Update climate_ir.md - advanced_commands_support

### DIFF
--- a/content/components/climate/climate_ir.md
+++ b/content/components/climate/climate_ir.md
@@ -95,7 +95,7 @@ climate:
     sensor: room_temperature
     header_high: 3265us # AC Units from LG in Brazil, for example use these timings
     header_low: 9856us
-    alternative_mode: false
+    advanced_commands_support: false
 ```
 
 {{< anchor "daikin_brc" >}}

--- a/content/components/climate/climate_ir.md
+++ b/content/components/climate/climate_ir.md
@@ -85,7 +85,7 @@ climate:
 - **bit_high** (*Optional*, [Time](#config-time)): time for the high part of any bit in the LG protocol. Defaults to `600us`
 - **bit_one_low** (*Optional*, [Time](#config-time)): time for the low part of a '1' bit in the LG protocol. Defaults to `1600us`
 - **bit_zero_low** (*Optional*, [Time](#config-time)): time for the low part of a '0' bit in the LG protocol. Defaults to `550us`
-- **advanced_commands_support** (*Optional*, boolean): enables an advanced control mode for newer units, allowing temperature regulation in `Heat/Cool` mode and vertical airflow adjustment (6 fixed positions +  up/down swing) also swing mode is remembered after powering off. Defaults to `false`.
+- **advanced_commands_support** (*Optional*, boolean): enables an advanced control mode for newer units, allowing temperature regulation in `Heat/Cool` mode and vertical airflow adjustment (6 fixed positions +  up/down swing).  Swing mode is remembered after powering off as well. Defaults to `false`.
 
 ```yaml
 # Example configuration entry

--- a/content/components/climate/climate_ir.md
+++ b/content/components/climate/climate_ir.md
@@ -85,7 +85,7 @@ climate:
 - **bit_high** (*Optional*, [Time](#config-time)): time for the high part of any bit in the LG protocol. Defaults to `600us`
 - **bit_one_low** (*Optional*, [Time](#config-time)): time for the low part of a '1' bit in the LG protocol. Defaults to `1600us`
 - **bit_zero_low** (*Optional*, [Time](#config-time)): time for the low part of a '0' bit in the LG protocol. Defaults to `550us`
-- **alternative_mode** (*Optional*, boolean): enables an alternative control mode for newer units, allowing temperature regulation in `Heat/Cool` mode and vertical airflow adjustment (6 fixed positions +  up/down swing) also swing mode is remembered after powering off. Defaults to `false`
+- **advanced_commands_support** (*Optional*, boolean): enables an advanced control mode for newer units, allowing temperature regulation in `Heat/Cool` mode and vertical airflow adjustment (6 fixed positions +  up/down swing) also swing mode is remembered after powering off. Defaults to `false`.
 
 ```yaml
 # Example configuration entry

--- a/content/components/climate/climate_ir.md
+++ b/content/components/climate/climate_ir.md
@@ -85,6 +85,7 @@ climate:
 - **bit_high** (*Optional*, [Time](#config-time)): time for the high part of any bit in the LG protocol. Defaults to `600us`
 - **bit_one_low** (*Optional*, [Time](#config-time)): time for the low part of a '1' bit in the LG protocol. Defaults to `1600us`
 - **bit_zero_low** (*Optional*, [Time](#config-time)): time for the low part of a '0' bit in the LG protocol. Defaults to `550us`
+- **alternative_mode** (*Optional*, boolean): enables an alternative control mode for newer units, allowing temperature regulation in `Heat/Cool` mode and vertical airflow adjustment (6 fixed positions +  up/down swing). Defaults to `false`
 
 ```yaml
 # Example configuration entry
@@ -94,6 +95,7 @@ climate:
     sensor: room_temperature
     header_high: 3265us # AC Units from LG in Brazil, for example use these timings
     header_low: 9856us
+    alternative_mode: false
 ```
 
 {{< anchor "daikin_brc" >}}

--- a/content/components/climate/climate_ir.md
+++ b/content/components/climate/climate_ir.md
@@ -85,7 +85,7 @@ climate:
 - **bit_high** (*Optional*, [Time](#config-time)): time for the high part of any bit in the LG protocol. Defaults to `600us`
 - **bit_one_low** (*Optional*, [Time](#config-time)): time for the low part of a '1' bit in the LG protocol. Defaults to `1600us`
 - **bit_zero_low** (*Optional*, [Time](#config-time)): time for the low part of a '0' bit in the LG protocol. Defaults to `550us`
-- **alternative_mode** (*Optional*, boolean): enables an alternative control mode for newer units, allowing temperature regulation in `Heat/Cool` mode and vertical airflow adjustment (6 fixed positions +  up/down swing). Defaults to `false`
+- **alternative_mode** (*Optional*, boolean): enables an alternative control mode for newer units, allowing temperature regulation in `Heat/Cool` mode and vertical airflow adjustment (6 fixed positions +  up/down swing) also swing mode is remembered after powering off. Defaults to `false`
 
 ```yaml
 # Example configuration entry


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes https://github.com/esphome/esphome/issues/10867

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#10875

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `COMPONENT_NAME` with your component name in **UPPER_CASE** format with **underscores** (e.g., `BME280`, `SHT3X`, `DALLAS_TEMP`):

   ```
   @esphomebot generate image COMPONENT_NAME
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `images/` folder of this repository.

4. Use the image in your component's index table entry in `/components/index.rst`.

**Example:** For a component called "DHT22 Temperature Sensor", use:
```
@esphomebot generate image DHT22
```

</details>
