### PR TITLE
[bk72xx_ble_tracker] Document automation triggers and scan actions

### DIFF
--- a/src/content/docs/components/bk72xx_ble_tracker.mdx
+++ b/src/content/docs/components/bk72xx_ble_tracker.mdx
@@ -118,20 +118,22 @@ bk72xx_ble_tracker:
 
 ## Actions
 
-- **bk72xx_ble_tracker.start_scan**: Start a scan. The optional
-  [templatable](/automations/templates#config-templatable) `continuous` overrides the scan mode
-  until the next `start_scan` or `stop_scan` (the YAML-configured value itself is untouched);
-  without it the mode configured under `scan_parameters` is restored (a previous `stop_scan`
-  does not stick as "one-shot"). This differs from `esp32_ble_tracker.start_scan`, where an
-  omitted `continuous` always forces a one-shot scan. Invoked while a scan is already running,
-  a mode switch re-anchors the running scan's `duration` window instead of restarting the
-  radio (the `on_scan_end` period clock is unaffected); a same-mode call is a no-op — it does
-  not extend the running scan.
+### `bk72xx_ble_tracker.start_scan` Action
 
-- **bk72xx_ble_tracker.stop_scan**: Stop a running scan; also cancels a start that is still
-  being retried, and switches the scanner to one-shot until a later `start_scan` restores the
-  configured mode. Accepts the bare-id shorthand (`bk72xx_ble_tracker.stop_scan: my_tracker`)
-  like its esp32 counterpart.
+Start a scan. The optional [templatable](/automations/templates#config-templatable) `continuous`
+overrides the scan mode until the next `start_scan` or `stop_scan` (the YAML-configured value
+itself is untouched); without it the mode configured under `scan_parameters` is restored (a
+previous `stop_scan` does not stick as "one-shot"). This differs from
+`esp32_ble_tracker.start_scan`, where an omitted `continuous` always forces a one-shot scan.
+Invoked while a scan is already running, a mode switch re-anchors the running scan's `duration`
+window instead of restarting the radio (the `on_scan_end` period clock is unaffected); a
+same-mode call is a no-op — it does not extend the running scan.
+
+### `bk72xx_ble_tracker.stop_scan` Action
+
+Stop a running scan; also cancels a start that is still being retried, and switches the scanner
+to one-shot until a later `start_scan` restores the configured mode. Accepts the bare-id
+shorthand (`bk72xx_ble_tracker.stop_scan: my_tracker`) like `esp32_ble_tracker.stop_scan`.
 
 Scan only while Home Assistant is connected — the time-share pattern from
 [Use on a single-core chip](#use-on-a-single-core-chip):

--- a/src/content/docs/components/bk72xx_ble_tracker.mdx
+++ b/src/content/docs/components/bk72xx_ble_tracker.mdx
@@ -65,19 +65,57 @@ bk72xx_ble_tracker:
     complete scan session. When `continuous` is `true` the scanner restarts immediately after each
     session ends. Defaults to `5min`.
 
-  - **continuous** (*Optional*, boolean): Leave this at `true`. When `true` the scanner runs
-    permanently, with the `duration` period used only for per-session bookkeeping. When `false`
-    a started scan runs for `duration` and then stops. Defaults to `true`.
+  - **continuous** (*Optional*, boolean): When `true` the scanner runs permanently, with the
+    `duration` period used only for per-session bookkeeping. When `false` a started scan runs
+    for `duration` and then stops — note that nothing starts the first scan automatically, so
+    pair it with the `bk72xx_ble_tracker.start_scan` action (for example from
+    `api.on_client_connected`, so the single-core radio only scans while Home Assistant is
+    connected). Defaults to `true`.
+
+- **on_ble_advertise** (*Optional*, [Automation](/automations)): An automation to perform
+  when a Bluetooth advertisement is received. An optional `mac_address` (single address or list)
+  filters to specific devices. A variable `x` of type
+  `ble_device_base::ESPBTDevice` is passed to the automation.
+
+- **on_ble_service_data_advertise** (*Optional*, [Automation](/automations)): An
+  automation to perform when an advertisement carries service data for the given
+  `service_uuid` (16, 32 or 128 bit; optional `mac_address` filter). A variable `x` with the
+  service data bytes (`std::vector<uint8_t>`) is passed to the automation.
+
+- **on_ble_manufacturer_data_advertise** (*Optional*, [Automation](/automations)): The
+  same for manufacturer data, filtered by `manufacturer_id`.
+
+- **on_scan_end** (*Optional*, [Automation](/automations)): An automation to perform
+  when a scan session ends (its `duration` elapsed, or `stop_scan` was called).
 
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID used to
   reference this component in lambdas.
 
-> [!WARNING]
-> Automation triggers (`on_ble_advertise`, `on_scan_end`, …) and the
-> `start_scan` / `stop_scan` actions are not available on this platform yet. Because nothing
-> else starts a scan, setting `continuous: false` leaves the scanner permanently idle: there is
-> no config error and no scan-start log line, and every attached BLE sensor simply stays
-> unknown. Starting a scan is currently only possible from C++ (`start_scan()`).
+## Actions
+
+- **bk72xx_ble_tracker.start_scan**: Start a scan. The optional
+  [templatable](/automations/templates#config-templatable) `continuous` overrides the scan mode
+  for this start only; without it the mode configured under `scan_parameters` is restored (a
+  previous `stop_scan` does not stick as "one-shot"). Invoked while a scan is already running,
+  the action applies the mode and re-anchors the running scan's `duration` window instead of
+  restarting the radio.
+
+- **bk72xx_ble_tracker.stop_scan**: Stop a running scan; also cancels a start that is still
+  being retried.
+
+```yaml
+api:
+  on_client_connected:
+    - bk72xx_ble_tracker.start_scan:
+        continuous: true
+  on_client_disconnected:
+    - if:
+        condition:
+          not:
+            api.connected:
+        then:
+          - bk72xx_ble_tracker.stop_scan:
+```
 
 ## With BLE sensors
 

--- a/src/content/docs/components/bk72xx_ble_tracker.mdx
+++ b/src/content/docs/components/bk72xx_ble_tracker.mdx
@@ -78,12 +78,17 @@ bk72xx_ble_tracker:
   `ble_device_base::ESPBTDevice` is passed to the automation.
 
 - **on_ble_service_data_advertise** (*Optional*, [Automation](/automations)): An
-  automation to perform when an advertisement carries service data for the given
-  `service_uuid` (16, 32 or 128 bit; optional `mac_address` filter). A variable `x` with the
-  service data bytes (`std::vector<uint8_t>`) is passed to the automation.
+  automation to perform when an advertisement carries matching service data. A variable `x`
+  with the service data bytes (`std::vector<uint8_t>`) is passed to the automation.
+
+  - **service_uuid** (**Required**, string): 16-, 32- or 128-bit BLE service UUID in hex.
+  - **mac_address** (*Optional*, MAC Address): Filter to a single device.
 
 - **on_ble_manufacturer_data_advertise** (*Optional*, [Automation](/automations)): The
-  same for manufacturer data, filtered by `manufacturer_id`.
+  same for manufacturer data. A variable `x` with the manufacturer data bytes is passed.
+
+  - **manufacturer_id** (**Required**, string): 16-, 32- or 128-bit BLE manufacturer ID in hex.
+  - **mac_address** (*Optional*, MAC Address): Filter to a single device.
 
 - **on_scan_end** (*Optional*, [Automation](/automations)): An automation to perform
   when a scan session ends (its `duration` elapsed, or `stop_scan` was called).
@@ -95,17 +100,23 @@ bk72xx_ble_tracker:
 
 - **bk72xx_ble_tracker.start_scan**: Start a scan. The optional
   [templatable](/automations/templates#config-templatable) `continuous` overrides the scan mode
-  for this start only; without it the mode configured under `scan_parameters` is restored (a
-  previous `stop_scan` does not stick as "one-shot"). This differs from
-  `esp32_ble_tracker.start_scan`, where an omitted `continuous` always forces a one-shot scan.
-  Invoked while a scan is already running, the action applies the mode and re-anchors the running
-  scan's `duration` window instead of restarting the radio.
+  until the next `start_scan` or `stop_scan` (the YAML-configured value itself is untouched);
+  without it the mode configured under `scan_parameters` is restored (a previous `stop_scan`
+  does not stick as "one-shot"). This differs from `esp32_ble_tracker.start_scan`, where an
+  omitted `continuous` always forces a one-shot scan. Invoked while a scan is already running,
+  a mode switch re-anchors the running scan's `duration` window instead of restarting the
+  radio; a same-mode call is a no-op — it does not extend the running scan.
 
 - **bk72xx_ble_tracker.stop_scan**: Stop a running scan; also cancels a start that is still
-  being retried. Accepts the bare-id shorthand (`bk72xx_ble_tracker.stop_scan: my_tracker`)
+  being retried, and switches the scanner to one-shot until a later `start_scan` restores the
+  configured mode. Accepts the bare-id shorthand (`bk72xx_ble_tracker.stop_scan: my_tracker`)
   like its esp32 counterpart.
 
 ```yaml
+bk72xx_ble_tracker:
+  scan_parameters:
+    continuous: false   # do not start on boot — the api: automation drives scanning
+
 api:
   on_client_connected:
     - bk72xx_ble_tracker.start_scan:

--- a/src/content/docs/components/bk72xx_ble_tracker.mdx
+++ b/src/content/docs/components/bk72xx_ble_tracker.mdx
@@ -96,9 +96,10 @@ bk72xx_ble_tracker:
 - **bk72xx_ble_tracker.start_scan**: Start a scan. The optional
   [templatable](/automations/templates#config-templatable) `continuous` overrides the scan mode
   for this start only; without it the mode configured under `scan_parameters` is restored (a
-  previous `stop_scan` does not stick as "one-shot"). Invoked while a scan is already running,
-  the action applies the mode and re-anchors the running scan's `duration` window instead of
-  restarting the radio.
+  previous `stop_scan` does not stick as "one-shot"). This differs from
+  `esp32_ble_tracker.start_scan`, where an omitted `continuous` always forces a one-shot scan.
+  Invoked while a scan is already running, the action applies the mode and re-anchors the running
+  scan's `duration` window instead of restarting the radio.
 
 - **bk72xx_ble_tracker.stop_scan**: Stop a running scan; also cancels a start that is still
   being retried.

--- a/src/content/docs/components/bk72xx_ble_tracker.mdx
+++ b/src/content/docs/components/bk72xx_ble_tracker.mdx
@@ -102,7 +102,8 @@ bk72xx_ble_tracker:
   scan's `duration` window instead of restarting the radio.
 
 - **bk72xx_ble_tracker.stop_scan**: Stop a running scan; also cancels a start that is still
-  being retried.
+  being retried. Accepts the bare-id shorthand (`bk72xx_ble_tracker.stop_scan: my_tracker`)
+  like its esp32 counterpart.
 
 ```yaml
 api:

--- a/src/content/docs/components/bk72xx_ble_tracker.mdx
+++ b/src/content/docs/components/bk72xx_ble_tracker.mdx
@@ -73,9 +73,10 @@ bk72xx_ble_tracker:
     connected). Defaults to `true`.
 
 - **on_ble_advertise** (*Optional*, [Automation](/automations)): An automation to perform
-  when a Bluetooth advertisement is received. An optional `mac_address` (single address or list)
-  filters to specific devices. A variable `x` of type
+  when a Bluetooth advertisement is received. A variable `x` of type
   `ble_device_base::ESPBTDevice` is passed to the automation.
+
+  - **mac_address** (*Optional*, MAC Address or list of MAC Address): Filter to specific devices.
 
 - **on_ble_service_data_advertise** (*Optional*, [Automation](/automations)): An
   automation to perform when an advertisement carries matching service data. A variable `x`
@@ -85,7 +86,8 @@ bk72xx_ble_tracker:
   - **mac_address** (*Optional*, MAC Address): Filter to a single device.
 
 - **on_ble_manufacturer_data_advertise** (*Optional*, [Automation](/automations)): The
-  same for manufacturer data. A variable `x` with the manufacturer data bytes is passed.
+  same for manufacturer data. A variable `x` with the manufacturer data bytes
+  (`std::vector<uint8_t>`) is passed.
 
   - **manufacturer_id** (**Required**, string): 16-, 32- or 128-bit BLE manufacturer ID in hex.
   - **mac_address** (*Optional*, MAC Address): Filter to a single device.
@@ -96,6 +98,24 @@ bk72xx_ble_tracker:
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID used to
   reference this component in lambdas.
 
+The `x` variable differs between the triggers — `on_ble_advertise` receives the parsed device,
+while the service and manufacturer data triggers receive only the matched payload bytes:
+
+```yaml
+bk72xx_ble_tracker:
+  on_ble_advertise:
+    - mac_address: XX:XX:XX:XX:XX:XX
+      then:
+        - lambda: |-
+            ESP_LOGD("ble_adv", "Advertisement from %s (RSSI %d)",
+                     x.address_str().c_str(), x.get_rssi());
+  on_ble_service_data_advertise:
+    - service_uuid: FCD2
+      then:
+        - lambda: |-
+            ESP_LOGD("ble_svc_data", "Service data of length %i", x.size());
+```
+
 ## Actions
 
 - **bk72xx_ble_tracker.start_scan**: Start a scan. The optional
@@ -105,12 +125,16 @@ bk72xx_ble_tracker:
   does not stick as "one-shot"). This differs from `esp32_ble_tracker.start_scan`, where an
   omitted `continuous` always forces a one-shot scan. Invoked while a scan is already running,
   a mode switch re-anchors the running scan's `duration` window instead of restarting the
-  radio; a same-mode call is a no-op — it does not extend the running scan.
+  radio (the `on_scan_end` period clock is unaffected); a same-mode call is a no-op — it does
+  not extend the running scan.
 
 - **bk72xx_ble_tracker.stop_scan**: Stop a running scan; also cancels a start that is still
   being retried, and switches the scanner to one-shot until a later `start_scan` restores the
   configured mode. Accepts the bare-id shorthand (`bk72xx_ble_tracker.stop_scan: my_tracker`)
   like its esp32 counterpart.
+
+Scan only while Home Assistant is connected — the time-share pattern from
+[Use on a single-core chip](#use-on-a-single-core-chip):
 
 ```yaml
 bk72xx_ble_tracker:
@@ -122,10 +146,13 @@ api:
     - bk72xx_ble_tracker.start_scan:
         continuous: true
   on_client_disconnected:
+    # fires for EVERY departing client (log viewer, CLI) — state_subscription_only
+    # ignores logger-only clients, so scanning stops only when Home Assistant is gone
     - if:
         condition:
           not:
             api.connected:
+              state_subscription_only: true
         then:
           - bk72xx_ble_tracker.stop_scan:
 ```


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Documents the automation surface added to `bk72xx_ble_tracker` by esphome/esphome#17776: the four triggers (`on_ble_advertise`, `on_ble_service_data_advertise`, `on_ble_manufacturer_data_advertise`, `on_scan_end`) and the `start_scan` / `stop_scan` actions, replacing the page's warning that automations are not available on this platform.

Behavioral notes match the implementation: `continuous` on `start_scan` is templatable and one-shot (the `scan_parameters` mode is restored when the action omits it), a start against a running scan re-anchors the duration window instead of restarting the radio, and `stop_scan` also cancels a pending retried start. The `continuous: false` bullet now describes the HA-connected scan pattern instead of warning the scanner stays idle.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#17776

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
