### PR TITLE
[heatpumpir] Document ZMP IR receiver

### DIFF
--- a/src/content/docs/components/climate/climate_ir.mdx
+++ b/src/content/docs/components/climate/climate_ir.mdx
@@ -37,7 +37,7 @@ submit a feature request (see FAQ).
 | Yashima | `yashima`                          | |
 | [Whynter](#whynter) | `whynter`                          | yes |
 | [ZH/LT-01](#zhlt01) | `zhlt01`                           | yes |
-| [Arduino-HeatpumpIR](#heatpumpir) library | `heatpumpir`                       | |
+| [Arduino-HeatpumpIR](#heatpumpir) library | `heatpumpir`                       | ZMP |
 
 This component requires that you have configured a [Remote Transmitter](/components/remote_transmitter/).
 


### PR DESCRIPTION
Adds ZMP to the receiver support column for the heatpumpir platform.\n\nRelated: https://github.com/esphome/esphome/pull/17099