### PR TITLE
[esp32_hosted] Document ESP-NOW on ESP32-P4

### DIFF
--- a/src/content/docs/components/esp32_hosted.mdx
+++ b/src/content/docs/components/esp32_hosted.mdx
@@ -124,6 +124,54 @@ wifi:
 You can update the firmware on your ESP32 co-processor using the [Esp32 Hosted](/components/update/esp32_hosted/)
 platform. This allows you to deploy firmware updates to the co-processor without manually reflashing it.
 
+## ESP-NOW on ESP32-P4
+
+The ESP32-P4 has no radio of its own. When `esp32_hosted` is configured on an ESP32-P4 host, it also provides an
+ESP-NOW path by forwarding the ESP-NOW calls to the co-processor, so the [ESP-NOW](/components/espnow/) component
+works unchanged. Nothing extra is required beyond adding `espnow:` to your configuration; there is no separate
+component to add. On other ESP32 variants this behaviour is not needed and nothing changes.
+
+Your co-processor firmware must support ESP-NOW. The prebuilt esp-hosted firmware provided by ESPHome includes ESP-NOW
+support, and you can flash it to the co-processor with the [Esp32 Hosted](/components/update/esp32_hosted/) update
+platform.
+
+ESP-NOW works with or without Wi-Fi on the ESP32-P4: you can use ESP-NOW on its own, or run Wi-Fi in station mode and
+ESP-NOW at the same time.
+
+> [!NOTE]
+> The ESP-NOW source MAC address is the co-processor's radio MAC (for example, starting with `E4:B3:23`), not the
+> ESP32-P4's own MAC. Use the co-processor's MAC when adding this device to a remote peer list.
+
+> [!WARNING]
+> On the ESP32-P4, do not run `espnow` while [Wi-Fi](/components/wifi/) is in access point mode. ESP-NOW requires the
+> station interface to be up.
+
+```yaml
+# ESP32-P4 host with an ESP32-C6 co-processor
+esp32_hosted:
+  type: sdio
+  variant: ESP32C6
+  reset_pin: GPIOXX
+  cmd_pin: GPIOXX
+  clk_pin: GPIOXX
+  d0_pin: GPIOXX
+  d1_pin: GPIOXX
+  d2_pin: GPIOXX
+  d3_pin: GPIOXX
+  active_high: true
+
+espnow:
+  on_broadcast:
+    - lambda: |-
+        ESP_LOGD("espnow", "Broadcast of %u bytes received, RSSI %ddBm", size, info.rx_ctrl->rssi);
+
+interval:
+  - interval: 10s
+    then:
+      - espnow.broadcast:
+          data: "Hello from the ESP32-P4"
+```
+
 ## See Also
 
 - [WiFi Component](/components/wifi/)

--- a/src/content/docs/components/esp32_hosted.mdx
+++ b/src/content/docs/components/esp32_hosted.mdx
@@ -132,7 +132,7 @@ works unchanged. Nothing extra is required beyond adding `espnow:` to your confi
 component to add. On other ESP32 variants this behaviour is not needed and nothing changes.
 
 Your co-processor firmware must support ESP-NOW. The prebuilt esp-hosted firmware provided by ESPHome includes ESP-NOW
-support, and you can flash it to the co-processor with the [Esp32 Hosted](/components/update/esp32_hosted/) update
+support, and you can flash it to the co-processor with the [ESP32 Hosted](/components/update/esp32_hosted/) update
 platform.
 
 ESP-NOW works with or without Wi-Fi on the ESP32-P4: you can use ESP-NOW on its own, or run Wi-Fi in station mode and

--- a/src/content/docs/components/espnow.mdx
+++ b/src/content/docs/components/espnow.mdx
@@ -11,6 +11,12 @@ It enables the option to interact with other ESP32 devices over Espressif's ESP-
 It can be used with the [Packet Transport Component](/components/packet_transport) to share
 sensor data; see [ESP-NOW Packet Transport Platform](/components/packet_transport/espnow).
 
+> [!NOTE]
+> ESP-NOW is native to ESP32 variants that have their own radio. On the radio-less ESP32-P4 it instead requires the
+> [ESP32 Hosted](/components/esp32_hosted/) component with a co-processor running ESP-NOW-capable firmware; adding
+> `esp32_hosted:` enables the ESP-NOW path automatically. On radio-less variants without such a path (for example the
+> ESP32-H2), ESP-NOW is not available and the configuration will fail validation.
+
 ```yaml
 # Example configuration entry
 espnow:
@@ -297,4 +303,5 @@ over unicast and broadcast.
 
 ## See Also
 - [ESP-NOW Packet Transport Platform](/components/packet_transport/espnow/)
+- [ESP32 Hosted](/components/esp32_hosted/)
 - <APIRef text="espnow.h" path="espnow/espnow.h" />

--- a/src/content/docs/components/espnow.mdx
+++ b/src/content/docs/components/espnow.mdx
@@ -12,10 +12,11 @@ It can be used with the [Packet Transport Component](/components/packet_transpor
 sensor data; see [ESP-NOW Packet Transport Platform](/components/packet_transport/espnow).
 
 > [!NOTE]
-> ESP-NOW is native to ESP32 variants that have their own radio. On the radio-less ESP32-P4 it instead requires the
-> [ESP32 Hosted](/components/esp32_hosted/) component with a co-processor running ESP-NOW-capable firmware; adding
-> `esp32_hosted:` enables the ESP-NOW path automatically. On radio-less variants without such a path (for example the
-> ESP32-H2), ESP-NOW is not available and the configuration will fail validation.
+> ESP-NOW is a Wi-Fi-based protocol, so it is native to ESP32 variants that have their own Wi-Fi radio. The ESP32-P4
+> has no radio of its own; there it instead requires the [ESP32 Hosted](/components/esp32_hosted/) component with a
+> co-processor running ESP-NOW-capable firmware; adding `esp32_hosted:` enables the ESP-NOW path automatically. On
+> variants that lack Wi-Fi and have no such path (for example the ESP32-H2, which has an 802.15.4 and Bluetooth LE
+> radio but no Wi-Fi), ESP-NOW is not available and the configuration will fail validation.
 
 ```yaml
 # Example configuration entry


### PR DESCRIPTION
## Description

Document that the `esp32_hosted` component now provides an ESP-NOW path on the radio-less ESP32-P4 by forwarding calls to the co-processor, so the existing `espnow` component works unchanged. Adds an "ESP-NOW on ESP32-P4" section to the `esp32_hosted` page (co-processor firmware requirement, source-MAC note, Wi-Fi AP-mode warning, and an example config) and a platform-support note to the `espnow` page covering where ESP-NOW is available and the new config validation on radio-less variants.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#17712

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.