### PR TITLE
[pipsolar] Document QET/QLT energy sensors and last_qet/last_qlt text sensors

### DIFF
--- a/src/content/docs/components/pipsolar.mdx
+++ b/src/content/docs/components/pipsolar.mdx
@@ -112,6 +112,8 @@ All sensors are normal sensors... so all sensor variables are working to.
 - **battery_voltage_offset_for_fans_on** (*Optional*): battery voltage offset for fans on
 - **eeprom_version** (*Optional*): eeprom version
 - **pv_charging_power** (*Optional*): pc charging power
+- **total_pv_generated_energy** (*Optional*): total PV generated energy
+- **total_output_load_energy** (*Optional*): total output load energy
 
 ## Binary Sensor
 
@@ -218,6 +220,8 @@ All sensors are normal text sensors... so all text sensor variables are working 
 - **last_qpiws** (*Optional*): last qpiws reponse
 - **last_qt** (*Optional*): last qt reponse
 - **last_qmn** (*Optional*): last qmn reponse
+- **last_qet** (*Optional*): last qet reponse
+- **last_qlt** (*Optional*): last qlt reponse
 
 ## Switch
 


### PR DESCRIPTION
## Description

Documents the new `pipsolar` options added in esphome/esphome#17347:

- `total_pv_generated_energy` and `total_output_load_energy` sensors (QET / QLT lifetime energy counters)
- `last_qet` / `last_qlt` raw text sensors

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#17347

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

_(Not applicable — these are new options on an existing component, not a new component/cookbook document.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)