### PR TITLE
[ecocomfort2] Add documentation (Part 1: hub + fan)

### DIFF
--- a/src/content/docs/components/ecocomfort2.mdx
+++ b/src/content/docs/components/ecocomfort2.mdx
@@ -1,0 +1,124 @@
+---
+description: "Instructions for setting up the Fantini Cosmi Aspirvelo Air Ecocomfort 2.0 Smart VMC integration via BLE in ESPHome."
+title: "Ecocomfort2"
+---
+
+The `ecocomfort2` component allows you to control
+[Fantini Cosmi Aspirvelo Air Ecocomfort 2.0 Smart](https://www.fantinicosmi.it/prodotto/aspirvelo-air-ecocomfort-2-0-smart/) VMC
+(Mechanical Ventilation with Heat Recovery) units over BLE using an ESP32.
+
+The component uses a hub architecture: one `ecocomfort2` hub per VMC unit,
+with platform entities registered as children. A single ESP32 can control
+multiple VMC units simultaneously.
+
+This page documents the hub and the `fan` platform. Additional platforms
+(`sensor`, `binary_sensor`, `text_sensor`, `select`, `number`, `switch` and
+`button`) are added in follow-up releases.
+
+## Requirements
+
+- ESP32 device with BLE support
+- [BLE Tracker](/components/esp32_ble_tracker/) and
+  [BLE Client](/components/ble_client/) configured
+- VMC unit in pairing range
+
+## Hub Configuration
+
+```yaml
+esp32_ble_tracker:
+
+ble_client:
+  - mac_address: "AA:BB:CC:DD:EE:FF"
+    id: vmc_ble
+
+ecocomfort2:
+  - id: vmc_hub
+    ble_client_id: vmc_ble
+```
+
+### Configuration Variables
+
+- **id** (**Required**, [ID](/guides/configuration-types/#config-id)):
+  The ID of the hub.
+- **ble_client_id** (**Required**, [ID](/guides/configuration-types/#config-id)):
+  The ID of the BLE client connected to the VMC unit.
+- **update_interval** (*Optional*, [Time](/guides/configuration-types/#config-time)):
+  How often to poll the VMC unit for state updates. Defaults to `30s`.
+
+## Fan Platform
+
+The fan entity provides the main operating control for the VMC unit.
+
+```yaml
+fan:
+  - platform: ecocomfort2
+    name: "VMC Fan"
+    ecocomfort2_id: vmc_hub
+```
+
+### Configuration Variables
+
+- **ecocomfort2_id** (**Required**, [ID](/guides/configuration-types/#config-id)):
+  The ID of the Ecocomfort2 hub.
+- All other options from [Fan](/components/fan/).
+
+### Preset Modes
+
+| Preset | Description |
+|--------|-------------|
+| In | Intake only |
+| Out | Exhaust only |
+| In-Out | Bidirectional ventilation |
+| Sensor | Sensor-driven automatic direction |
+| Auto | Fully automatic mode (speed and direction) |
+
+Speed can be set from 1 to 4. In Auto mode, speed is managed by the VMC
+unit; changing speed manually switches to Sensor mode.
+
+## BLE Pairing
+
+The component requests BLE encryption automatically after connecting.
+If the VMC unit is already bonded (from a previous session), the encrypted
+link is restored without user interaction. BLE bonds persist across OTA
+updates.
+
+If pairing is required for the first time:
+
+1. Put the VMC unit into pairing mode (refer to the Ecocomfort 2.0 manual)
+2. The ESP32 will automatically attempt pairing on connect
+
+If authentication times out (10 seconds), the component disconnects and
+retries the full connection cycle automatically.
+
+## Multiple Units
+
+A single ESP32 can control multiple VMC units. Define one hub and one set
+of platform entities per unit:
+
+```yaml
+ble_client:
+  - mac_address: "AA:BB:CC:DD:EE:FF"
+    id: vmc1_ble
+  - mac_address: "11:22:33:44:55:66"
+    id: vmc2_ble
+
+ecocomfort2:
+  - id: vmc1
+    ble_client_id: vmc1_ble
+  - id: vmc2
+    ble_client_id: vmc2_ble
+
+fan:
+  - platform: ecocomfort2
+    name: "VMC 1 Fan"
+    ecocomfort2_id: vmc1
+  - platform: ecocomfort2
+    name: "VMC 2 Fan"
+    ecocomfort2_id: vmc2
+```
+
+## See Also
+
+- [BLE Client](/components/ble_client/)
+- [ESP32 BLE Tracker](/components/esp32_ble_tracker/)
+- [Fan Component](/components/fan/)

--- a/src/content/docs/components/index.mdx
+++ b/src/content/docs/components/index.mdx
@@ -835,10 +835,10 @@ Often known as "tag" or "card" readers within the community.
   ["Fan Core", "/components/fan/", "folder-open.svg", "dark-invert"],
   ["Template Fan", "/components/fan/template/", "description.svg", "dark-invert"],
   ["Binary Fan", "/components/fan/binary/", "fan.svg", "dark-invert"],
+  ["Ecocomfort2 VMC", "/components/ecocomfort2/", "fan.svg", "dark-invert"],
   ["H-bridge Fan", "/components/fan/hbridge/", "fan.svg", "dark-invert"],
   ["Speed Fan", "/components/fan/speed/", "fan.svg", "dark-invert"],
   ["Tuya Fan", "/components/fan/tuya/", "tuya.png"],
-  ["Ecocomfort2 VMC", "/components/ecocomfort2/", "fan.svg", "dark-invert"],
 ]} />
 
 ## Home Assistant Components

--- a/src/content/docs/components/index.mdx
+++ b/src/content/docs/components/index.mdx
@@ -838,6 +838,7 @@ Often known as "tag" or "card" readers within the community.
   ["H-bridge Fan", "/components/fan/hbridge/", "fan.svg", "dark-invert"],
   ["Speed Fan", "/components/fan/speed/", "fan.svg", "dark-invert"],
   ["Tuya Fan", "/components/fan/tuya/", "tuya.png"],
+  ["Ecocomfort2 VMC", "/components/ecocomfort2/", "fan.svg", "dark-invert"],
 ]} />
 
 ## Home Assistant Components


### PR DESCRIPTION
## Description

Documentation for the new `ecocomfort2` component — **Part 1 (hub + fan)** — matching the code PR esphome/esphome#17092.

The code is being merged in parts to stay under the PR size limit, so this page documents only the hub and the `fan` platform for now; the remaining platforms (`sensor`, `binary_sensor`, `text_sensor`, `select`, `number`, `switch`, `button`) will be documented as their code PRs land.

Also adds the component to the Fan Components index.

This supersedes #6385 (which targeted the full component and went stale).

## Related

- Code PR: esphome/esphome#17092

## Checklist

- [x] Link added in `/components/index.mdx` (Fan Components) when creating a new component page.
