### PR TITLE
[sendspin] Document the image platform

### DIFF
--- a/src/content/docs/components/image/index.mdx
+++ b/src/content/docs/components/image/index.mdx
@@ -14,6 +14,8 @@ data comes from:
 - **[`animation`](/components/image/animation/)**: Multi-frame (animated) images embedded into the firmware at
   compile time.
 - **[`online_image`](/components/image/online_image/)**: Images downloaded, decoded and drawn at runtime.
+- **[`sendspin`](/components/image/sendspin/)**: Album and artist artwork streamed from a
+  [Sendspin](/components/sendspin/) group and decoded at runtime.
 
 ```yaml
 # Example configuration entry
@@ -99,5 +101,6 @@ pixel. GRAYSCALE images with transparency store the alpha channel only, and rema
 - [File](/components/image/file/)
 - [Animation](/components/image/animation/)
 - [Online Image](/components/image/online_image/)
+- [Sendspin Image](/components/image/sendspin/)
 - [Display](/components/display/)
 - [LVGL](/components/lvgl/)

--- a/src/content/docs/components/image/sendspin.mdx
+++ b/src/content/docs/components/image/sendspin.mdx
@@ -30,13 +30,13 @@ image:
       id: album_art
 ```
 
-The entry's own `id` refers to the slot, which is what actions and conditions target. The `id` inside
+The entry's own `id` refers to the slot, which is what the action targets. The `id` inside
 `current_image` is the image itself, and is what you reference from a display lambda or an LVGL widget.
 
 ## Configuration variables
 
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): The ID of the artwork slot. Use this to target the
-  actions and conditions below.
+  action below.
 - **format** (**Required**): The format the artwork is encoded with. One of `JPEG`, `PNG` or `BMP`.
 - **resize** (**Required**, string): The size the artwork is requested and rendered at, as `WIDTHxHEIGHT`. The
   Sendspin server scales the artwork to these dimensions before sending it.
@@ -103,9 +103,10 @@ Report that the transition for the artwork just displayed has finished, telling 
 for more. Only needed when a `transition_image` is configured.
 
 > [!IMPORTANT]
-> Every `on_image_display` must run this action exactly once if `transition_image` is configured. If it
-> is not run, no further artwork appears until the artwork is cleared, and a warning naming the slot is
-> logged ten seconds after the artwork was displayed.
+> Every displayed artwork must be acknowledged with this action exactly once if `transition_image` is
+> configured, either from `on_image_display` or from whatever finishes the transition it starts. If it is not
+> run, no further artwork appears until the artwork is cleared, and a warning naming the slot is logged ten
+> seconds after the artwork was displayed.
 
 #### Configuration variables
 
@@ -170,8 +171,8 @@ image:
 ### Cross-fading between tracks
 
 To dissolve the old artwork into the new one, both have to be on screen at once, so this needs a
-`transition_image` and two stacked LVGL widgets. Declaration order sets which widget is on top, so declare the
-incoming one first.
+`transition_image` and two stacked LVGL widgets. Later-declared widgets render on top, so declare the incoming
+one first and let the outgoing one fade out above it.
 
 A widget keeps drawing whichever artwork it was last pointed at, so both widgets are pointed at their image
 again on every display. `display_offset` starts the fade early so it is centered on the change of track.

--- a/src/content/docs/components/image/sendspin.mdx
+++ b/src/content/docs/components/image/sendspin.mdx
@@ -102,7 +102,7 @@ Report that the transition for the artwork just displayed has finished, telling 
 for more. Only needed when a `transition_image` is configured.
 
 > [!IMPORTANT]
-> Every `on_image_display` must run this action exactly once if `trainsition_image` is configured. If it
+> Every `on_image_display` must run this action exactly once if `transition_image` is configured. If it
 > is not run, no further artwork appears until the artwork is cleared.
 
 #### Configuration variables

--- a/src/content/docs/components/image/sendspin.mdx
+++ b/src/content/docs/components/image/sendspin.mdx
@@ -1,0 +1,229 @@
+---
+description: "Instructions for displaying Sendspin album and artist artwork in ESPHome."
+title: "Sendspin Image"
+---
+
+import APIRef from '@components/APIRef.astro';
+
+The `sendspin` image platform displays album and artist artwork streamed from a
+[Sendspin](/components/sendspin/) group. The Sendspin [hub](/components/sendspin/) must be configured on the
+same device.
+
+The Sendspin server delivers the artwork already scaled to the requested size; it is decoded at runtime and
+exposed as a regular [image](/components/image/) that you can draw on a [display](/components/display/) or use
+with [LVGL](/components/lvgl/) widgets.
+
+Configure one entry per artwork you want to show, up to a maximum of four. This platform only works on
+ESP32-based chips.
+
+```yaml
+# Example configuration entry
+sendspin:
+
+image:
+  - platform: sendspin
+    id: album_slot
+    format: JPEG
+    type: RGB565
+    resize: 240x240
+    current_image:
+      id: album_art
+```
+
+The entry's own `id` refers to the slot, which is what actions and conditions target. The `id` inside
+`current_image` is the image itself, and is what you reference from a display lambda or an LVGL widget.
+
+## Configuration variables
+
+- **id** (*Optional*, [ID](/guides/configuration-types#id)): The ID of the artwork slot. Use this to target the
+  actions and conditions below.
+- **format** (**Required**): The format the artwork is encoded with. One of `JPEG`, `PNG` or `BMP`.
+- **resize** (**Required**, string): The size the artwork is requested and rendered at, as `WIDTHxHEIGHT`. The
+  Sendspin server scales the artwork to these dimensions before sending it.
+- **type** (**Required**): Specifies how to encode the image internally.
+
+  - `BINARY`: Two colors, suitable for 1 color displays or a 2 color image on color displays. Uses 1 bit per
+    pixel, 8 pixels per byte. Only `chroma_key` transparency is available.
+  - `GRAYSCALE`: Full scale grey. Uses 8 bits per pixel, 1 pixel per byte.
+  - `RGB565`: Lossy RGB color. Uses 2 bytes per pixel, 3 with an alpha channel.
+  - `RGB`: Full RGB color. Uses 3 bytes per pixel, 4 with an alpha channel.
+- **current_image** (**Required**): The image showing the artwork that is currently playing.
+
+  - **id** (**Required**, [ID](/guides/configuration-types#id)): The ID to reference the image in your display
+  or LVGL code.
+- **transition_image** (*Optional*): A second image holding the outgoing artwork while a transition runs, for
+  transitions that must keep it on screen after `on_image_display` returns. It holds the current artwork at any
+  other time, and is black until the first artwork has been shown. When set, the server is not told the device
+  is ready for more artwork until
+  [`sendspin.image.transition_finished`](#sendspin-image-transition_finished-action) runs. See
+  [Cross-fading between tracks](#cross-fading-between-tracks).
+
+  - **id** (**Required**, [ID](/guides/configuration-types#id)): The ID to reference the outgoing artwork.
+- **source** (*Optional*): Which artwork to display. One of `album` (default), `artist` or `none`.
+- **display_offset** (*Optional*, [Time](/guides/configuration-types#time)): Request a shift when
+  `on_image_display` fires relative to the moment the server asked for the artwork to appear. A positive value
+  fires it early, a negative value delays it. Must be between `-60s` and `60s`. Defaults to `0ms`.
+- **transparency** (*Optional*): If set, the alpha channel of the artwork will be taken into account. The
+  possible values are `opaque` (default), `chroma_key` and `alpha_channel`. See the discussion on transparency
+  in the [image component](/components/image/#transparency-options).
+- **byte_order** (*Optional*, string): For RGB565 images, the pixels are converted to 16 bit values. By default
+  these are stored in little endian byte order (LSB first), but you can override this by setting `byte_order` to
+  `big_endian`. Options are `little_endian` (default) and `big_endian`. Not applicable to other image formats.
+- **placeholder** (*Optional*, [ID](/guides/configuration-types#id)): ID of another [image](/components/image/)
+  to display until the first artwork has been received. This placeholder image will **not** be resized. It only
+  applies when the image is drawn from a display lambda; LVGL widgets show nothing instead.
+- **sendspin_id** (*Optional*, [ID](/guides/configuration-types#id)): The ID of the
+  [Sendspin](/components/sendspin/) hub to attach to. Only needed if you have more than one hub configured.
+
+> [!NOTE]
+> Each entry permanently reserves memory for two pictures at the configured `resize` size. 240x240 artwork of
+> type `RGB565` costs 230 kB.
+
+## Automations
+
+- **on_image_display** (*Optional*, [Automation](/automations)): An automation to perform when new artwork is
+  ready to be shown. A common use is to refresh the display so the new artwork is drawn.
+
+  The variable `lateness_ms` is available in [lambdas](/automations/templates#config-lambda). It reports how
+  many milliseconds past the intended moment the artwork actually arrived, so a transition can be shortened by
+  that much and still finish on schedule.
+- **on_image_clear** (*Optional*, [Automation](/automations)): An automation to perform when the artwork is
+  cleared, such as at the end of a stream. The image is blank from this point until new artwork arrives. An LVGL
+  widget keeps drawing the artwork it was pointed at.
+- **on_image_error** (*Optional*, [Automation](/automations)): An automation to perform when the artwork could
+  not be decoded, or when it decoded to dimensions other than the ones requested with `resize`. The artwork
+  already on screen is left in place.
+
+## Actions
+
+### `sendspin.image.transition_finished` Action
+
+Report that the transition for the artwork just displayed has finished, telling the server the device is ready
+for more. Only needed when a `transition_image` is configured.
+
+> [!IMPORTANT]
+> Every `on_image_display` must run this action exactly once if `trainsition_image` is configured. If it
+> is not run, no further artwork appears until the artwork is cleared.
+
+#### Configuration variables
+
+- **id** (**Required**, [ID](/guides/configuration-types#id)): The artwork slot the transition belongs to.
+
+```yaml
+on_...:
+  - sendspin.image.transition_finished: album_slot
+```
+
+## Examples
+
+Display album artwork and refresh the display whenever it changes:
+
+```yaml
+sendspin:
+
+image:
+  - platform: sendspin
+    id: album_slot
+    format: JPEG
+    type: RGB565
+    resize: 240x240
+    current_image:
+      id: album_art
+    on_image_display:
+      - component.update: my_display
+```
+
+```yaml
+display:
+  - platform: ...
+    id: my_display
+    # ...
+    lambda: |-
+      // Draw the album artwork at position [x=0,y=0]
+      it.image(0, 0, id(album_art));
+```
+
+Album and artist artwork can be requested at the same time by configuring one entry per source:
+
+```yaml
+image:
+  - platform: sendspin
+    id: album_slot
+    format: JPEG
+    type: RGB565
+    resize: 240x240
+    source: album
+    current_image:
+      id: album_art
+  - platform: sendspin
+    id: artist_slot
+    format: PNG
+    type: RGB565
+    resize: 96x96
+    source: artist
+    current_image:
+      id: artist_art
+```
+
+### Cross-fading between tracks
+
+To dissolve the old artwork into the new one, both have to be on screen at once, so this needs a
+`transition_image` and two stacked LVGL widgets. Declaration order sets which widget is on top, so declare the
+incoming one first.
+
+A widget keeps drawing whichever artwork it was last pointed at, so both widgets are pointed at their image
+again on every display. `display_offset` starts the fade early so it is centered on the change of track.
+
+```yaml
+image:
+  - platform: sendspin
+    id: album_slot
+    format: JPEG
+    type: RGB565
+    resize: 240x240
+    display_offset: 1s
+    current_image:
+      id: album_art
+    transition_image:
+      id: album_art_transition
+    on_image_display:
+      - lvgl.image.update:
+          id: outgoing_art
+          src: album_art_transition
+      - lvgl.image.update:
+          id: incoming_art
+          src: album_art
+      - lvgl.animation.start: album_art_crossfade
+
+lvgl:
+  animations:
+    - id: album_art_crossfade
+      duration: 2s
+      widgets:
+        - id: outgoing_art
+          opa:
+            from: 100%
+            to: 0%
+      on_stop:
+        - sendspin.image.transition_finished: album_slot
+  widgets:
+    - image:
+        id: incoming_art
+        src: album_art
+    - image:
+        id: outgoing_art
+        src: album_art
+```
+
+The fade outlives the automation that starts it, so the transition is reported as finished from the animation's
+`on_stop` rather than at the end of `on_image_display`. The fade always runs for the same length here; to have
+it end on schedule even when artwork arrives late, pass a duration to
+[`lvgl.animation.start`](/components/lvgl/animation#lvgl-animation-start-action) shortened by `lateness_ms`.
+
+## See Also
+
+- [Sendspin](/components/sendspin/)
+- [Image Component](/components/image/)
+- [Online Image](/components/image/online_image/)
+- [Display](/components/display/)
+- <APIRef text="sendspin_image.h" path="esphome/components/sendspin/image/sendspin_image.h" />

--- a/src/content/docs/components/image/sendspin.mdx
+++ b/src/content/docs/components/image/sendspin.mdx
@@ -59,10 +59,11 @@ The entry's own `id` refers to the slot, which is what actions and conditions ta
   [Cross-fading between tracks](#cross-fading-between-tracks).
 
   - **id** (**Required**, [ID](/guides/configuration-types#id)): The ID to reference the outgoing artwork.
-- **source** (*Optional*): Which artwork to display. One of `album` (default), `artist` or `none`.
+- **source** (*Optional*): Which artwork to display. One of `album` (default) or `artist`.
 - **display_offset** (*Optional*, [Time](/guides/configuration-types#time)): Request a shift when
   `on_image_display` fires relative to the moment the server asked for the artwork to appear. A positive value
-  fires it early, a negative value delays it. Must be between `-60s` and `60s`. Defaults to `0ms`.
+  fires it early, a negative value delays it. Must be a whole number of milliseconds between `-60s` and `60s`.
+  Defaults to `0ms`.
 - **transparency** (*Optional*): If set, the alpha channel of the artwork will be taken into account. The
   possible values are `opaque` (default), `chroma_key` and `alpha_channel`. See the discussion on transparency
   in the [image component](/components/image/#transparency-options).
@@ -103,7 +104,8 @@ for more. Only needed when a `transition_image` is configured.
 
 > [!IMPORTANT]
 > Every `on_image_display` must run this action exactly once if `transition_image` is configured. If it
-> is not run, no further artwork appears until the artwork is cleared.
+> is not run, no further artwork appears until the artwork is cleared, and a warning naming the slot is
+> logged ten seconds after the artwork was displayed.
 
 #### Configuration variables
 

--- a/src/content/docs/components/index.mdx
+++ b/src/content/docs/components/index.mdx
@@ -869,6 +869,7 @@ Used for defining images to draw on [displays](#display-components) or use with 
   ["Animation", "/components/image/animation/", "image-multiple-outline.svg", "dark-invert"],
   ["File", "/components/image/file/", "file-image-outline.svg", "dark-invert"],
   ["Online Image", "/components/image/online_image/", "image-sync-outline.svg", "dark-invert"],
+  ["Sendspin Image", "/components/image/sendspin/", "music.svg", "dark-invert"],
 ]} />
 
 ## Infrared Components

--- a/src/content/docs/components/sendspin.mdx
+++ b/src/content/docs/components/sendspin.mdx
@@ -50,6 +50,8 @@ on_...:
 
 ## Child components
 
+- [Sendspin Image](/components/image/sendspin/): Displays album and artist artwork
+  streamed from the group on a connected display.
 - [Sendspin Group Media Player](/components/media_player/sendspin/): Exposes
   group-wide playback and volume controls as a Home Assistant media player entity.
 - [Sendspin Media Source](/components/media_source/sendspin/): Plays synchronized


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Documents the new Sendspin image component.

**Related issue (if applicable):** not applicable

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#17937

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [x] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
