### PR TITLE
Add ESP32 JPEG codec docs

### DIFF
--- a/src/content/docs/components/esp32_jpeg.mdx
+++ b/src/content/docs/components/esp32_jpeg.mdx
@@ -1,0 +1,69 @@
+---
+description: "Instructions for setting up the ESP32 hardware JPEG codec helper in ESPHome."
+title: "ESP32 JPEG Codec"
+---
+
+import APIRef from "@components/APIRef.astro";
+
+The `esp32_jpeg` component enables ESPHome components to use the hardware JPEG
+encoder/decoder available on supported ESP32 variants.
+
+It is a helper component and does not create Home Assistant entities on its own.
+Other components, or custom C++ code, can use it to compress raw RGB/gray images
+to JPEG or decode JPEG images back to RGB/gray buffers without using a software
+JPEG implementation.
+
+> [!NOTE]
+> This component currently supports ESP32-P4 with the ESP-IDF framework.
+
+```yaml
+# Example configuration entry
+esp32:
+  board: esp32-p4-evboard
+  variant: esp32p4
+  framework:
+    type: esp-idf
+    advanced:
+      enable_idf_experimental_features: true
+
+esp32_jpeg:
+```
+
+## Configuration variables
+
+- **apply_idf_patches** (*Optional*, boolean): Apply ESP-IDF JPEG/DMA2D compatibility
+  patches needed by ESPHome's hardware JPEG helper on supported ESP-IDF versions.
+  These patches correct RGB color-space conversion selection for JPEGs using
+  different YUV subsampling modes and use full-range YUV-to-RGB conversion
+  matrices. Defaults to `true`.
+
+## Usage
+
+The component provides a C++ helper API for encode/decode paths. It is primarily
+intended for other ESPHome components that need a reusable JPEG hardware backend,
+such as camera, display, LVGL, or snapshot/cache implementations.
+
+The helper supports:
+
+- Encoding RGB565, RGB888, or grayscale input buffers to JPEG.
+- Decoding JPEG images to RGB565, RGB888, or grayscale output buffers.
+- RGB/BGR element order selection for RGB888 decode output.
+- BT.601 and BT.709 YUV/RGB conversion standards.
+- YUV444, YUV422, YUV420, and grayscale JPEG sampling modes where supported by
+  the ESP-IDF driver and target chip.
+
+## Limitations
+
+- Only ESP32 variants with `SOC_JPEG_CODEC_SUPPORTED` can use the hardware
+  encoder/decoder.
+- The initial ESPHome integration is limited to ESP32-P4 and ESP-IDF.
+- This component provides the codec backend only. Higher-level components decide
+  when to capture, resize, cache, stream, or display image data.
+
+## See Also
+
+- [ESP32 Platform](/components/esp32/)
+- [ESP32 Camera](/components/esp32_camera/)
+- [Camera Encoder](/components/camera/camera_encoder/)
+- [LVGL Graphics](/components/lvgl/)
+- <APIRef text="esp32_jpeg.h" path="esp32_jpeg/esp32_jpeg.h" />

--- a/src/content/docs/components/esp32_jpeg.mdx
+++ b/src/content/docs/components/esp32_jpeg.mdx
@@ -29,14 +29,6 @@ esp32:
 esp32_jpeg:
 ```
 
-## Configuration variables
-
-- **apply_idf_patches** (*Optional*, boolean): Apply ESP-IDF JPEG/DMA2D compatibility
-  patches needed by ESPHome's hardware JPEG helper on supported ESP-IDF versions.
-  These patches correct RGB color-space conversion selection for JPEGs using
-  different YUV subsampling modes and use full-range YUV-to-RGB conversion
-  matrices. Defaults to `true`.
-
 ## Usage
 
 The component provides a C++ helper API for encode/decode paths. It is primarily

--- a/src/content/docs/components/index.mdx
+++ b/src/content/docs/components/index.mdx
@@ -52,6 +52,7 @@ Peripherals which directly support the operation of the microcontroller's proces
   ["PSRAM", "/components/psram/", "psram.svg"],
   ["Deep Sleep", "/components/deep_sleep/", "hotel.svg", "dark-invert"],
   ["ESP32-P4 LDO regulator", "/components/esp_ldo/", "ldo.svg", "dark-invert"],
+  ["ESP32 JPEG Codec", "/components/esp32_jpeg/", "camera.svg", "dark-invert"],
 ]} />
 
 ## ESPHome Automations


### PR DESCRIPTION
﻿## Description

Adds documentation for the new `esp32_jpeg` component, including platform requirements, the `apply_idf_patches` option and a minimal ESP32-P4 configuration example.

**Related issue (if applicable):** n/a

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#16902

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [x] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in the component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
