### PR TITLE
[epaper_spi] Document Waveshare 2.9in V2 mono model

### DIFF
--- a/src/content/docs/components/display/epaper_spi.mdx
+++ b/src/content/docs/components/display/epaper_spi.mdx
@@ -48,6 +48,7 @@ the pins used to interface to the display to be specified.
 | Waveshare-1.54in-G        | Waveshare           | [https://www.waveshare.com/1.54inch-e-paper-g.htm](https://www.waveshare.com/1.54inch-e-paper-g.htm) |
 | Waveshare-2.13in-v3       | Waveshare           | [https://www.waveshare.com/pico-epaper-2.13.htm](https://www.waveshare.com/pico-epaper-2.13.htm)   |
 | Waveshare-2.13in-bv4      | Waveshare           | 2.13" 3-color e-paper (250x122, SSD1683) [https://www.waveshare.com/product/displays/e-paper/epaper-3/2.13inch-e-paper-b.htm](https://www.waveshare.com/product/displays/e-paper/epaper-3/2.13inch-e-paper-b.htm) |
+| Waveshare-2.9in-v2        | Waveshare           | 2.9" mono e-paper Rev 2.1 (128x296). Replaces deprecated `waveshare_epaper` `2.90inv2`. [https://www.waveshare.com/pico-epaper-2.9.htm](https://www.waveshare.com/pico-epaper-2.9.htm) |
 | Waveshare-3.97in          | Waveshare           | [https://www.waveshare.com/3.97inch-e-paper-hat-plus.htm](https://www.waveshare.com/3.97inch-e-paper-hat-plus.htm) |
 | Waveshare-4.26in          | Waveshare           | [https://www.waveshare.com/4.26inch-e-paper.htm](https://www.waveshare.com/4.26inch-e-paper.htm)   |
 | Waveshare-7.5in-H         | Waveshare           | [https://www.waveshare.com/7.5inch-e-paper-hat-h.htm](https://www.waveshare.com/7.5inch-e-paper-hat-h.htm) |

--- a/src/content/docs/components/display/epaper_spi.mdx
+++ b/src/content/docs/components/display/epaper_spi.mdx
@@ -48,7 +48,7 @@ the pins used to interface to the display to be specified.
 | Waveshare-1.54in-G        | Waveshare           | [https://www.waveshare.com/1.54inch-e-paper-g.htm](https://www.waveshare.com/1.54inch-e-paper-g.htm) |
 | Waveshare-2.13in-v3       | Waveshare           | [https://www.waveshare.com/pico-epaper-2.13.htm](https://www.waveshare.com/pico-epaper-2.13.htm)   |
 | Waveshare-2.13in-bv4      | Waveshare           | 2.13" 3-color e-paper (250x122, SSD1683) [https://www.waveshare.com/product/displays/e-paper/epaper-3/2.13inch-e-paper-b.htm](https://www.waveshare.com/product/displays/e-paper/epaper-3/2.13inch-e-paper-b.htm) |
-| Waveshare-2.9in-v2        | Waveshare           | 2.9" mono e-paper Rev 2.1 (128x296). Replaces deprecated `waveshare_epaper` `2.90inv2`. [https://www.waveshare.com/pico-epaper-2.9.htm](https://www.waveshare.com/pico-epaper-2.9.htm) |
+| Waveshare-2.9in-v2        | Waveshare           | 2.9" mono e-paper Rev 2.1 (128x296). Replaces deprecated `waveshare_epaper` `model: 2.90inv2` / `model: 2.90inv2-r2`. [https://www.waveshare.com/pico-epaper-2.9.htm](https://www.waveshare.com/pico-epaper-2.9.htm) |
 | Waveshare-3.97in          | Waveshare           | [https://www.waveshare.com/3.97inch-e-paper-hat-plus.htm](https://www.waveshare.com/3.97inch-e-paper-hat-plus.htm) |
 | Waveshare-4.26in          | Waveshare           | [https://www.waveshare.com/4.26inch-e-paper.htm](https://www.waveshare.com/4.26inch-e-paper.htm)   |
 | Waveshare-7.5in-H         | Waveshare           | [https://www.waveshare.com/7.5inch-e-paper-hat-h.htm](https://www.waveshare.com/7.5inch-e-paper-hat-h.htm) |


### PR DESCRIPTION
## Summary

Document the new `waveshare-2.9in-v2` model in `epaper_spi` (Waveshare 2.9" V2 Rev 2.1 mono, 128x296).

Includes a migration note for users of deprecated `waveshare_epaper` `model: 2.90inv2`.

## Related

- Code PR: https://github.com/esphome/esphome/pull/17548
- Issue: https://github.com/esphome/issues/issues/2334

## Checklist

- [x] Documentation added for new display model