### PR TITLE
[bthome_mithermometer] Add component documentation

### DIFF
--- a/src/content/docs/components/index.mdx
+++ b/src/content/docs/components/index.mdx
@@ -297,6 +297,7 @@ Sensors are organized into categories; if a given sensor fits into more than one
   ["AM43", "/components/sensor/am43/", "am43.jpg", "Lux & Battery level"],
   ["BLE Client Sensor", "/components/sensor/ble_client/", "bluetooth.svg", "dark-invert"],
   ["BLE RSSI", "/components/sensor/ble_rssi/", "bluetooth.svg", "dark-invert"],
+  ["BTHome MiThermometer", "/components/sensor/bthome_mithermometer/", "bluetooth.svg", "dark-invert"],
   ["HHCCJCY10 (MiFlora Pink)", "/components/sensor/xiaomi_hhccjcy10/", "xiaomi_hhccjcy10.jpg", "Soil moisture & Temperature & Light"],
   ["Inkbird IBS-TH1 Mini", "/components/sensor/inkbird_ibsth1_mini/", "inkbird_isbth1_mini.jpg", "Temperature & Humidity"],
   ["Mopeka Pro Check LP", "/components/sensor/mopeka_pro_check/", "mopeka_pro_check.jpg", "Tank level"],

--- a/src/content/docs/components/sensor/bthome_mithermometer.mdx
+++ b/src/content/docs/components/sensor/bthome_mithermometer.mdx
@@ -5,12 +5,14 @@ title: "BTHome MiThermometer Sensor"
 import APIRef from '@components/APIRef.astro';
 
 
-The `bthome_mithermometer` sensor platform lets you receive measurements broadcast by
-[BTHome](https://bthome.io/)-format Bluetooth Low Energy devices — for example Xiaomi/Mijia
-thermometers running the [ATC](https://github.com/atc1441/ATC_MiThermometer) or
-[PVVX](https://github.com/pvvx/ATC_MiThermometer) custom firmware in BTHome mode. The component
-listens passively to the advertisements, so it does not pair with the device and has no impact on
-its battery life.
+The `bthome_mithermometer` sensor platform lets you receive measurements from Xiaomi/Mijia
+thermometers broadcasting in [BTHome](https://bthome.io/) v2 format — that is, devices flashed with
+[PVVX MiThermometer](https://github.com/pvvx/ATC_MiThermometer) firmware and set to the "BTHome v2"
+advertisement type. The component listens passively to the advertisements, so it does not pair with
+the device and has no impact on its battery life.
+
+It requires a BLE tracker, for example the [ESP32 BLE Tracker](/components/esp32_ble_tracker), to
+receive the advertisements.
 
 For choosing between the firmware options of these thermometers (stock MiBeacon, ATC, PVVX and
 their advertisement formats) and for flashing/bindkey instructions, see
@@ -23,9 +25,8 @@ esp32_ble_tracker:
 
 sensor:
   - platform: bthome_mithermometer
-    mac_address: "A4:C1:38:XX:XX:XX"
-    # bindkey is only needed for devices that encrypt their advertisements
-    bindkey: "231d39c1d7cc1ab1aee224cd096db932"
+    mac_address: "XX:XX:XX:XX:XX:XX"
+    bindkey: "00112233445566778899aabbccddeeff"
     temperature:
       name: "BTHome Temperature"
     humidity:

--- a/src/content/docs/components/sensor/bthome_mithermometer.mdx
+++ b/src/content/docs/components/sensor/bthome_mithermometer.mdx
@@ -1,0 +1,63 @@
+---
+description: "Instructions for setting up BTHome BLE thermometer/hygrometer sensors in ESPHome."
+title: "BTHome MiThermometer Sensor"
+---
+import APIRef from '@components/APIRef.astro';
+
+
+The `bthome_mithermometer` sensor platform lets you receive measurements broadcast by
+[BTHome](https://bthome.io/)-format Bluetooth Low Energy devices — for example Xiaomi/Mijia
+thermometers running the [ATC](https://github.com/atc1441/ATC_MiThermometer) or
+[PVVX](https://github.com/pvvx/ATC_MiThermometer) custom firmware in BTHome mode. The component
+listens passively to the advertisements, so it does not pair with the device and has no impact on
+its battery life.
+
+For choosing between the firmware options of these thermometers (stock MiBeacon, ATC, PVVX and
+their advertisement formats) and for flashing/bindkey instructions, see
+[LYWSD03MMC on the Xiaomi BLE page](/components/sensor/xiaomi_ble#lywsd03mmc) — this page is the
+option reference for the `bthome_mithermometer` platform itself.
+
+```yaml
+# Example configuration entry
+esp32_ble_tracker:
+
+sensor:
+  - platform: bthome_mithermometer
+    mac_address: "A4:C1:38:XX:XX:XX"
+    # bindkey is only needed for devices that encrypt their advertisements
+    bindkey: "231d39c1d7cc1ab1aee224cd096db932"
+    temperature:
+      name: "BTHome Temperature"
+    humidity:
+      name: "BTHome Humidity"
+    battery_level:
+      name: "BTHome Battery Level"
+```
+
+> [!NOTE]
+> A `bindkey` is only required for devices configured to **encrypt** their BTHome advertisements;
+> unencrypted devices work without one. It is the same 32-character (16-byte) hex key you set when
+> enabling encryption on the device (for example in the ATC/PVVX web configurator).
+
+## Configuration variables
+
+- **mac_address** (**Required**, MAC Address): The MAC address of the device to receive data from.
+- **bindkey** (*Optional*, 32-character hex string): The encryption key for devices that broadcast
+  encrypted BTHome advertisements. Omit it for unencrypted devices.
+- **temperature** (*Optional*): The temperature, in °C. All options from [Sensor](/components/sensor).
+- **humidity** (*Optional*): The relative humidity, in %. All options from [Sensor](/components/sensor).
+- **battery_level** (*Optional*): The battery level, in %. All options from [Sensor](/components/sensor).
+- **battery_voltage** (*Optional*): The battery voltage, in V. All options from [Sensor](/components/sensor).
+- **signal_strength** (*Optional*): The signal strength (RSSI), in dBm. All options from [Sensor](/components/sensor).
+- **esp32_ble_id** (*Optional*, [ID](/guides/configuration-types#id)): The ID of the
+  [ESP32 BLE Tracker](/components/esp32_ble_tracker) to receive advertisements from.
+  Only needed when more than one tracker is configured.
+
+## See Also
+
+- [ESP32 Bluetooth Low Energy Tracker Hub](/components/esp32_ble_tracker/)
+- [Bluetooth Low Energy RSSI Sensor](/components/sensor/ble_rssi/)
+- [Sensor Component](/components/sensor/)
+- [Xiaomi BLE — LYWSD03MMC firmware guide](/components/sensor/xiaomi_ble#lywsd03mmc)
+- [BTHome](https://bthome.io/)
+- <APIRef text="bthome_ble.h" path="bthome_mithermometer/bthome_ble.h" />

--- a/src/content/docs/components/sensor/xiaomi_ble.mdx
+++ b/src/content/docs/components/sensor/xiaomi_ble.mdx
@@ -218,7 +218,8 @@ sensor:
       name: "LYWSD03MMC Battery Level"
 ```
 
-Configuration example for PVVX MiThermometer firmware set to "BTHome v2" advertisement:
+Configuration example for PVVX MiThermometer firmware set to "BTHome v2" advertisement — see
+[BTHome MiThermometer](/components/sensor/bthome_mithermometer) for the full option reference:
 
 ```yaml
 sensor:


### PR DESCRIPTION
## What does this implement?

Adds the missing documentation page for the `bthome_mithermometer` sensor platform, which is in-tree and released but undocumented:

- receiving measurements from [BTHome](https://bthome.io/)-format BLE devices (Xiaomi/Mijia thermometers running ATC or PVVX firmware in BTHome mode)
- `mac_address`, optional `bindkey` for encrypted advertisements, and the temperature / humidity / battery level / battery voltage / signal strength sensors
- component index entry

Targets `current` per @jesserockz on #6859: the page documents the released platform and does not depend on the BLE work in `dev`. Written against 2026.7.4, where the platform is esp32-only (`DEPENDENCIES = ["esp32_ble_tracker"]`) and takes `esp32_ble_id`.

Firmware-choice and bindkey instructions stay on the Xiaomi BLE page; this page is the option reference for the platform itself.

## Related

- Replaces the page portion of #6859, which will be closed.
