### PR TITLE
epaper_spi: Add 4.0" and 7.3" Spectra 6 displays, fill in missing info for existing displays

### DIFF
--- a/src/content/docs/components/display/epaper_spi.mdx
+++ b/src/content/docs/components/display/epaper_spi.mdx
@@ -41,17 +41,18 @@ pins and dimensions specified.
 These models represent display panels with known dimensions, but without a microcontroller. The configuration will require
 the pins used to interface to the display to be specified.
 
-| Display name              | Manufacturer        | Product Description                                |
-|---------------------------|---------------------|----------------------------------------------------|
-| GooDisplay-GDEY042T81-4.2 | Dalian Good Display | [https://www.good-display.com/product/386.html](https://www.good-display.com/product/386.html) |
-| Waveshare-1.54in-G        | Waveshare           | [https://www.waveshare.com/1.54inch-e-paper-g.htm](https://www.waveshare.com/1.54inch-e-paper-g.htm) |
-| Waveshare-2.13in-v3       | Waveshare           | [https://www.waveshare.com/pico-epaper-2.13.htm](https://www.waveshare.com/pico-epaper-2.13.htm)   |
-| Waveshare-3.97in          | Waveshare           | [https://www.waveshare.com/3.97inch-e-paper-hat-plus.htm](https://www.waveshare.com/3.97inch-e-paper-hat-plus.htm) |
-| Waveshare-4.26in          | Waveshare           | [https://www.waveshare.com/4.26inch-e-paper.htm](https://www.waveshare.com/4.26inch-e-paper.htm)   |
-| Waveshare-7.5in-H         | Waveshare           | [https://www.waveshare.com/7.5inch-e-paper-hat-h.htm](https://www.waveshare.com/7.5inch-e-paper-hat-h.htm) |
-| WeAct-2.13in-3c           | WeAct               | 2.13" 3-color e-paper (250x122, SSD1683)           |
-| WeAct-2.9in-3c            | WeAct               | 2.9" 3-color e-paper (128x296, SSD1683)           |
-| WeAct-4.2in-3c            | WeAct               | 4.2" 3-color e-paper (400x300, SSD1683)           |
+| Display name        | Manufacturer | Product Description                                |
+|---------------------|--------------|----------------------------------------------------|
+| 4.0in-Spectra-E6    | Eink         | 4.0" 6-color (400x600, Spectra-E6) [ED2208-DOA (EL040EF1)](https://www.eink.com/product/detail/EL040EF1)<br/>[Waveshare 4inch e-Paper (E)](https://www.waveshare.com/4inch-e-paper-hat-plus-e.htm) |
+| 7.3in-Spectra-E6    | Eink         | 7.3" 6-color (800x480, Spectra-E6) [ED2208-GCA (EL073TF1)](https://www.eink.com/product/detail/EL073TF1U5)<br/>[Waveshare 7.3inch e-Paper (E)](https://www.waveshare.com/product/displays/e-paper/epaper-1/7.3inch-e-paper-hat-e.htm), [seeed studio 7.3" spectra™6 ePaper](https://www.seeedstudio.com/7-3inch-Six-Color-eInk-ePaper-Display-with-800x480-Pixels-p-6567.html)<br/>The Waveshare 7.3inch e-Paper (F) is not compatible |
+| GooDisplay-GDEY042T81-4.2 | Dalian Good Display | 4.2" mono / 4-grey (400x300, SSD1683)<br/>[4.2" E-Ink GDEY042T81](https://www.good-display.com/product/386.html) |
+| Waveshare-1.54in-G  | Waveshare    | 1.54" 4-color (200x200, JD79660)<br/>[Waveshare 1.54inch e-Paper (G)](https://www.waveshare.com/1.54inch-e-paper-g.htm) |
+| Waveshare-2.13in-v3 | Waveshare    | 2.13" mono (250x122, SSD1680)<br/>[Waveshare Pico-ePaper-2.13](https://www.waveshare.com/pico-epaper-2.13.htm), [Waveshare 2.13inch e-Paper HAT](https://www.waveshare.com/2.13inch-e-Paper-HAT.htm)<br/>Compatible screens have a "V3" or "V4" sticker |
+| Waveshare-4.26in    | Waveshare    | 4.26" mono / 4-grey (480x800, SSD1677)<br/>[Waveshare 4.26inch e-Paper](https://www.waveshare.com/4.26inch-e-paper.htm), [seeed studio 4.26 Monochrome ePaper](https://www.seeedstudio.com/4-26-Monochrome-SPI-ePaper-Display-p-6398.html) |
+| Waveshare-7.5in-H   | Waveshare    | 7.5" 4-color (800x480, JD79665)<br/>[Waveshare 7.5inch e-Paper (H)](https://www.waveshare.com/7.5inch-e-paper-hat-h.htm) |
+| WeAct-2.13in-3c     | WeAct        | 2.13" 3-color (250x122, SSD1683)           |
+| WeAct-2.9in-3c      | WeAct        | 2.9" 3-color (128x296, SSD1683)           |
+| WeAct-4.2in-3c      | WeAct        | 4.2" 3-color (400x300, SSD1683)           |
 
 ## Supported integrated display boards
 
@@ -60,8 +61,8 @@ a minimum only the model name need be configured. Other options can be overridde
 
 | Model name             | Manufacturer | Product Description                                                                                                          |
 | ---------------------- |--------------| ---------------------------------------------------------------------------------------------------------------------------- |
-| Seeed-reTerminal-E1002 | Seeed Studio | [https://www.seeedstudio.com/reTerminal-E1002-p-6533.html](https://www.seeedstudio.com/reTerminal-E1002-p-6533.html)                                                                   |
-| Seeed-ee04-mono-4.26   | Seeed Studio | Seeed EE04 board with Waveshare 4.26" mono epaper. [https://www.seeedstudio.com/XIAO-ePaper-Display-Board-EE04-p-6560.html](https://www.seeedstudio.com/XIAO-ePaper-Display-Board-EE04-p-6560.html)  |
+| Seeed-reTerminal-E1002 | Seeed Studio | Uses a `7.3in-Spectra-E6` display panel.<br/>[https://www.seeedstudio.com/reTerminal-E1002-p-6533.html](https://www.seeedstudio.com/reTerminal-E1002-p-6533.html) |
+| Seeed-ee04-mono-4.26   | Seeed Studio | Uses a `Waveshare-4.26in` display panel.<br/>[https://www.seeedstudio.com/XIAO-ePaper-Display-Board-EE04-p-6560.html](https://www.seeedstudio.com/XIAO-ePaper-Display-Board-EE04-p-6560.html)  |
 
 ## Configuration variables
 
@@ -75,7 +76,7 @@ but can be overridden if needed.
 
   > [!NOTE]
   > Some displays use inverted busy pin polarity (LOW = busy, HIGH = idle). For these models, set `inverted: true`
-  > on the busy pin. This applies to: `Waveshare-1.54in-G`, `Waveshare-7.5in-H`.
+  > on the busy pin. This applies to all `Spectra-E6` displays: `4.0in-Spectra-E6`, `7.3in-Spectra-E6` as well as: `Waveshare-1.54in-G`, `Waveshare-7.5in-H`.
 
 - **reset_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The RESET pin, if used.
   Make sure you pull this pin high (by connecting it to 3.3V with a resistor) if not connected to a GPIO pin.


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

The existing 7.3" E Ink Spectra 6 display was missing from the supported display panels list (it is used in the Seeed-reTerminal-E1002). Since it's also available standalone from Waveshare and Seeed Studio, add it.

Add the 4.0" E Ink Spectra 6 display which I am submitting a PR to esphome for.

Update several existing product descriptions in the supported display panels list with additional specifications, and in the supported integrated display boards section mention which display panel is used.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#16031

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.
