### PR TITLE
Use hasSidebar to determine mobile menu button visibility

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -9,8 +9,6 @@ import { headerNavItems } from "../headerNav";
 
 const shouldRenderSearch = config.pagefind || config.components.Search !== "@astrojs/starlight/components/Search.astro";
 
-// Pages with a sidebar get Starlight's own mobile menu button; pages without one (splash templates such as
-// the homepage and the Starter Kit page) need this header to provide the mobile navigation toggle.
 const { hasSidebar } = Astro.locals.starlightRoute;
 ---
 

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -9,7 +9,9 @@ import { headerNavItems } from "../headerNav";
 
 const shouldRenderSearch = config.pagefind || config.components.Search !== "@astrojs/starlight/components/Search.astro";
 
-const isHomepage = Astro.url.pathname === "/";
+// Pages with a sidebar get Starlight's own mobile menu button; pages without one (splash templates such as
+// the homepage and the Starter Kit page) need this header to provide the mobile navigation toggle.
+const { hasSidebar } = Astro.locals.starlightRoute;
 ---
 
 <div class="header__inner">
@@ -38,7 +40,7 @@ const isHomepage = Astro.url.pathname === "/";
   <LinkButton href="/install/getting-started/" class="header__cta">Get started</LinkButton>
 
   {
-    isHomepage && (
+    !hasSidebar && (
       <>
         <button
           type="button"


### PR DESCRIPTION
## Description

Replace the homepage-specific check (`isHomepage`) with a more general sidebar presence check (`hasSidebar`) to determine when the header should render the mobile navigation toggle button.

This change allows the mobile menu button to appear on any page without a sidebar (splash templates like the homepage and Starter Kit page), rather than only on the homepage. The logic is now based on layout structure rather than URL pathname.

## Checklist

- [x] I am merging into `current` because this is a fix/adjustment in the current documentation.

https://claude.ai/code/session_014di7wUjK7uEBk7DAdQVtXw