### PR TITLE
[aranet] Add Aranet BLE sensor documentation

### DIFF
--- a/src/content/docs/components/index.mdx
+++ b/src/content/docs/components/index.mdx
@@ -248,7 +248,7 @@ Sensors are organized into categories; if a given sensor fits into more than one
   ["AGS10", "/components/sensor/ags10/", "ags10.jpg", "Volatile Organic Compound Sensor"],
   ["Air Quality Index", "/components/sensor/aqi/", "aqi.svg"],
   ["AirThings BLE", "/components/sensor/airthings_ble/", "airthings_logo.png", "Radon", "CO2", "Volatile organics"],
-  ["Aranet BLE", "/components/sensor/aranet4/", "bluetooth.svg", "CO2", "Radon", "Radiation", "dark-invert"],
+  ["Aranet BLE", "/components/sensor/aranet/", "bluetooth.svg", "CO2", "Radon", "Radiation", "dark-invert"],
   ["CCS811", "/components/sensor/ccs811/", "ccs811.jpg", "CO2 & Volatile organics"],
   ["CM1106", "/components/sensor/cm1106/", "cm1106.png", "CO2"],
   ["EE895", "/components/sensor/ee895/", "EE895.png", "CO2 & Temperature & Pressure"],
@@ -302,7 +302,7 @@ Sensors are organized into categories; if a given sensor fits into more than one
 <ImgTable items={[
   ["Alpha3", "/components/sensor/alpha3/", "alpha3.jpg"],
   ["AM43", "/components/sensor/am43/", "am43.jpg", "Lux & Battery level"],
-  ["Aranet BLE", "/components/sensor/aranet4/", "bluetooth.svg", "CO2 & Radon & Radiation", "dark-invert"],
+  ["Aranet BLE", "/components/sensor/aranet/", "bluetooth.svg", "CO2 & Radon & Radiation", "dark-invert"],
   ["ATC MiThermometer", "/components/sensor/atc_mithermometer/", "bluetooth.svg", "dark-invert"],
   ["BLE Client Sensor", "/components/sensor/ble_client/", "bluetooth.svg", "dark-invert"],
   ["BLE RSSI", "/components/sensor/ble_rssi/", "bluetooth.svg", "dark-invert"],

--- a/src/content/docs/components/index.mdx
+++ b/src/content/docs/components/index.mdx
@@ -248,6 +248,7 @@ Sensors are organized into categories; if a given sensor fits into more than one
   ["AGS10", "/components/sensor/ags10/", "ags10.jpg", "Volatile Organic Compound Sensor"],
   ["Air Quality Index", "/components/sensor/aqi/", "aqi.svg"],
   ["AirThings BLE", "/components/sensor/airthings_ble/", "airthings_logo.png", "Radon", "CO2", "Volatile organics"],
+  ["Aranet BLE", "/components/sensor/aranet4/", "bluetooth.svg", "CO2", "Radon", "Radiation", "dark-invert"],
   ["CCS811", "/components/sensor/ccs811/", "ccs811.jpg", "CO2 & Volatile organics"],
   ["CM1106", "/components/sensor/cm1106/", "cm1106.png", "CO2"],
   ["EE895", "/components/sensor/ee895/", "EE895.png", "CO2 & Temperature & Pressure"],
@@ -301,6 +302,7 @@ Sensors are organized into categories; if a given sensor fits into more than one
 <ImgTable items={[
   ["Alpha3", "/components/sensor/alpha3/", "alpha3.jpg"],
   ["AM43", "/components/sensor/am43/", "am43.jpg", "Lux & Battery level"],
+  ["Aranet BLE", "/components/sensor/aranet4/", "bluetooth.svg", "CO2 & Radon & Radiation", "dark-invert"],
   ["ATC MiThermometer", "/components/sensor/atc_mithermometer/", "bluetooth.svg", "dark-invert"],
   ["BLE Client Sensor", "/components/sensor/ble_client/", "bluetooth.svg", "dark-invert"],
   ["BLE RSSI", "/components/sensor/ble_rssi/", "bluetooth.svg", "dark-invert"],

--- a/src/content/docs/components/sensor/aranet.mdx
+++ b/src/content/docs/components/sensor/aranet.mdx
@@ -3,7 +3,7 @@ title: "Aranet BLE Sensors"
 description: "Instructions for reading Aranet air-quality and radiation monitors over Bluetooth Low Energy."
 ---
 
-The `aranet4` sensor platform reads advertisements from Aranet Bluetooth Low Energy devices. It supports Aranet4,
+The `aranet` sensor platform reads advertisements from Aranet Bluetooth Low Energy devices. It supports Aranet4,
 Aranet2, Aranet Radiation, Aranet Radon Plus, and Aranet Radon One devices. The platform listens passively and does not
 connect to the device.
 
@@ -19,7 +19,7 @@ The sensors available depend on the Aranet device model. This minimal example co
 
 ```yaml
 sensor:
-  - platform: aranet4
+  - platform: aranet
     mac_address: XX:XX:XX:XX:XX:XX
     co2:
       name: "Aranet4 Carbon Dioxide"
@@ -56,7 +56,7 @@ All sensor options support the settings described in the [Sensor component](/com
 
 ```yaml
 sensor:
-  - platform: aranet4
+  - platform: aranet
     mac_address: XX:XX:XX:XX:XX:XX
     temperature:
       name: "Aranet2 Temperature"
@@ -68,7 +68,7 @@ sensor:
 
 ```yaml
 sensor:
-  - platform: aranet4
+  - platform: aranet
     mac_address: XX:XX:XX:XX:XX:XX
     radiation_rate:
       name: "Aranet Radiation Dose Rate"
@@ -82,7 +82,7 @@ sensor:
 
 ```yaml
 sensor:
-  - platform: aranet4
+  - platform: aranet
     mac_address: XX:XX:XX:XX:XX:XX
     radon:
       name: "Aranet Radon Concentration"

--- a/src/content/docs/components/sensor/aranet4.mdx
+++ b/src/content/docs/components/sensor/aranet4.mdx
@@ -1,0 +1,103 @@
+---
+title: "Aranet BLE Sensors"
+description: "Instructions for reading Aranet air-quality and radiation monitors over Bluetooth Low Energy."
+---
+
+The `aranet4` sensor platform reads advertisements from Aranet Bluetooth Low Energy devices. It supports Aranet4,
+Aranet2, Aranet Radiation, Aranet Radon Plus, and Aranet Radon One devices. The platform listens passively and does not
+connect to the device.
+
+This platform requires the [ESP32 Bluetooth Low Energy Tracker](/components/esp32_ble_tracker/).
+
+> [!IMPORTANT]
+> Enable Smart Home integrations for the device in the Aranet Home app. The device does not include measurements in
+> its advertisements when this setting is disabled.
+
+## Configuration
+
+The sensors available depend on the Aranet device model. This minimal example configures an Aranet4:
+
+```yaml
+sensor:
+  - platform: aranet4
+    mac_address: XX:XX:XX:XX:XX:XX
+    co2:
+      name: "Aranet4 Carbon Dioxide"
+```
+
+## Configuration Variables
+
+- **mac_address** (**Required**, MAC Address): The MAC address of the Aranet device.
+- **co2** (*Optional*, [Sensor](/components/sensor/)): The carbon dioxide concentration reported by an Aranet4.
+- **temperature** (*Optional*, [Sensor](/components/sensor/)): The temperature reported by an Aranet4, Aranet2, or
+  Aranet Radon Plus.
+- **humidity** (*Optional*, [Sensor](/components/sensor/)): The relative humidity reported by an Aranet4, Aranet2, or
+  Aranet Radon Plus.
+- **pressure** (*Optional*, [Sensor](/components/sensor/)): The atmospheric pressure reported by an Aranet4, Aranet
+  Radon Plus, or Aranet Radon One.
+- **radon** (*Optional*, [Sensor](/components/sensor/)): The radon concentration reported by an Aranet Radon Plus or
+  Aranet Radon One.
+- **radiation_rate** (*Optional*, [Sensor](/components/sensor/)): The radiation dose rate reported by an Aranet
+  Radiation.
+- **radiation_total** (*Optional*, [Sensor](/components/sensor/)): The accumulated radiation dose reported by an
+  Aranet Radiation.
+- **radiation_duration** (*Optional*, [Sensor](/components/sensor/)): The duration over which the accumulated dose was
+  measured by an Aranet Radiation.
+- **battery_level** (*Optional*, [Sensor](/components/sensor/)): The device battery level.
+- **measurement_interval** (*Optional*, [Sensor](/components/sensor/)): The interval between device measurements.
+- **measurement_age** (*Optional*, [Sensor](/components/sensor/)): The age of the most recent measurement.
+- **signal_strength** (*Optional*, [Sensor](/components/sensor/)): The Bluetooth signal strength.
+
+All sensor options support the settings described in the [Sensor component](/components/sensor/).
+
+## Model Examples
+
+### Aranet2
+
+```yaml
+sensor:
+  - platform: aranet4
+    mac_address: XX:XX:XX:XX:XX:XX
+    temperature:
+      name: "Aranet2 Temperature"
+    humidity:
+      name: "Aranet2 Humidity"
+```
+
+### Aranet Radiation
+
+```yaml
+sensor:
+  - platform: aranet4
+    mac_address: XX:XX:XX:XX:XX:XX
+    radiation_rate:
+      name: "Aranet Radiation Dose Rate"
+    radiation_total:
+      name: "Aranet Radiation Total Dose"
+    radiation_duration:
+      name: "Aranet Radiation Dose Duration"
+```
+
+### Aranet Radon
+
+```yaml
+sensor:
+  - platform: aranet4
+    mac_address: XX:XX:XX:XX:XX:XX
+    radon:
+      name: "Aranet Radon Concentration"
+    temperature:
+      name: "Aranet Radon Temperature"
+    humidity:
+      name: "Aranet Radon Humidity"
+    pressure:
+      name: "Aranet Radon Pressure"
+```
+
+Aranet Radon One devices do not report temperature or humidity.
+
+## See Also
+
+- [ESP32 Bluetooth Low Energy Tracker](/components/esp32_ble_tracker/)
+- [Aranet Home](https://aranet.com/en/home/aranet-home-app)
+- [Aranet4-Python](https://github.com/Anrijs/Aranet4-Python)


### PR DESCRIPTION
## Description

Documents the Aranet BLE sensor platform and its support for Aranet4, Aranet2, Aranet Radiation, Aranet Radon Plus, and Aranet Radon One devices.

**Pull request in esphome with YAML changes:**

- esphome/esphome#18263

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull request in esphome as linked above.
- [x] Link added in `/src/content/docs/components/index.mdx` for the new component document.