### PR TITLE
[api] Fix ESPHome version in docs for dropped Home Assistant actions before subscription

### DIFF
--- a/src/content/docs/components/api.mdx
+++ b/src/content/docs/components/api.mdx
@@ -233,7 +233,7 @@ on_...:
 > Home Assistant starts listening for device actions shortly *after* the API connection is established, so actions
 > triggered right at connection time (for example from `on_client_connected` or `on_time_sync`) can fire before
 > Home Assistant is ready for them. Such actions are not delivered and ESPHome logs a warning
-> (versions before 2026.8.0 dropped them silently). The same applies to `homeassistant.event`. If you need to
+> (versions before 2026.7.0 dropped them silently). The same applies to `homeassistant.event`. If you need to
 > perform an action as soon as a connection is made, add a short `delay` before it so Home Assistant has time to
 > start listening.
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Fixes ESPHome version in the documentation for dropped Home Assistant actions before subscription.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** N/A

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.