### PR TITLE
[changelog] Add entity key collision fix notes for 2026.8.0

### DIFF
--- a/src/content/docs/changelog/2026.8.0.mdx
+++ b/src/content/docs/changelog/2026.8.0.mdx
@@ -286,6 +286,12 @@ or LVGL can draw, with optional cross-fade transitions.
 - **CC1101 tuning options** by [@hn](https://github.com/hn): frequency offset compensation and bit
   synchronization registers are now configurable from YAML for narrowband protocols like wM-Bus
   ([#17577](https://github.com/esphome/esphome/pull/17577))
+- **Non-ASCII entity names no longer collide** by [@bdraco](https://github.com/bdraco): entity keys are now
+  hashed from the raw name instead of the sanitized object ID, so names that differ only in non-ASCII
+  characters (for example two Cyrillic sensor names that both sanitize to underscores) are now accepted and
+  stay distinct in the API and Home Assistant. Stored preferences migrate to the new keys automatically on
+  first boot. MQTT and Prometheus still require distinct sanitized names, as they address entities by
+  `object_id` ([#17949](https://github.com/esphome/esphome/pull/17949))
 - **Modbus garage doors and more** covered in the Modbus section above
 {/* FEATURE_HIGHLIGHTS_END */}
 
@@ -461,6 +467,11 @@ changes. These are not covered by the formal breaking change policy, but lambdas
   [#17677](https://github.com/esphome/esphome/pull/17677)
 - **ESPBTDevice::address_str() deprecated**: Use the buffer-based `address_str_to()`; the old method is removed
   in 2027.2.0 [#18092](https://github.com/esphome/esphome/pull/18092)
+- **EntityBase::get_object_id_hash() deprecated**: Entity keys are now hashed from the raw entity name rather
+  than the sanitized object ID. Use `get_entity_key()` for the key sent to API clients, or
+  `make_entity_preference<T>()` for preference storage, which migrates values stored under the old
+  object-id-hash key automatically; the old method is removed in 2027.1.0
+  [#17949](https://github.com/esphome/esphome/pull/17949)
 
 For detailed migration guides and API documentation, see the
 [ESPHome Developers Documentation](https://developers.esphome.io/).


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

The entity key collision fix was only listed in the generated changes for 2026.8.0; this adds a writeup under notable features and a developer note for the `get_object_id_hash()` deprecation.

**Related issue (if applicable):** https://github.com/esphome/backlog/issues/85

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#17949

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
