### PR TITLE
[alarm_control_panel] Add docs for the three new conditions.

### DIFF
--- a/src/content/docs/components/alarm_control_panel/index.mdx
+++ b/src/content/docs/components/alarm_control_panel/index.mdx
@@ -181,7 +181,7 @@ alarm_control_panel:
 
 ### `on_disarmed` Trigger
 
-This trigger is activated when the alarm changes from to disarmed.
+This trigger is activated when the alarm changes to disarmed state.
 
 ```yaml
 alarm_control_panel:
@@ -314,6 +314,54 @@ on_...:
   if:
     condition:
       alarm_control_panel.is_armed: acp1
+```
+
+<span id="alarm_control_panel_is_armed_away_condition"></span>
+
+### `alarm_control_panel.is_armed_away` Condition
+
+This [Condition](/automations/actions#all-conditions) checks if the alarm control panel is armed in away mode.
+
+> [!NOTE]
+> This condition is also true in the arming state before being armed in away mode.
+
+```yaml
+on_...:
+  if:
+    condition:
+      alarm_control_panel.is_armed_away: acp1
+```
+
+<span id="alarm_control_panel_is_armed_home_condition"></span>
+
+### `alarm_control_panel.is_armed_home` Condition
+
+This [Condition](/automations/actions#all-conditions) checks if the alarm control panel is armed in home mode.
+
+> [!NOTE]
+> This condition is also true in the arming state before being armed in home mode.
+
+```yaml
+on_...:
+  if:
+    condition:
+      alarm_control_panel.is_armed_home: acp1
+```
+
+<span id="alarm_control_panel_is_armed_night_condition"></span>
+
+### `alarm_control_panel.is_armed_night` Condition
+
+This [Condition](/automations/actions#all-conditions) checks if the alarm control panel is armed in night mode.
+
+> [!NOTE]
+> This condition is also true in the arming state before being armed in night mode.
+
+```yaml
+on_...:
+  if:
+    condition:
+      alarm_control_panel.is_armed_night: acp1
 ```
 
 <span id="alarm_control_panel_lambda_calls"></span>


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Adding documentation for three new Conditions added to the `alarm_control_panel` component in the related pull request:

- `is_armed_away`
- `is_armed_home`
- `is_armed_night`

**Related issue (if applicable):** none

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#14376

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
