### PR TITLE
[mipi_dsi] Document DMA2D async flush options

### DIFF
--- a/src/content/docs/components/display/mipi_dsi.mdx
+++ b/src/content/docs/components/display/mipi_dsi.mdx
@@ -149,7 +149,7 @@ most of the configuration will be set by default, but can be overridden if neede
 - **color_depth** (*Optional*): The color depth of the display buffer, expressed in bits. Options are `16` (default) and `24`. Preferably should be the same as the `pixel_mode` option.
 - **draw_rounding** (*Optional*): The rounding factor for drawing operations. Defaults to 2. Some chips require a higher value to avoid display artifacts. Must be a power of 2.
 - **use_axis_flips** (*Optional*): If true, the driver will use alternate bits in the MADCTL register to implement x and y mirroring. Defaults to false.
-- **use_dma2d** (*Optional*, boolean): Enable the ESP-IDF DMA2D path for MIPI DSI frame buffer copies on ESP32-P4. Defaults to `true`.
+- **use_dma2d** (*Optional*, boolean): Enable the ESP-IDF DMA2D path for MIPI DSI frame buffer copies on ESP32-P4. Defaults to `false`.
 - **async_lvgl_flush** (*Optional*, boolean): Enable the asynchronous LVGL flush path for DMA2D-capable ESP32-P4 MIPI DSI displays. This allows aligned LVGL draw buffers to be submitted without blocking until the transfer-complete callback fires. Defaults to `false`.
 - **byte_order** (*Optional*): The byte order of the display buffer. Options are `big_endian` and `little_endian` (default). This affects the byte order for the buffer when
   using 16 bit color depth. The default is appropriate for the majority of displays.

--- a/src/content/docs/components/display/mipi_dsi.mdx
+++ b/src/content/docs/components/display/mipi_dsi.mdx
@@ -149,6 +149,8 @@ most of the configuration will be set by default, but can be overridden if neede
 - **color_depth** (*Optional*): The color depth of the display buffer, expressed in bits. Options are `16` (default) and `24`. Preferably should be the same as the `pixel_mode` option.
 - **draw_rounding** (*Optional*): The rounding factor for drawing operations. Defaults to 2. Some chips require a higher value to avoid display artifacts. Must be a power of 2.
 - **use_axis_flips** (*Optional*): If true, the driver will use alternate bits in the MADCTL register to implement x and y mirroring. Defaults to false.
+- **use_dma2d** (*Optional*, boolean): Enable the ESP-IDF DMA2D path for MIPI DSI frame buffer copies on ESP32-P4. Defaults to `true`.
+- **async_lvgl_flush** (*Optional*, boolean): Enable the asynchronous LVGL flush path for DMA2D-capable ESP32-P4 MIPI DSI displays. This allows aligned LVGL draw buffers to be submitted without blocking until the transfer-complete callback fires. Defaults to `false`.
 - **byte_order** (*Optional*): The byte order of the display buffer. Options are `big_endian` and `little_endian` (default). This affects the byte order for the buffer when
   using 16 bit color depth. The default is appropriate for the majority of displays.
 


### PR DESCRIPTION
## Description

Documents the `use_dma2d` and `async_lvgl_flush` options added by esphome/esphome#16853.

## Related pull request

- esphome/esphome#16853