### PR TITLE
Bump shared lock workflow pin to 2026.8.1

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -13,4 +13,4 @@ jobs:
     permissions:
       issues: write         # issues.lock on closed issues
       pull-requests: write  # issues.lock on closed pull requests
-    uses: esphome/workflows/.github/workflows/lock.yml@9f6577fd37b5cf773ab1b9be929714a0dcd15661  # 2026.7.0
+    uses: esphome/workflows/.github/workflows/lock.yml@0fdd5e311b7e744069166696072a1a9cbc5fbeb6  # 2026.8.1


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Bumps the `esphome/workflows/.github/workflows/lock.yml` pin from `9f6577fd` (2026.7.0) to `0fdd5e31` (2026.8.1), the newest tag on esphome/workflows.

The reusable workflow file is byte-identical between the two refs, so there is no interface change: the same five optional `workflow_call` inputs (all with defaults), no required secrets, and the same `issues: write` / `pull-requests: write` permissions the caller already grants. Only the SHA and its trailing tag comment change.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.