### PR TITLE
[mqtt] Document LN882H platform support

### DIFF
--- a/src/content/docs/components/mqtt.mdx
+++ b/src/content/docs/components/mqtt.mdx
@@ -11,6 +11,8 @@ The MQTT Client Component sets up the MQTT connection to your broker.
 If you are connecting to Home Assistant, you may prefer to use the native API,
 in which case this is not needed.
 
+MQTT is supported on the ESP32, ESP8266, BK72xx, RTL87xx and LN882H platforms.
+
 > [!WARNING]
 > If you enable MQTT and you do *not* use the [Api](/components/api/), you must
 > remove the `api:` configuration or set `reboot_timeout: 0s`, otherwise the ESP will

--- a/src/content/docs/components/mqtt.mdx
+++ b/src/content/docs/components/mqtt.mdx
@@ -11,7 +11,7 @@ The MQTT Client Component sets up the MQTT connection to your broker.
 If you are connecting to Home Assistant, you may prefer to use the native API,
 in which case this is not needed.
 
-MQTT is supported on the ESP32, ESP8266, BK72xx, RTL87xx and LN882H platforms.
+MQTT is supported on the ESP32, ESP8266, BK72xx, LN882H and RTL87xx platforms.
 
 > [!WARNING]
 > If you enable MQTT and you do *not* use the [Api](/components/api/), you must


### PR DESCRIPTION
Documents MQTT platform support, adding **LN882H**.

Companion to esphome/esphome#17297, which enables the `mqtt` component on the LN882X (LN882H) platform. The MQTT page did not list its supported platforms; this adds a short note covering ESP32, ESP8266, BK72xx, RTL87xx and LN882H.
