### PR TITLE
[bmi270] Document optional BMM150 magnetometer support

### DIFF
--- a/src/content/docs/components/motion/bmi270.mdx
+++ b/src/content/docs/components/motion/bmi270.mdx
@@ -15,6 +15,13 @@ a 16-bit 3-axis accelerometer and a 16-bit 3-axis gyroscope, plus an on-chip tem
 sensor. It requires an internal configuration blob to be uploaded at each power-on
 (handled automatically by this component).
 
+The BMI270 also exposes an auxiliary (secondary I²C master) interface that can optionally drive a
+[Bosch BMM150](https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-bmm150-ds001.pdf)
+magnetometer wired to its AUX pins rather than the main I²C bus, since the BMM150 has no address of its own on
+that bus. Set `aux_device` to `BMM150` to enable it, then read the magnetic field via the
+[BMI270 Sensor](/components/sensor/bmi270/) platform's `magnetic_field_x`/`magnetic_field_y`/`magnetic_field_z`
+types.
+
 ```yaml
 # Example configuration entry
 motion:
@@ -46,10 +53,14 @@ sensor:
   `125DPS`, `250DPS`, `500DPS`, `1000DPS`, `2000DPS`. Defaults to `2000DPS`.
 - **gyroscope_odr** (*Optional*, string): The output data rate of the gyroscope. One of
   `25HZ`, `50HZ`, `100HZ`, `200HZ`, `400HZ`, `800HZ`, `1600HZ`, `3200HZ`. Defaults to `200HZ`.
+- **aux_device** (*Optional*, string): What, if anything, is wired to the BMI270's auxiliary interface.
+  One of `NONE`, `BMM150`. Defaults to `NONE`.
+- **aux_address** (*Optional*, int): The I²C address of the device on the auxiliary interface. Only relevant
+  when `aux_device` is not `NONE`. Defaults to `0x10`, the BMM150's fixed address.
 
 - All other options from [Motion](/components/motion).
 
 ## See Also
 
-- [BMI270 Temperature Sensor](/components/sensor/bmi270/)
+- [BMI270 Temperature and Magnetic Field Sensor](/components/sensor/bmi270/)
 - <APIRef text="bmi270.h" path="bmi270/bmi270.h" />

--- a/src/content/docs/components/sensor/bmi270.mdx
+++ b/src/content/docs/components/sensor/bmi270.mdx
@@ -1,10 +1,13 @@
 ---
-description: "Instructions for setting up BMI270 temperature sensor."
-title: "BMI270 Temperature Sensor"
+description: "Instructions for setting up BMI270 temperature and BMM150 magnetic field sensors."
+title: "BMI270 Temperature and Magnetic Field Sensor"
 ---
 
-The `bmi270` sensor platform provides access to the temperature sensor in a BMI270 Accelerometer/Gyroscope
-([datasheet](https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-bmi270-ds000.pdf)) with ESPHome.
+The `bmi270` sensor platform provides access to the on-chip temperature sensor in a BMI270 Accelerometer/Gyroscope
+([datasheet](https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-bmi270-ds000.pdf)), and,
+when a
+[Bosch BMM150](https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-bmm150-ds001.pdf)
+magnetometer is wired to the BMI270's auxiliary interface, its magnetic field readings as well, with ESPHome.
 It requires a [`motion`](/components/motion) component to be configured with the `bmi270` platform,
 which handles the accelerometer and gyroscope data processing and configures the device. See that component for more information.
 
@@ -15,13 +18,36 @@ motion:
 
 sensor:
   - platform: bmi270
-    type: temperature # Optional, temperature is the only supported type for this platform
+    type: temperature # Optional, temperature is the default type for this platform
     name: "BMI270 Temperature"
+```
+
+To read the magnetic field, first set `aux_device: BMM150` on the parent [`motion`](/components/motion/bmi270/)
+platform, then add one entry per axis:
+
+```yaml
+# Example configuration entry
+motion:
+  - platform: bmi270
+    aux_device: BMM150
+
+sensor:
+  - platform: bmi270
+    type: magnetic_field_x
+    name: "BMM150 Magnetic Field X"
+  - platform: bmi270
+    type: magnetic_field_y
+    name: "BMM150 Magnetic Field Y"
+  - platform: bmi270
+    type: magnetic_field_z
+    name: "BMM150 Magnetic Field Z"
 ```
 
 ## Configuration variables
 
-- **type** (*Optional*, string): Must be set to `temperature`, or simply omitted.
+- **type** (*Optional*, string): One of `temperature`, `magnetic_field_x`, `magnetic_field_y`, `magnetic_field_z`.
+  Defaults to `temperature`. The `magnetic_field_*` types report the field strength in microtesla (µT) and
+  require the parent `bmi270` platform's `aux_device` to be set to `BMM150`.
 - All other options from [Sensor](/components/sensor).
 
 ## See Also


### PR DESCRIPTION
## Description

Documents the `aux_device`/`aux_address` options on the `bmi270` motion platform, and the new
`magnetic_field_x`/`magnetic_field_y`/`magnetic_field_z` sensor types, for a BMM150 magnetometer wired to the
BMI270's auxiliary (secondary I2C master) interface.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#18436

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook. (Not applicable — BMM150 is not a standalone component/platform, it's an optional sub-feature of the existing `bmi270` entry.)