### PR TITLE
[esp32_ble_tracker] Document the WiFi dependent scan window default

### DIFF
--- a/src/content/docs/components/esp32_ble_tracker.mdx
+++ b/src/content/docs/components/esp32_ble_tracker.mdx
@@ -76,7 +76,8 @@ sensor:
     spend more time listening to packets (but also consume more power). Must not be larger than
     `interval`; the same range and step apply. When WiFi is configured, this defaults to the
     `interval` value: WiFi and Bluetooth share one radio, and this lets Bluetooth listen whenever
-    WiFi is not using it. Without WiFi, it defaults to `30ms`.
+    WiFi is not using it. Without WiFi, or with `software_coexistence` disabled, it defaults
+    to `30ms`.
 
   - **duration** (*Optional*, [Time](/guides/configuration-types#time)): The duration of each complete scan. This has no real
     impact on the device but can be used to debug the BLE stack. Defaults to `5min`.

--- a/src/content/docs/components/esp32_ble_tracker.mdx
+++ b/src/content/docs/components/esp32_ble_tracker.mdx
@@ -74,13 +74,9 @@ sensor:
   - **window** (*Optional*, [Time](/guides/configuration-types#time)): The time the ESP is actively listening for packets
     on a channel during each scan interval. If this is close to the `interval` value, the ESP will
     spend more time listening to packets (but also consume more power). Must not be larger than
-    `interval`; the same range and step apply. When WiFi is configured and the build uses ESP-IDF
-    5.5.5 or newer, this defaults to the `interval` value, as Espressif recommends for WiFi
-    coexistence: the radio arbiter still shares airtime with WiFi, and Bluetooth uses the airtime
-    WiFi does not claim. Older ESP-IDF versions had a bug that made the scanner listen far longer
-    than the configured window, so a small window appeared to work well; ESP-IDF 5.5.5 fixed this,
-    and a small window now misses most advertisements when WiFi is active. Without WiFi (for
-    example on Ethernet boards), it defaults to `30ms`.
+    `interval`; the same range and step apply. When WiFi is configured, this defaults to the
+    `interval` value: WiFi and Bluetooth share one radio, and this lets Bluetooth listen whenever
+    WiFi is not using it. Without WiFi, it defaults to `30ms`.
 
   - **duration** (*Optional*, [Time](/guides/configuration-types#time)): The duration of each complete scan. This has no real
     impact on the device but can be used to debug the BLE stack. Defaults to `5min`.

--- a/src/content/docs/components/esp32_ble_tracker.mdx
+++ b/src/content/docs/components/esp32_ble_tracker.mdx
@@ -74,7 +74,13 @@ sensor:
   - **window** (*Optional*, [Time](/guides/configuration-types#time)): The time the ESP is actively listening for packets
     on a channel during each scan interval. If this is close to the `interval` value, the ESP will
     spend more time listening to packets (but also consume more power). Must not be larger than
-    `interval`; the same range and step apply. Defaults to `30ms`.
+    `interval`; the same range and step apply. When WiFi is configured and the build uses ESP-IDF
+    5.5.5 or newer, this defaults to the `interval` value, as Espressif recommends for WiFi
+    coexistence: the radio arbiter still shares airtime with WiFi, and Bluetooth uses the airtime
+    WiFi does not claim. Older ESP-IDF versions had a bug that made the scanner listen far longer
+    than the configured window, so a small window appeared to work well; ESP-IDF 5.5.5 fixed this,
+    and a small window now misses most advertisements when WiFi is active. Without WiFi (for
+    example on Ethernet boards), it defaults to `30ms`.
 
   - **duration** (*Optional*, [Time](/guides/configuration-types#time)): The duration of each complete scan. This has no real
     impact on the device but can be used to debug the BLE stack. Defaults to `5min`.


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Document the new conditional default for the esp32_ble_tracker scan window. When WiFi is configured, the window defaults to the scan interval, as Espressif recommends for coexistence; without WiFi, or with software_coexistence disabled, the default stays 30ms.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#18356

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.
