### PR TITLE
[bthome_mithermometer] Add documentation

### DIFF
--- a/src/content/docs/components/binary_sensor/ble_presence.mdx
+++ b/src/content/docs/components/binary_sensor/ble_presence.mdx
@@ -1,6 +1,6 @@
 ---
-description: "Instructions for setting up BLE binary sensors for the ESP32."
-title: "ESP32 Bluetooth Low Energy Device"
+description: "Instructions for setting up the BLE Presence binary sensor."
+title: "Bluetooth Low Energy Presence"
 ---
 
 import { Image } from 'astro:assets';
@@ -8,6 +8,9 @@ import esp32BleUiImg from './images/esp32_ble-ui.png';
 import APIRef from '@components/APIRef.astro';
 
 The `ble_presence` binary sensor platform lets you track the presence of a Bluetooth Low Energy device.
+
+This platform attaches to whichever BLE tracker hub is configured, so it is not ESP32-specific:
+the examples below use the ESP32 BLE tracker, but it works the same on any BLE-capable platform.
 
 > [!WARNING]
 > The BLE software stack on the ESP32 consumes a significant amount of RAM on the device.

--- a/src/content/docs/components/index.mdx
+++ b/src/content/docs/components/index.mdx
@@ -298,6 +298,7 @@ Sensors are organized into categories; if a given sensor fits into more than one
   ["AM43", "/components/sensor/am43/", "am43.jpg", "Lux & Battery level"],
   ["BLE Client Sensor", "/components/sensor/ble_client/", "bluetooth.svg", "dark-invert"],
   ["BLE RSSI", "/components/sensor/ble_rssi/", "bluetooth.svg", "dark-invert"],
+  ["BTHome MiThermometer", "/components/sensor/bthome_mithermometer/", "bluetooth.svg", "Temperature & Humidity & Battery", "dark-invert"],
   ["HHCCJCY10 (MiFlora Pink)", "/components/sensor/xiaomi_hhccjcy10/", "xiaomi_hhccjcy10.jpg", "Soil moisture & Temperature & Light"],
   ["Inkbird IBS-TH1 Mini", "/components/sensor/inkbird_ibsth1_mini/", "inkbird_isbth1_mini.jpg", "Temperature & Humidity"],
   ["Mopeka Pro Check LP", "/components/sensor/mopeka_pro_check/", "mopeka_pro_check.jpg", "Tank level"],

--- a/src/content/docs/components/sensor/ble_rssi.mdx
+++ b/src/content/docs/components/sensor/ble_rssi.mdx
@@ -1,6 +1,6 @@
 ---
-description: "Instructions for setting up RSSI sensors for the ESP32 BLE."
-title: "ESP32 Bluetooth Low Energy RSSI Sensor"
+description: "Instructions for setting up the BLE RSSI sensor."
+title: "Bluetooth Low Energy RSSI Sensor"
 ---
 import APIRef from '@components/APIRef.astro';
 
@@ -8,6 +8,9 @@ import APIRef from '@components/APIRef.astro';
 The `ble_rssi` sensor platform lets you track the RSSI value or signal strength of a
 BLE device. See [the binary sensor setup](/components/binary_sensor/ble_presence#setting-up-devices) for
 instructions for setting up this platform.
+
+This platform attaches to whichever BLE tracker hub is configured, so it is not ESP32-specific:
+the examples below use the ESP32 BLE tracker, but it works the same on any BLE-capable platform.
 
 > [!WARNING]
 > The BLE software stack on the ESP32 consumes a significant amount of RAM on the device.

--- a/src/content/docs/components/sensor/bthome_mithermometer.mdx
+++ b/src/content/docs/components/sensor/bthome_mithermometer.mdx
@@ -1,0 +1,63 @@
+---
+description: "Instructions for setting up BTHome BLE thermometer/hygrometer sensors in ESPHome."
+title: "BTHome MiThermometer Sensor"
+---
+import APIRef from '@components/APIRef.astro';
+
+
+The `bthome_mithermometer` sensor platform lets you receive measurements broadcast by
+[BTHome](https://bthome.io/)-format Bluetooth Low Energy devices — for example Xiaomi/Mijia
+thermometers running the [ATC](https://github.com/atc1441/ATC_MiThermometer) or
+[PVVX](https://github.com/pvvx/ATC_MiThermometer) custom firmware in BTHome mode. The component
+listens passively to the advertisements, so it does not pair with the device and has no impact on
+its battery life.
+
+This platform attaches to whichever BLE tracker hub is configured, so it is not ESP32-specific:
+the example below uses the ESP32 BLE tracker, but it works the same on any BLE-capable platform.
+
+For choosing between the firmware options of these thermometers (stock MiBeacon, ATC, PVVX and
+their advertisement formats) and for flashing/bindkey instructions, see
+[LYWSD03MMC on the Xiaomi BLE page](/components/sensor/xiaomi_ble/#lywsd03mmc) — this page is the
+option reference for the `bthome_mithermometer` platform itself.
+
+```yaml
+# Example configuration entry
+esp32_ble_tracker:
+
+sensor:
+  - platform: bthome_mithermometer
+    mac_address: "A4:C1:38:XX:XX:XX"
+    # bindkey is only needed for devices that encrypt their advertisements
+    bindkey: "231d39c1d7cc1ab1aee224cd096db932"
+    temperature:
+      name: "BTHome Temperature"
+    humidity:
+      name: "BTHome Humidity"
+    battery_level:
+      name: "BTHome Battery Level"
+```
+
+> [!NOTE]
+> A `bindkey` is only required for devices configured to **encrypt** their BTHome advertisements;
+> unencrypted devices work without one. It is the same 32-character (16-byte) hex key you set when
+> enabling encryption on the device (for example in the ATC/PVVX web configurator).
+
+## Configuration variables
+
+- **mac_address** (**Required**, MAC Address): The MAC address of the device to receive data from.
+- **bindkey** (*Optional*, 32-character hex string): The encryption key for devices that broadcast
+  encrypted BTHome advertisements. Omit it for unencrypted devices.
+- **temperature** (*Optional*): The temperature, in °C. All options from [Sensor](/components/sensor).
+- **humidity** (*Optional*): The relative humidity, in %. All options from [Sensor](/components/sensor).
+- **battery_level** (*Optional*): The battery level, in %. All options from [Sensor](/components/sensor).
+- **battery_voltage** (*Optional*): The battery voltage, in V. All options from [Sensor](/components/sensor).
+- **signal_strength** (*Optional*): The signal strength (RSSI), in dBm. All options from [Sensor](/components/sensor).
+
+## See Also
+
+- [ESP32 Bluetooth Low Energy Tracker Hub](/components/esp32_ble_tracker/)
+- [Bluetooth Low Energy RSSI Sensor](/components/sensor/ble_rssi/)
+- [Sensor Component](/components/sensor/)
+- [Xiaomi BLE — LYWSD03MMC firmware guide](/components/sensor/xiaomi_ble/#lywsd03mmc)
+- [BTHome](https://bthome.io/)
+- <APIRef text="bthome_ble.h" path="bthome_mithermometer/bthome_ble.h" />

--- a/src/content/docs/components/sensor/xiaomi_ble.mdx
+++ b/src/content/docs/components/sensor/xiaomi_ble.mdx
@@ -218,7 +218,8 @@ sensor:
       name: "LYWSD03MMC Battery Level"
 ```
 
-Configuration example for PVVX MiThermometer firmware set to "BTHome v2" advertisement:
+Configuration example for PVVX MiThermometer firmware set to "BTHome v2" advertisement (all
+options: [BTHome MiThermometer](/components/sensor/bthome_mithermometer/)):
 
 ```yaml
 sensor:

--- a/src/content/docs/components/text_sensor/ble_scanner.mdx
+++ b/src/content/docs/components/text_sensor/ble_scanner.mdx
@@ -1,11 +1,14 @@
 ---
-description: "Instructions for setting up BLE text sensors for the ESP32."
-title: "ESP32 Bluetooth Low Energy Scanner"
+description: "Instructions for setting up the BLE Scanner text sensor."
+title: "Bluetooth Low Energy Scanner"
 ---
 import APIRef from '@components/APIRef.astro';
 
 
 The `ble_scanner` text sensor platform lets you track reachable BLE devices.
+
+This platform attaches to whichever BLE tracker hub is configured, so it is not ESP32-specific:
+the example below uses the ESP32 BLE tracker, but it works the same on any BLE-capable platform.
 
 See the [BLE Tracker Configuration variables](/components/esp32_ble_tracker#config-esp32_ble_tracker) for instructions for setting up scan parameters.
 


### PR DESCRIPTION
## What does this implement?

Adds a documentation page for the `bthome_mithermometer` sensor platform, which is in-tree but currently undocumented:

- receiving measurements from [BTHome](https://bthome.io/)-format BLE devices (e.g. Xiaomi/Mijia thermometers running ATC/PVVX firmware in BTHome mode)
- `mac_address`, optional `bindkey` for encrypted advertisements, and the temperature / humidity / battery level / battery voltage / signal strength sensors
- `ble_hub_id:` binding key with the `esp32_ble_id` deprecated-alias note (matches the sensor migration series)
- component index entry

Scope note: earlier revisions of this branch also reworded the shared `ble_presence` / `ble_rssi` / `ble_scanner` / `xiaomi_ble` pages; that sweep now lives in #7024, and this PR is scoped to the new page only.

## Related

- esphome/esphome#17150 (`ble_device_base`)

