### PR TITLE
[xiaomi_ble] Document the ble_hub_id tracker binding

### DIFF
--- a/src/content/docs/components/sensor/xiaomi_ble.mdx
+++ b/src/content/docs/components/sensor/xiaomi_ble.mdx
@@ -559,6 +559,14 @@ Required:
 - **mac_address** (MAC Address): The MAC address of the device.
 - **bindkey** (string, 32 characters, case insensitive): The key to decrypt the BLE advertisements for encrypted sensor types
 
+Optional:
+
+- **ble_hub_id** (*Optional*, [ID](/guides/configuration-types#id)): The BLE tracker
+  hub to receive advertisements from. Auto-generated when only one tracker is configured;
+  set it explicitly to disambiguate multiple trackers. On platforms not yet migrated to the
+  neutral BLE layer this option is still named `esp32_ble_id`; after migration that key keeps
+  working as a deprecated alias until ESPHome 2027.2.0.
+
 All options from [Sensor](/components/sensor) are supported for:
 
 - **temperature**

--- a/src/content/docs/components/sensor/xiaomi_ble.mdx
+++ b/src/content/docs/components/sensor/xiaomi_ble.mdx
@@ -562,10 +562,9 @@ Required:
 Optional:
 
 - **ble_hub_id** (*Optional*, [ID](/guides/configuration-types#id)): The ID of the
-  BLE tracker to receive advertisements from — the [ESP32 BLE Tracker](/components/esp32_ble_tracker)
-  on ESP32. Only needed when more than one tracker is configured. On platforms not yet
-  migrated to the neutral BLE layer this option is still named `esp32_ble_id`; after
-  migration that key keeps working as a deprecated alias until ESPHome 2027.2.0.
+  [ESP32 BLE Tracker](/components/esp32_ble_tracker/) to receive advertisements from.
+  Only needed when more than one tracker is configured. Configurations using the former
+  `esp32_ble_id` key keep working as a deprecated alias until ESPHome 2027.2.0.
 
 All options from [Sensor](/components/sensor) are supported for:
 

--- a/src/content/docs/components/sensor/xiaomi_ble.mdx
+++ b/src/content/docs/components/sensor/xiaomi_ble.mdx
@@ -561,11 +561,11 @@ Required:
 
 Optional:
 
-- **ble_hub_id** (*Optional*, [ID](/guides/configuration-types#id)): The BLE tracker
-  hub to receive advertisements from. Auto-generated when only one tracker is configured;
-  set it explicitly to disambiguate multiple trackers. On platforms not yet migrated to the
-  neutral BLE layer this option is still named `esp32_ble_id`; after migration that key keeps
-  working as a deprecated alias until ESPHome 2027.2.0.
+- **ble_hub_id** (*Optional*, [ID](/guides/configuration-types#id)): The ID of the
+  BLE tracker to receive advertisements from — the [ESP32 BLE Tracker](/components/esp32_ble_tracker)
+  on ESP32. Only needed when more than one tracker is configured. On platforms not yet
+  migrated to the neutral BLE layer this option is still named `esp32_ble_id`; after
+  migration that key keeps working as a deprecated alias until ESPHome 2027.2.0.
 
 All options from [Sensor](/components/sensor) are supported for:
 


### PR DESCRIPTION
## Description

Documents the `ble_hub_id` tracker-binding option on the Xiaomi BLE page. The key was never documented on this page, so this fills a pre-existing gap rather than only tracking a rename.

The Xiaomi platforms are moving to the neutral BLE layer batch by batch (esphome/esphome#18168, esphome/esphome#18170 and successors), where the option is named `ble_hub_id`. Platforms not yet migrated still use `esp32_ble_id`, so the entry is worded to cover both states and does not need editing per batch. Wording matches the ATC MiThermometer page (#7025).

**Related issue (if applicable):** none

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#18170

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook. (Not applicable — edits an existing page.)
