### PR TITLE
[cse7761] Add new sensors

### DIFF
--- a/src/content/docs/components/sensor/cse7761.mdx
+++ b/src/content/docs/components/sensor/cse7761.mdx
@@ -21,6 +21,10 @@ sensor:
   - platform: cse7761
     voltage:
       name: 'CSE7761 Voltage'
+    frequency:
+      name: 'CSE7761 Frequency'
+    power_factor:
+      name: 'CSE7761 Power Factor'
     current_1:
       name: 'CSE7761 Current 1'
     current_2:
@@ -29,6 +33,10 @@ sensor:
       name: 'CSE7761 Active Power 1'
     active_power_2:
       name: 'CSE7761 Active Power 2'
+    energy_1:
+      name: 'CSE7761 Energy 1'
+    energy_2:
+      name: 'CSE7761 Energy 2'
 ```
 
 > [!NOTE]
@@ -38,6 +46,12 @@ sensor:
 
 - **voltage** (*Optional*): Use the voltage value of the sensor in V (RMS).
   All options from [Sensor](/components/sensor).
+
+- **frequency** (*Optional*): Use the frequency value of the sensor in Hz. All options from
+  [Sensor](/components/sensor).
+
+- **power_factor** (*Optional*): Use the power factor value of the sensor. All options from
+  [Sensor](/components/sensor).
 
 - **current_1** (*Optional*): Use the current value of the channel 1 in amperes. All options from
   [Sensor](/components/sensor).
@@ -49,6 +63,12 @@ sensor:
   [Sensor](/components/sensor).
 
 - **active_power_2** (*Optional*): Use the (active) power value of the channel 2 in watts. All options from
+  [Sensor](/components/sensor).
+
+- **energy_1** (*Optional*): Use the energy value of the channel 1 in watt-hours. All options from
+  [Sensor](/components/sensor).
+
+- **energy_2** (*Optional*): Use the energy value of the channel 2 in watt-hours. All options from
   [Sensor](/components/sensor).
 
 - **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval to check the


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#17531

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
