### PR TITLE
[atc_mithermometer] Add component documentation

### DIFF
--- a/src/content/docs/components/index.mdx
+++ b/src/content/docs/components/index.mdx
@@ -299,6 +299,7 @@ Sensors are organized into categories; if a given sensor fits into more than one
 <ImgTable items={[
   ["Alpha3", "/components/sensor/alpha3/", "alpha3.jpg"],
   ["AM43", "/components/sensor/am43/", "am43.jpg", "Lux & Battery level"],
+  ["ATC MiThermometer", "/components/sensor/atc_mithermometer/", "bluetooth.svg", "dark-invert"],
   ["BLE Client Sensor", "/components/sensor/ble_client/", "bluetooth.svg", "dark-invert"],
   ["BLE RSSI", "/components/sensor/ble_rssi/", "bluetooth.svg", "dark-invert"],
   ["HHCCJCY10 (MiFlora Pink)", "/components/sensor/xiaomi_hhccjcy10/", "xiaomi_hhccjcy10.jpg", "Soil moisture & Temperature & Light"],

--- a/src/content/docs/components/sensor/atc_mithermometer.mdx
+++ b/src/content/docs/components/sensor/atc_mithermometer.mdx
@@ -1,0 +1,66 @@
+---
+description: "Instructions for setting up ATC MiThermometer bluetooth-based temperature and humidity sensors in ESPHome."
+title: "ATC MiThermometer"
+---
+
+import APIRef from '@components/APIRef.astro';
+
+The `atc_mithermometer` sensor platform lets you track the output of Xiaomi LYWSD03MMC
+Bluetooth Low Energy devices running the alternative
+[ATC firmware](https://github.com/atc1441/ATC_MiThermometer), using a BLE tracker (for example
+the [ESP32 BLE Tracker](/components/esp32_ble_tracker/)). This component listens passively to
+the advertisement packets the device broadcasts in the ATC format (temperature, humidity,
+battery level and battery voltage) and does not pair with or connect to the device, so it has
+no impact on the device's battery life.
+
+The ATC "custom" advertisement format is unencrypted, so no bindkey is required. Note that both
+the ATC and PVVX firmware projects have deprecated this format in favor of BTHome v2 — prefer the
+`bthome_mithermometer` platform for new setups.
+
+For choosing between the firmware options of these thermometers (stock MiBeacon, ATC, PVVX and
+their advertisement formats) and for flashing instructions, see
+[LYWSD03MMC on the Xiaomi BLE page](/components/sensor/xiaomi_ble/#lywsd03mmc) — this page is the
+option reference for the `atc_mithermometer` platform itself.
+
+```yaml
+# Example configuration entry
+esp32_ble_tracker:
+
+sensor:
+  - platform: atc_mithermometer
+    mac_address: "A4:C1:38:XX:XX:XX"
+    temperature:
+      name: "ATC Temperature"
+    humidity:
+      name: "ATC Humidity"
+    battery_level:
+      name: "ATC Battery-Level"
+    battery_voltage:
+      name: "ATC Battery-Voltage"
+```
+
+## Configuration variables
+
+- **mac_address** (**Required**, MAC Address): The MAC address of the device.
+- **temperature** (*Optional*): The information for the temperature sensor. All options from
+  [Sensor](/components/sensor/).
+- **humidity** (*Optional*): The information for the humidity sensor. All options from
+  [Sensor](/components/sensor/).
+- **battery_level** (*Optional*): The information for the battery level sensor in %. All options
+  from [Sensor](/components/sensor/).
+- **battery_voltage** (*Optional*): The information for the battery voltage sensor. All options
+  from [Sensor](/components/sensor/).
+- **signal_strength** (*Optional*): The information for the received signal strength sensor in
+  dBm. All options from [Sensor](/components/sensor/).
+- **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID used for
+  code generation.
+- **ble_hub_id** (*Optional*, [ID](/guides/configuration-types#id)): The BLE tracker
+  hub to receive advertisements from. Auto-generated when only one tracker is configured;
+  set it explicitly to disambiguate multiple trackers. Replaces the former `esp32_ble_id`
+  key, which still works as a deprecated alias until ESPHome 2027.2.0.
+
+## See Also
+
+- [ESP32 Bluetooth Low Energy Tracker Hub](/components/esp32_ble_tracker/)
+- [Xiaomi BLE — LYWSD03MMC firmware guide](/components/sensor/xiaomi_ble/#lywsd03mmc)
+- <APIRef text="atc_mithermometer.h" path="atc_mithermometer/atc_mithermometer.h" />

--- a/src/content/docs/components/sensor/atc_mithermometer.mdx
+++ b/src/content/docs/components/sensor/atc_mithermometer.mdx
@@ -6,16 +6,18 @@ title: "ATC MiThermometer"
 import APIRef from '@components/APIRef.astro';
 
 The `atc_mithermometer` sensor platform lets you track the output of Xiaomi LYWSD03MMC
-Bluetooth Low Energy devices running the alternative
-[ATC firmware](https://github.com/atc1441/ATC_MiThermometer), using a BLE tracker (for example
-the [ESP32 BLE Tracker](/components/esp32_ble_tracker/)). This component listens passively to
-the advertisement packets the device broadcasts in the ATC format (temperature, humidity,
+Bluetooth Low Energy devices broadcasting in the ATC1441 advertisement format — that is, devices
+running the [ATC firmware](https://github.com/atc1441/ATC_MiThermometer), or
+[PVVX MiThermometer](https://github.com/pvvx/ATC_MiThermometer) firmware set to the "ATC1441"
+advertisement type — using a BLE tracker (for example the
+[ESP32 BLE Tracker](/components/esp32_ble_tracker)). This component listens passively to
+the advertisement packets the device broadcasts in that format (temperature, humidity,
 battery level and battery voltage) and does not pair with or connect to the device, so it has
 no impact on the device's battery life.
 
-The ATC "custom" advertisement format is unencrypted, so no bindkey is required. Note that both
-the ATC and PVVX firmware projects have deprecated this format in favor of BTHome v2 — prefer the
-`bthome_mithermometer` platform for new setups.
+The ATC1441 advertisement format is unencrypted, so no bindkey is required. Note that both the
+ATC and PVVX firmware projects have deprecated this format in favor of BTHome v2 — prefer the
+[BTHome MiThermometer](/components/sensor/bthome_mithermometer) platform for new setups.
 
 For choosing between the firmware options of these thermometers (stock MiBeacon, ATC, PVVX and
 their advertisement formats) and for flashing instructions, see

--- a/src/content/docs/components/sensor/atc_mithermometer.mdx
+++ b/src/content/docs/components/sensor/atc_mithermometer.mdx
@@ -17,7 +17,7 @@ no impact on the device's battery life.
 
 The ATC1441 advertisement format is unencrypted, so no bindkey is required. Note that both the
 ATC and PVVX firmware projects have deprecated this format in favor of BTHome v2 — prefer the
-[BTHome MiThermometer](/components/sensor/bthome_mithermometer) platform for new setups.
+`bthome_mithermometer` platform for new setups.
 
 For choosing between the firmware options of these thermometers (stock MiBeacon, ATC, PVVX and
 their advertisement formats) and for flashing instructions, see

--- a/src/content/docs/components/sensor/xiaomi_ble.mdx
+++ b/src/content/docs/components/sensor/xiaomi_ble.mdx
@@ -260,7 +260,8 @@ sensor:
       name: "PVVX Signal"
 ```
 
-Configuration example for ATC MiThermometer firmware set to "Custom" advertisement (deprecated):
+Configuration example for ATC MiThermometer firmware set to "Custom" advertisement (deprecated; all
+options: [ATC MiThermometer](/components/sensor/atc_mithermometer/)):
 
 ```yaml
 sensor:


### PR DESCRIPTION
# Description

Adds a dedicated option-reference page for the `atc_mithermometer` sensor platform.

As @nagyrobi correctly pointed out, the platform is already documented by example within the [LYWSD03MMC section of the Xiaomi BLE page](https://esphome.io/components/sensor/xiaomi_ble/#lywsd03mmc) — this PR does not duplicate that. The division of labor: the xiaomi page remains the **firmware-selection guide** for these thermometers (stock MiBeacon / ATC / PVVX / BTHome formats), while this page is the **per-platform option reference** (all five sensor options), consistent with the other standalone BLE platforms. The two are cross-linked in both directions, and the page notes the ATC custom format is deprecated in favor of BTHome v2. The page also documents the `ble_hub_id:` binding key with the `esp32_ble_id` deprecated-alias note, matching the sensor migration series.

Related: esphome/esphome#17716, #6859, #7024.

## Checklist:

- [x] I am merging into `next` because this is new documentation for an existing feature.
