### PR TITLE
[external_components] Document doc_url

### DIFF
--- a/src/content/docs/components/external_components.mdx
+++ b/src/content/docs/components/external_components.mdx
@@ -62,7 +62,7 @@ external_components:
   By default, all available components are used.
 
 - **refresh** (*Optional*, [Time](/guides/configuration-types#time)): The interval the source will be checked. Has no
-  effect on `local`. See [Refresh](#refresh). for more info. Defaults to `1day`.
+  effect on `local`. See [Refresh](#refresh) for more info. Defaults to `1day`.
 
 - **doc_url** (*Optional*, url): The base URL of this source's own documentation. When set, ESPHome will link to it
   wherever it mentions a component from this source (for example, in configuration error messages). See

--- a/src/content/docs/components/external_components.mdx
+++ b/src/content/docs/components/external_components.mdx
@@ -64,6 +64,10 @@ external_components:
 - **refresh** (*Optional*, [Time](/guides/configuration-types#time)): The interval the source will be checked. Has no
   effect on `local`. See [Refresh](#refresh). for more info. Defaults to `1day`.
 
+- **doc_url** (*Optional*, url): The base URL of this source's own documentation. When set, ESPHome will link to it
+  wherever it mentions a component from this source (for example, in configuration error messages). See
+  [Documentation links](#documentation-links) for more info.
+
 ## Local
 
 You can specify a local path containing external components. This is most useful when developing a
@@ -205,3 +209,24 @@ excessive repository checks.
 
 Likewise, you can set this setting to `never` and ESPHome will never
 **update** the repository, useful e.g. when `ref` points to a **tag**.
+
+## Documentation links
+
+Components loaded through `external_components:` aren't on esphome.io, so ESPHome has no way to link to their
+documentation unless you tell it where to look. Setting `doc_url` on a source fixes this: ESPHome combines it with
+each component's name, following the same layout esphome.io itself uses, to build a link shown in configuration
+error messages (in the ESPHome CLI, the VS Code extension, and the device builder).
+
+```yaml
+external_components:
+  - source: github://my-org/my-esphome-components
+    components: [my_component]
+    doc_url: https://my-org.github.io/my-esphome-components
+```
+
+Given the example above, a validation error in `my_component` would link to
+`https://my-org.github.io/my-esphome-components/components/my_component/`.
+
+`doc_url` applies to every component pulled in from that source. If you maintain the components yourself and want
+a specific one to link somewhere else, see [`DOC_URL`](https://developers.esphome.io/architecture/components/#further-information)
+in the developer documentation.


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#18390

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
