### PR TITLE
[image] Document `defaults` option

### DIFF
--- a/src/content/docs/components/image/animation.mdx
+++ b/src/content/docs/components/image/animation.mdx
@@ -86,6 +86,11 @@ Moves the animation to a specific frame. This is equivalent to the
 - **id** (**Required**, [ID](/guides/configuration-types#id)): The ID of the animation to animate.
 - **frame** (**Required**, int): The frame index to show next.
 
+## Sharing Options Across Files
+
+If you have several `animation` images that share most of their options, see [Setting Defaults](/components/image#setting-defaults)
+on the [image](/components/image/) component page.
+
 ## See Also
 
 - [Images](/components/image/)

--- a/src/content/docs/components/image/animation.mdx
+++ b/src/content/docs/components/image/animation.mdx
@@ -88,7 +88,8 @@ Moves the animation to a specific frame. This is equivalent to the
 
 ## Sharing Options Across Files
 
-If you have several `animation` images that share most of their options, see [Setting Defaults](/components/image#setting-defaults)
+If you have several `animation` images that share most of their options,
+see [Setting Defaults](/components/image#setting-defaults)
 on the [image](/components/image/) component page.
 
 ## See Also

--- a/src/content/docs/components/image/file.mdx
+++ b/src/content/docs/components/image/file.mdx
@@ -56,7 +56,7 @@ image:
   the discussion on transparency in the [image component](/components/image#transparency-options).
 - **invert_alpha** (*Optional*, boolean): Applicable to binary and grayscale only, this will invert the colors, i.e. make black white and vice versa. Useful for e-ink displays. Defaults to `false`.
 
-- **dither** (*Optional*): Specifies which dither method used to process the image, only used in GRAYSCALE and BINARY type image. Defaults to `NONE`. You can read more about it on the [Pillow documentation](https://pillow.readthedocs.io/en/stable/reference/Image.html?highlight=Dither#PIL.Image.Image.convert) and on [Wikipedia](https://en.wikipedia.org/wiki/Dither).
+- **dither** (*Optional*): Specifies which dither method is used to process the image, only used for `BINARY` type images. Defaults to `NONE`. You can read more about it on the [Pillow documentation](https://pillow.readthedocs.io/en/stable/reference/Image.html?highlight=Dither#PIL.Image.Image.convert) and on [Wikipedia](https://en.wikipedia.org/wiki/Dither).
 
   - `NONE`  : Every pixel converts to its nearest color.
   - `FLOYDSTEINBERG`  : Uses Floyd-Steinberg dither to approximate the original image luminosity levels.

--- a/src/content/docs/components/image/file.mdx
+++ b/src/content/docs/components/image/file.mdx
@@ -99,6 +99,11 @@ image:
 - **url** (**Required** for `web`, url): The URL to download the image file from.
 - **icon** (**Required** for `mdi`, `mdil` and `memory`, string): The icon name, without the `mdi:` style prefix.
 
+## Sharing Options Across Files
+
+If you have several `file` images that share most of their options, see [Setting Defaults](/components/image#setting-defaults)
+on the [image](/components/image/) component page.
+
 ## See Also
 
 - [Images](/components/image/)

--- a/src/content/docs/components/image/file.mdx
+++ b/src/content/docs/components/image/file.mdx
@@ -101,7 +101,8 @@ image:
 
 ## Sharing Options Across Files
 
-If you have several `file` images that share most of their options, see [Setting Defaults](/components/image#setting-defaults)
+If you have several `file` images that share most of their options,
+see [Setting Defaults](/components/image#setting-defaults)
 on the [image](/components/image/) component page.
 
 ## See Also

--- a/src/content/docs/components/image/index.mdx
+++ b/src/content/docs/components/image/index.mdx
@@ -81,6 +81,36 @@ display:
 You can also use this to invert images in two color displays, use `COLOR_OFF` then `COLOR_ON`
 as the additional parameters.
 
+## Setting Defaults
+
+If you have several images that share most of their options (`type`, `transparency`, `resize`, ...), a platform entry
+can use `defaults:` together with `files:` instead of repeating those options on every image:
+
+```yaml
+image:
+  - platform: file
+    defaults:
+      type: RGB565
+      transparency: opaque
+      resize: 100x100
+    files:
+      - id: image_one
+        file: "image1.png"
+      - id: image_two
+        file: "image2.png"
+        type: GRAYSCALE # overrides the default type for this image only
+```
+
+Each entry in `files:` is merged with `defaults:`, with the entry's own options taking priority. `defaults:` can only
+be used together with `files:`. This works the same way for every image platform
+([`file`](/components/image/file/), [`animation`](/components/image/animation/) and
+[`online_image`](/components/image/online_image/)) — just replace the entries in `files:` with the options normally
+used for that platform.
+
+- **defaults** (*Optional*, mapping): Options merged into every entry in `files:`.
+- **files** (*Optional*, list): A list of images, each using the normal configuration variables of the selected
+  platform.
+
 ## Transparency Options
 
 By default transparency is not used. If `transparency: chroma_key` is set then a specific colour will be used to

--- a/src/content/docs/components/image/index.mdx
+++ b/src/content/docs/components/image/index.mdx
@@ -113,16 +113,17 @@ used for that platform.
 
 ## Transparency Options
 
-By default transparency is not used. If `transparency: chroma_key` is set then a specific colour will be used to
-replace any transparent or partially transparent portions of the image. This will not be drawn when rendering the
-image, allowing the background to be visible.
+The `transparency` option controls how the alpha channel of the input image is handled. Possible values are:
 
-If `transparency: alpha_channel` is set, then each pixel of the image will be assigned an additional byte with a
-transparency value. This is useful mainly when using [LVGL](/components/lvgl/) as the `alpha_channel` transparency
-will enable smooth blending of transparent images with the background. This choice is not available for binary
-images.
-When using the display lambda image drawing functions these will draw or not draw the pixel, no blending with the
-background will be done.
+- `opaque` (default): Transparency is not used; the image is drawn fully opaque.
+- `chroma_key`: A specific colour is used to represent any transparent or partially transparent portions of the
+  image. Pixels of that colour will not be drawn when rendering the image, allowing the background to be visible.
+- `alpha_channel`: Each pixel of the image is assigned an additional byte with a transparency value. This is useful
+  mainly when using [LVGL](/components/lvgl/), as `alpha_channel` transparency enables smooth blending of
+  transparent images with the background. This choice is not available for binary images. When using the display
+  lambda image drawing functions, these will only draw or not draw the pixel; no blending with the background will
+  be done.
+
 The `BINARY` format with `chroma_key` transparency effectively turns the image into an alpha mask with one bit per
 pixel. GRAYSCALE images with transparency store the alpha channel only, and remain 1 byte per pixel.
 

--- a/src/content/docs/components/image/index.mdx
+++ b/src/content/docs/components/image/index.mdx
@@ -106,7 +106,7 @@ be used together with `files:`. This works the same way for every image platform
 used for that platform.
 
 - **defaults** (*Optional*, mapping): Options merged into every entry in `files:`.
-- **files** (*Optional*, list): A list of images, each using the normal configuration variables of the selected
+- **files** (**Required**, list): A list of images, each using the normal configuration variables of the selected
   platform.
 
 ## Transparency Options

--- a/src/content/docs/components/image/index.mdx
+++ b/src/content/docs/components/image/index.mdx
@@ -111,16 +111,17 @@ used for that platform.
 
 ## Transparency Options
 
-By default transparency is not used. If `transparency: chroma_key` is set then a specific colour will be used to
-replace any transparent or partially transparent portions of the image. This will not be drawn when rendering the
-image, allowing the background to be visible.
+The `transparency` option controls how the alpha channel of the input image is handled. Possible values are:
 
-If `transparency: alpha_channel` is set, then each pixel of the image will be assigned an additional byte with a
-transparency value. This is useful mainly when using [LVGL](/components/lvgl/) as the `alpha_channel` transparency
-will enable smooth blending of transparent images with the background. This choice is not available for binary
-images.
-When using the display lambda image drawing functions these will draw or not draw the pixel, no blending with the
-background will be done.
+- `opaque` (default): Transparency is not used; the image is drawn fully opaque.
+- `chroma_key`: A specific colour is used to represent any transparent or partially transparent portions of the
+  image. Pixels of that colour will not be drawn when rendering the image, allowing the background to be visible.
+- `alpha_channel`: Each pixel of the image is assigned an additional byte with a transparency value. This is useful
+  mainly when using [LVGL](/components/lvgl/), as `alpha_channel` transparency enables smooth blending of
+  transparent images with the background. This choice is not available for binary images. When using the display
+  lambda image drawing functions, these will only draw or not draw the pixel; no blending with the background will
+  be done.
+
 The `BINARY` format with `chroma_key` transparency effectively turns the image into an alpha mask with one bit per
 pixel. GRAYSCALE images with transparency store the alpha channel only, and remain 1 byte per pixel.
 

--- a/src/content/docs/components/image/index.mdx
+++ b/src/content/docs/components/image/index.mdx
@@ -79,6 +79,36 @@ display:
 You can also use this to invert images in two color displays, use `COLOR_OFF` then `COLOR_ON`
 as the additional parameters.
 
+## Setting Defaults
+
+If you have several images that share most of their options (`type`, `transparency`, `resize`, ...), a platform entry
+can use `defaults:` together with `files:` instead of repeating those options on every image:
+
+```yaml
+image:
+  - platform: file
+    defaults:
+      type: RGB565
+      transparency: opaque
+      resize: 100x100
+    files:
+      - id: image_one
+        file: "image1.png"
+      - id: image_two
+        file: "image2.png"
+        type: GRAYSCALE # overrides the default type for this image only
+```
+
+Each entry in `files:` is merged with `defaults:`, with the entry's own options taking priority. `defaults:` can only
+be used together with `files:`. This works the same way for every image platform
+([`file`](/components/image/file/), [`animation`](/components/image/animation/) and
+[`online_image`](/components/image/online_image/)) — just replace the entries in `files:` with the options normally
+used for that platform.
+
+- **defaults** (*Optional*, mapping): Options merged into every entry in `files:`.
+- **files** (*Optional*, list): A list of images, each using the normal configuration variables of the selected
+  platform.
+
 ## Transparency Options
 
 By default transparency is not used. If `transparency: chroma_key` is set then a specific colour will be used to

--- a/src/content/docs/components/image/online_image.mdx
+++ b/src/content/docs/components/image/online_image.mdx
@@ -192,6 +192,11 @@ wifi:
     - component.update: my_online_image
 ```
 
+## Sharing Options Across Files
+
+If you have several `online_image` images that share most of their options, see [Setting Defaults](/components/image#setting-defaults)
+on the [image](/components/image/) component page.
+
 ## See Also
 
 - [Image Component](/components/image/)

--- a/src/content/docs/components/image/online_image.mdx
+++ b/src/content/docs/components/image/online_image.mdx
@@ -43,9 +43,8 @@ image:
 
 - **format** (**Required**): The format that the image is encoded with.
 
-  - `AUTO`  : The format is detected automatically from the downloaded image content.
   - `BMP`  : The image on the server is encoded in BMP format.
-  - `JPEG`  : The image on the server is encoded in JPEG format.
+  - `JPEG` (or `JPG`) : The image on the server is encoded in JPEG format.
   - `PNG`  : The image on the server is encoded in PNG format.
 - **resize** (*Optional*, string): If set, this will resize the image to fit inside the given dimensions `WIDTHxHEIGHT`
   and preserve the aspect ratio.

--- a/src/content/docs/components/image/online_image.mdx
+++ b/src/content/docs/components/image/online_image.mdx
@@ -193,7 +193,8 @@ wifi:
 
 ## Sharing Options Across Files
 
-If you have several `online_image` images that share most of their options, see [Setting Defaults](/components/image#setting-defaults)
+If you have several `online_image` images that share most of their options,
+see [Setting Defaults](/components/image#setting-defaults)
 on the [image](/components/image/) component page.
 
 ## See Also


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#18032

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
