### PR TITLE
[sendspin] Document on_connect/on_disconnect trigger

### DIFF
--- a/src/content/docs/components/sendspin.mdx
+++ b/src/content/docs/components/sendspin.mdx
@@ -12,10 +12,12 @@ The device uses mDNS to discover Sendspin servers on the network, so mDNS
 traffic must not be blocked on your network. TCP port **8928** must also be
 reachable between the device and the server.
 
-On its own, the hub does not expose any user-facing entities. Once a Sendspin
-server is present on the network, it will connect to the device and begin
-sending group state updates, but audio playback, control, and metadata require
-the corresponding child components to be configured as well.
+On its own, the hub does not expose any user-facing entities beyond the
+[`on_connect`/`on_disconnect` trigger](#sendspin-on_connect_disconnect)
+below. Once a Sendspin server is present on the network, it will connect to
+the device and begin sending group state updates, but audio playback,
+control, and metadata require the corresponding child components to be
+configured as well.
 
 This platform only works on ESP32-based chips.
 
@@ -35,6 +37,24 @@ sendspin:
 - **task_stack_in_psram** (*Optional*, boolean): Place the internal HTTP server task
   stack in PSRAM to reduce internal RAM usage. Requires the
   [Psram](/components/psram/) component to be configured. Defaults to `false`.
+- **on_connect** (*Optional*, [Automation](/automations)): An action to be performed when the hub establishes a connection to a Sendspin server.
+- **on_disconnect** (*Optional*, [Automation](/automations)): An action to be performed when the hub loses its connection to a Sendspin server.
+
+<span id="sendspin-on_connect_disconnect"></span>
+
+## `on_connect` / `on_disconnect` Trigger
+
+This trigger is activated when the hub establishes or loses its connection to
+a Sendspin server.
+
+```yaml
+sendspin:
+  # ...
+  on_connect:
+    - logger.log: "Connected to Sendspin server"
+  on_disconnect:
+    - logger.log: "Lost connection to Sendspin server"
+```
 
 ## Actions
 


### PR DESCRIPTION
## Description:

esphome/esphome#17518 adds `on_connect`/`on_disconnect` triggers to the `sendspin` hub, so YAML automations can detect whether the device has a live connection to a Sendspin server. Documents the two new config keys and adds a dedicated trigger section, mirroring the wording/structure of the `wifi` component's own `on_connect`/`on_disconnect` docs. Also lightly updates the existing "the hub does not expose any user-facing entities" line, since that's no longer quite accurate on its own.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#17518

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.

  - [ ] Link added in `/components/_index.md` when creating new documents for new components or cookbook.