### PR TITLE
[nrf52] Document MCUboot bootloader support on XIAO BLE

### DIFF
--- a/src/content/docs/components/nrf52.mdx
+++ b/src/content/docs/components/nrf52.mdx
@@ -41,7 +41,22 @@ Flashing with MCUboot requires an SWD connection, for which a programmer is nece
 # Example configuration entry
 nrf52:
   board: adafruit_feather_nrf52840
+  bootloader: mcuboot
 ```
+
+The Seeed XIAO nRF52840 (`xiao_ble`) also supports the MCUboot two-slot bootloader. Select it explicitly with
+`bootloader: mcuboot`:
+
+```yaml
+# Example configuration entry
+nrf52:
+  board: xiao_ble
+  bootloader: mcuboot
+```
+
+After the initial SWD flash, the MCUboot two-slot layout enables [OTA updates](/components/ota/zephyr_mcumgr/) over BLE
+or USB CDC, so a programmer is no longer required for subsequent updates. The dashboard offers a **HEX package** for the
+initial SWD flash and an **app update package** for OTA.
 
 ## Flashing with Adafruit nRF52 Bootloader
 

--- a/src/content/docs/components/nrf52.mdx
+++ b/src/content/docs/components/nrf52.mdx
@@ -58,6 +58,11 @@ After the initial SWD flash, the MCUboot two-slot layout enables [OTA updates](/
 or USB CDC, so a programmer is no longer required for subsequent updates. The dashboard offers a **HEX package** for the
 initial SWD flash and an **app update package** for OTA.
 
+> [!IMPORTANT]
+> OTA works only if the [`zephyr_mcumgr`](/components/ota/zephyr_mcumgr/) OTA component is part of the firmware you flash
+> over SWD. Add `transport.ble: true` for updates over BLE and `transport.hardware_uart: CDC` for updates over USB CDC.
+> If the initial SWD-flashed firmware has no OTA endpoint, a programmer is still required for subsequent updates.
+
 ## Flashing with Adafruit nRF52 Bootloader
 
 For flashing via a flash drive.


### PR DESCRIPTION
## Description

Documents that the `mcuboot` bootloader is now selectable on the Seeed XIAO nRF52840 (`board: xiao_ble`).
Previously `bootloader: mcuboot` could not be selected for this board.

Adds an `xiao_ble` example to the "Flashing with MCUboot" section of the nRF52 platform docs and notes that the
MCUboot two-slot layout enables OTA over BLE/USB CDC after an initial SWD flash (HEX package for the initial flash,
app update package for OTA).

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#17088

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)