### PR TITLE
[media_player.sendspin] Note when paused is distinguishable from idle

### DIFF
--- a/src/content/docs/components/media_player/sendspin.mdx
+++ b/src/content/docs/components/media_player/sendspin.mdx
@@ -12,6 +12,9 @@ The `sendspin` media player platform exposes controls for an entire [Sendspin](/
 
 The Sendspin [hub](/components/sendspin/) must be configured on the same device. This platform only works on ESP32-based chips.
 
+> [!NOTE]
+> The reported state distinguishes `paused` from `idle` only when a [`sendspin` sensor](/components/sensor/sendspin/) or [`text_sensor`](/components/text_sensor/sendspin/) is also configured on the same hub. Pausing is only visible in the metadata role's playback progress, not in the group state this platform reads on its own, so without a metadata entity configured a paused group is reported as `playing`.
+
 ```yaml
 # Example configuration entry
 sendspin:


### PR DESCRIPTION
## Description:

esphome/esphome#17515 fixes the `sendspin` media_player to report a real `paused` state instead of collapsing it into `playing`. That's only possible when the metadata role is also configured on the same hub (pausing is only observable via the metadata role's playback progress, not the group state this platform reads on its own) - this adds a short note explaining that caveat right after the intro, next to the platform's existing "no audio on device" callout.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#17515

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.