### PR TITLE
[dlms_meter] changes for new pull request

### DIFF
--- a/src/content/docs/components/sensor/dlms_meter.mdx
+++ b/src/content/docs/components/sensor/dlms_meter.mdx
@@ -223,15 +223,16 @@ Your custom patterns will be evaluated alongside these based on their configured
 
 | Name                                  | Priority | Typical use                               |
 |---------------------------------------|---------:|-------------------------------------------|
-| `classId-taggedObis-scaler-value`     |       10 | class ID, tagged OBIS, scaler, value      |
-| `taggedObis-value-scalerUnit`         |       20 | tagged OBIS, value, scaler-unit structure |
-| `value-classId-scalerUnit-taggedObis` |       30 | value first, class ID, scaler-unit, OBIS  |
-| `zpaAidon-untaggedLayout`             |       40 | untagged ZPA/Aidon-style layouts          |
-| `structuredObis-value-scalerUnit`     |       50 | OBIS, value, scaler-unit structure        |
-| `structuredObis-value`                |       60 | OBIS and value structure                  |
-| `flatObis-valuePair`                  |       70 | flat OBIS + value pairs                   |
-| `firstElement-dateTime`               |       80 | first-element date-time structure         |
-| `swappedTagObis-value-scalerUnit`     |       90 | swapped-tag OBIS, value, scaler-unit      |
+| `SelfDescribing`                      |       10 | definitions array + values                |
+| `classId-taggedObis-scaler-value`     |       20 | class ID, tagged OBIS, scaler, value      |
+| `taggedObis-value-scalerUnit`         |       30 | tagged OBIS, value, scaler-unit structure |
+| `value-classId-scalerUnit-taggedObis` |       40 | value first, class ID, scaler-unit, OBIS  |
+| `zpaAidon-untaggedLayout`             |       50 | untagged ZPA/Aidon-style layouts          |
+| `structuredObis-value-scalerUnit`     |       60 | OBIS, value, scaler-unit structure        |
+| `structuredObis-value`                |       70 | OBIS and value structure                  |
+| `flatObis-valuePair`                  |       80 | flat OBIS + value pairs                   |
+| `firstElement-dateTime`               |       90 | first-element date-time structure         |
+| `swappedTagObis-value-scalerUnit`     |      100 | swapped-tag OBIS, value, scaler-unit      |
 
 #### Common Custom Pattern Examples
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

Changes for the https://github.com/esphome/esphome/pull/16942

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- https://github.com/esphome/esphome/pull/16942

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
