### PR TITLE
[esp32][mipi_spi][touchscreen] Add Freenove FNK0104N display and touchscreen docs

### DIFF
--- a/src/content/docs/components/display/mipi_spi.mdx
+++ b/src/content/docs/components/display/mipi_spi.mdx
@@ -76,6 +76,7 @@ the pins used to interface to the display to be specified.
 | ESP32-2432S028-7789                  | Sunton       | Dual-USB version with ST7789V.                                                                                                     |
 | ESP32-2432S028-9342                  | Sunton       | Dual-USB version with ILI9342.                                                                                                     |
 | ESP-VOCAT                            | Espressif    | 1.43" 360×360 round QSPI display with ST77916 controller. [https://github.com/espressif/esp-vocat](https://github.com/espressif/esp-vocat) |
+| FNK0104N                             | Freenove     | [ESP32-S3 3.5-inch display](https://github.com/Freenove/Freenove_ESP32_S3_Display) with ST77922 controller.                       |
 | GEEKMAGIC-SMALLTV                    | GeekMagic    | [https://geekmagic.com/products/geekmagic-ultra-4](https://geekmagic.com/products/geekmagic-ultra-4)                               |
 | GEEKMAGIC-SMALLTV-PRO                | GeekMagic    | [https://geekmagic.com/products/geekmagic-ultra](https://geekmagic.com/products/geekmagic-ultra)                                   |
 | JC3248W535                           | Guition      | [https://www.aliexpress.com/item/1005007566332450.html](https://www.aliexpress.com/item/1005007566332450.html)                     |

--- a/src/content/docs/components/index.mdx
+++ b/src/content/docs/components/index.mdx
@@ -1125,6 +1125,7 @@ Used for creating infrared (IR) remote control transmitters and/or receivers.
   ["GT911", "/components/touchscreen/gt911/", "esp32_s3_box_3.png"],
   ["Lilygo T5 4.7", "/components/touchscreen/lilygo_t5_47/", "lilygo_t5_47_touch.jpg"],
   ["ST7123", "/components/touchscreen/st7123/", "touch.svg", "dark-invert"],
+  ["ST77922", "/components/touchscreen/st77922/", "touch.svg", "dark-invert"],
   ["TT21100", "/components/touchscreen/tt21100/", "esp32-s3-korvo-2-lcd.png"],
   ["XPT2046", "/components/touchscreen/xpt2046/", "xpt2046.jpg"],
 ]} />

--- a/src/content/docs/components/touchscreen/st77922.mdx
+++ b/src/content/docs/components/touchscreen/st77922.mdx
@@ -1,0 +1,77 @@
+---
+description: "Configure the ST77922 touchscreen controller used by the Freenove FNK0104N display."
+title: "ST77922 Touchscreen Controller"
+---
+
+import APIRef from '@components/APIRef.astro';
+
+The `st77922_touch` touchscreen platform supports the touchscreen controller used by the Freenove FNK0104N
+ESP32-S3 display. The [I²C](/components/i2c/) component is required.
+
+## Base Touchscreen Configuration
+
+```yaml
+touchscreen:
+  - platform: st77922_touch
+    display: fnk0104n_display
+    interrupt_pin: GPIO47
+    reset_pin: GPIO48
+```
+
+The controller uses I²C address `0x55`. The FNK0104N wiring is:
+
+| Signal | GPIO |
+| ------ | ---- |
+| SDA | GPIO38 |
+| SCL | GPIO39 |
+| Interrupt | GPIO47 |
+| Reset | GPIO48 |
+
+### Configuration variables
+
+- **display** (**Required**, [ID](/guides/configuration-types#id)): The display associated with the touchscreen.
+- **i2c_id** (*Optional*, [ID](/guides/configuration-types#id)): The I²C bus to use. Defaults to the automatically selected I²C bus.
+- **interrupt_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The touch detection pin.
+- **reset_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): The touchscreen reset pin.
+
+All other options are inherited from the [Touchscreen](/components/touchscreen/) component.
+
+## Freenove FNK0104N Example
+
+The display and touchscreen are configured separately. The display uses quad SPI and the touchscreen uses I²C.
+
+```yaml
+esp32:
+  board: freenove-esp32-s3-fnk0104n
+  framework:
+    type: esp-idf
+
+psram:
+  mode: octal
+  speed: 80MHz
+
+spi:
+  type: quad
+  clk_pin: GPIO12
+  data_pins: [GPIO11, GPIO13, GPIO14, GPIO9]
+
+display:
+  - platform: mipi_spi
+    id: fnk0104n_display
+    model: FNK0104N
+
+i2c:
+  sda: GPIO38
+  scl: GPIO39
+
+touchscreen:
+  - platform: st77922_touch
+    id: fnk0104n_touchscreen
+    display: fnk0104n_display
+    interrupt_pin: GPIO47
+    reset_pin: GPIO48
+```
+
+## See Also
+
+- [MIPI SPI Display Driver](/components/display/mipi_spi/)


### PR DESCRIPTION
## Description

Adds documentation for the Freenove FNK0104N board support and the ST77922 touchscreen used by that display.

This includes:
- the MIPI SPI display model entry in [esphome.io/src/content/docs/components/display/mipi_spi.mdx](esphome.io/src/content/docs/components/display/mipi_spi.mdx)
- a dedicated touchscreen page at [esphome.io/src/content/docs/components/touchscreen/st77922.mdx](esphome.io/src/content/docs/components/touchscreen/st77922.mdx)
- the sidebar index update in [esphome.io/src/content/docs/components/index.mdx](esphome.io/src/content/docs/components/index.mdx)

**Related issue (if applicable):** fixes N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#18411

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [x] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.