### PR TITLE
[ln882h_ble] Add component documentation

### DIFF
--- a/src/content/docs/components/index.mdx
+++ b/src/content/docs/components/index.mdx
@@ -126,6 +126,7 @@ ESPHome-specific components or components supporting ESPHome device provisioning
   ["ESP32 BLE Server", "/components/esp32_ble_server/", "bluetooth.svg", "dark-invert"],
   ["ESP32 BLE Tracker", "/components/esp32_ble_tracker/", "bluetooth.svg", "dark-invert"],
   ["Improv via BLE", "/components/esp32_improv/", "improv.svg", "dark-invert"],
+  ["LN882H BLE", "/components/ln882h_ble/", "bluetooth.svg", "dark-invert"],
   ["Nordic UART Service (NUS)", "/components/ble_nus/", "bluetooth.svg", "dark-invert"],
   ["RP2040 BLE", "/components/rp2040_ble/", "bluetooth.svg", "dark-invert"],
   ["Zephyr BLE Server", "/components/zephyr_ble_server/", "bluetooth.svg", "dark-invert"],

--- a/src/content/docs/components/ln882h_ble.mdx
+++ b/src/content/docs/components/ln882h_ble.mdx
@@ -1,0 +1,36 @@
+---
+description: "Instructions for setting up the LN882H BLE controller in ESPHome."
+title: "LN882H Bluetooth Low Energy"
+---
+
+import APIRef from '@components/APIRef.astro';
+
+The `ln882h_ble` component enables the Bluetooth Low Energy controller of the LN882H
+(LibreTiny `ln882x` platform) — the platform analog of
+[ESP32 BLE](/components/esp32_ble/). It owns the BLE stack bring-up and the controller's
+persistent BLE address; higher-level consumers (such as the LN882H BLE tracker) build on
+it and load it automatically.
+
+```yaml
+# Example configuration entry
+ln882h_ble:
+  enable_on_boot: false
+```
+
+## Configuration variables
+
+- **enable_on_boot** (*Optional*, boolean): Bring the BLE stack up during boot. Defaults
+  to `false`: on the single-core LN882H, stack init during boot competes with the WiFi
+  connection handshake, so consumers enable the stack lazily on first use instead.
+- **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID used
+  to reference this component.
+
+> [!NOTE]
+> **BLE adapter address.** The address is loaded from the device's persistent storage;
+> when none is stored it is derived once as **WiFi MAC + 1** (only the last byte
+> incremented, OUI unchanged — the standard factory pairing) and persisted.
+
+## See Also
+
+- [ESP32 Bluetooth Low Energy](/components/esp32_ble/)
+- <APIRef text="ln882h_ble.h" path="ln882h_ble/ln882h_ble.h" />


### PR DESCRIPTION
## Description

Documentation for the `ln882h_ble` component — BLE controller support for the LN882H LibreTiny chips: BLE stack enable/disable (`enable_on_boot`) and the controller's persistent BLE address, matching the scope of the code PR. Adds the component to the Bluetooth/BLE index table.

**Related issue (if applicable):** design discussion esphome/esphome#3758

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#17777

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [x] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.
