### PR TITLE
[audio] Document full duplex and resampler microphone

### DIFF
--- a/src/content/docs/components/i2s_audio.mdx
+++ b/src/content/docs/components/i2s_audio.mdx
@@ -21,7 +21,14 @@ i2s_audio:
 - **i2s_bclk_pin** (*Optional*, [Pin](/guides/configuration-types#pin)): The GPIO pin to use for the I²S `BCLK` *(Bit Clock)* signal, also referred to as `SCK` *(Serial Clock)*.
 - **i2s_mclk_pin** (*Optional*, [Pin](/guides/configuration-types#pin)): The GPIO pin to use for the I²S `MCLK` *(Master Clock)* signal.
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID for this I²S bus if you need multiple.
+- **full_duplex** (*Optional*, boolean): Enable simultaneous input and output on the same I2S bus. This is useful
+  for devices that use the output channel to provide the clock required by an external ADC while microphone input is
+  active. Defaults to `false`.
 - **use_legacy** (*Optional, boolean*): Use the legacy I²S driver when using esp-idf framework version 5.x.x. Not valid for Arduino framework or esp-idf version < 5. All `i2s_audio` components need to use the same setting. Defaults to `false`.
+
+> [!NOTE]
+> Full duplex mode requires the microphone and speaker to use the same `i2s_audio` component. It is intended for
+> standard I2S input/output devices and does not support PDM microphones.
 
 ## See Also
 

--- a/src/content/docs/components/index.mdx
+++ b/src/content/docs/components/index.mdx
@@ -923,6 +923,7 @@ Used for creating infrared (IR) remote control transmitters and/or receivers.
 <ImgTable items={[
   ["Microphone Core", "/components/microphone/", "microphone.svg", "dark-invert"],
   ["I2S Microphone", "/components/microphone/i2s_audio/", "i2s_audio.svg"],
+  ["Resampler Microphone", "/components/microphone/resampler/", "waveform.svg", "dark-invert"],
 ]} />
 
 ## Number Components

--- a/src/content/docs/components/micro_wake_word.mdx
+++ b/src/content/docs/components/micro_wake_word.mdx
@@ -26,6 +26,9 @@ micro_wake_word:
 
 - **microphone** (*Optional*, [Microphone Source Configuration](/components/microphone#config-microphone-source)): The [microphone](/components/microphone/) settings to use for audio input.
 - **stop_after_detection** (*Optional*, boolean): Whether to stop the component after detecting a wake word. Defaults to `true`.
+- **ring_buffer_duration** (*Optional*, [Time](/guides/configuration-types#time)): The duration of the internal
+  audio ring buffer used by the inference task. Increase this if the microphone source delivers audio in larger
+  bursts and the log reports that the ring buffer is being reset. Larger values use more RAM. Defaults to `120ms`.
 - **task_stack_in_psram** (*Optional*, boolean): If `true`, allocate the inference task stack in PSRAM instead of internal RAM. Requires the [PSRAM](/components/psram/) component. Defaults to `false`.
 - **models** (**Required**, list): The models to use. Only the first model is enabled by default on the first boot. Each model's enabled state is then saved/restored to/from the flash.
 

--- a/src/content/docs/components/microphone/resampler.mdx
+++ b/src/content/docs/components/microphone/resampler.mdx
@@ -1,0 +1,54 @@
+---
+description: "Instructions for setting up resampler microphones in ESPHome."
+title: "Resampler Microphone"
+---
+
+The `resampler` microphone platform converts audio from another [microphone component](/components/microphone/) to a
+different sample rate before passing it to consumers such as [Voice Assistant](/components/voice_assistant/) or
+[Micro Wake Word](/components/micro_wake_word/).
+
+If the input microphone already uses the configured sample rate, audio is passed through without resampling.
+
+This platform only works on ESP32 based chips.
+
+> [!WARNING]
+> Audio and voice components consume a significant amount of resources (RAM and CPU) on the device.
+>
+> **Crashes are likely to occur** if you include too many additional components in your device's configuration. In
+> particular, Bluetooth/BLE components are known to cause issues when used with Voice Assistant and other audio
+> components.
+
+```yaml
+# Example configuration entry
+microphone:
+  - platform: resampler
+    id: resampled_microphone
+    microphone:
+      microphone: source_microphone
+    sample_rate: 16000
+```
+
+## Configuration Variables
+
+- **microphone** (**Required**, [Microphone Source Configuration](/components/microphone#config-microphone-source)):
+  The [microphone](/components/microphone/) source to resample.
+- **sample_rate** (*Optional*, positive integer): Sample rate to convert to. Defaults to `16000`.
+- **buffer_duration** (*Optional*, [Time](/guides/configuration-types#time)): The duration of the internal ring
+  buffer. Larger values may reduce stuttering but use more memory. Defaults to `100ms`.
+- **filters** (*Optional*, positive integer): The number of windowed sinc interpolation filters to use. Must be
+  between `2` and `1024`. Defaults to `16`.
+- **taps** (*Optional*, positive integer): The number of taps per windowed sinc interpolation filter. Must be between
+  `16` and `128` and divisible by 4. Defaults to `16`.
+- **task_stack_in_psram** (*Optional*, boolean): Run the resampling task in external memory. Defaults to `false`.
+- All other options from [Microphone Component](/components/microphone#config-microphone).
+
+## Improving Quality
+
+Resampling is processor intensive and should be avoided when possible. Higher `filters` values increase memory usage,
+and higher `taps` values increase CPU usage.
+
+## See Also
+
+- [ART Audio Resampler (GitHub)](https://github.com/dbry/audio-resampler)
+- [Microphone Component](/components/microphone/)
+- [Resampler Speaker](/components/speaker/resampler/)


### PR DESCRIPTION
﻿<!-- markdownlint-disable -->

## Description

Documents the audio configuration added by the matching ESPHome PR:

- `i2s_audio.full_duplex`
- `micro_wake_word.ring_buffer_duration`
- the new `resampler` microphone platform

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#16882

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [x] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in the component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
