### PR TITLE
[light] Replace rgb_order/is_rgbw/is_wrgb with channel_colors

### DIFF
--- a/src/content/docs/components/light/beken_spi_led_strip.mdx
+++ b/src/content/docs/components/light/beken_spi_led_strip.mdx
@@ -13,7 +13,7 @@ This is a component using the Beken SPI DMA interface to drive addressable LED s
 ```yaml
 light:
   - platform: beken_spi_led_strip
-    rgb_order: GRB
+    channel_colors: GRB
     pin: P16
     num_leds: 30
     chipset: ws2812
@@ -23,23 +23,19 @@ light:
 ## Configuration variables
 
 - **pin** (**Required**, [Pin](/guides/configuration-types#pin)): The pin for the data line of the light.
-- **num_leds** (**Required**, int): The number of LEDs in the strip.
+- **num_leds** (**Required**, int): The number of LEDs in the strip. The DMA buffer limits this to 165 LEDs, or 123
+  LEDs when `channel_colors` contains a `W`.
+
 - **chipset** (**Required**, enum): The chipset to apply known timings from.
   - `WS2812`
   - `SK6812`
   - `APA106`
   - `SM16703`
 
-- **rgb_order** (**Required**, string): The RGB order of the strip.
-  - `RGB`
-  - `RBG`
-  - `GRB`
-  - `GBR`
-  - `BGR`
-  - `BRG`
+- **channel_colors** (**Required**, string): The order in which the strip expects its color channels. List each of
+  `R`, `G` and `B` exactly once, optionally with a single `W` in any position; for example `GRB`, `BGR`, `GRBW`,
+  `WRGB` or `RWGB`. The value is case-insensitive. Including a `W` makes this a four channel RGBW strip.
 
-- **is_rgbw** (*Optional*, boolean): Set to `true` if the strip is RGBW. Defaults to `false`.
-- **is_wrgb** (*Optional*, boolean): Set to `true` if the strip is WRGB. Defaults to `false`.
 - **max_refresh_rate** (*Optional*, [Time](/guides/configuration-types#time)):
   A time interval used to limit the number of commands a light can handle per second. For example
   16ms will limit the light to a refresh rate of about 60Hz. Defaults to sending commands as quickly as

--- a/src/content/docs/components/light/esp32_rmt_led_strip.mdx
+++ b/src/content/docs/components/light/esp32_rmt_led_strip.mdx
@@ -13,7 +13,7 @@ This is a component using the ESP32 RMT peripheral to drive most addressable LED
 ```yaml
 light:
   - platform: esp32_rmt_led_strip
-    rgb_order: GRB
+    channel_colors: GRB
     pin: GPIOXX
     num_leds: 30
     chipset: ws2812
@@ -33,18 +33,10 @@ light:
   - `APA106`
   - `SM16703`
 
-- **rgb_order** (**Optional**, string): The RGB order of the strip.
+- **channel_colors** (**Required**, string): The order in which the strip expects its color channels. List each of
+  `R`, `G` and `B` exactly once, optionally with a single `W` in any position; for example `GRB`, `BGR`, `GRBW`,
+  `WRGB` or `RWGB`. The value is case-insensitive. Including a `W` makes this a four channel RGBW strip.
 
-  - `RGB`
-  - `RBG`
-  - `GRB`
-  - `GBR`
-  - `BGR`
-  - `BRG`
-
-- **is_rgbw** (*Optional*, boolean): Set to `true` if the strip is RGBW. Defaults to `false`.
-- **is_wrgb** (*Optional*, boolean): Set to `true` if the strip is WRGB. Defaults to `false`.
-- **rgbw_order** (**Optional**, string): The RGBW order of the strip. Options are the same as `rgb_order` but with the `W` channel placed at an arbitrary location in the order. Note that this is mutually exclusive with `rgb_order`, `is_rgbw`, and `is_wrgb`.
 - **max_refresh_rate** (*Optional*, [Time](/guides/configuration-types#time)): A time interval used to limit the number of commands a light
   can handle per second. For example, `16ms` will limit the light to a refresh rate of about 60Hz. Defaults to
   sending commands as quickly as changes are made to the lights.

--- a/src/content/docs/components/light/rp2040_pio_led_strip.mdx
+++ b/src/content/docs/components/light/rp2040_pio_led_strip.mdx
@@ -13,7 +13,7 @@ light:
     pin: GPIOXX
     num_leds: 10
     pio: 0
-    rgb_order: GRB
+    channel_colors: GRB
     chipset: WS2812B
 ```
 
@@ -29,15 +29,9 @@ light:
   - `SK6812`
   - `SM16703`
 
-- **rgb_order** (**Required**, string): The RGB order of the strip.
-  - `RGB`
-  - `RBG`
-  - `GRB`
-  - `GBR`
-  - `BGR`
-  - `BRG`
-
-- **is_rgbw** (*Optional*, boolean): Set to `true` if the strip is RGBW. Defaults to `false`.
+- **channel_colors** (**Required**, string): The order in which the strip expects its color channels. List each of
+  `R`, `G` and `B` exactly once, optionally with a single `W` in any position; for example `GRB`, `BGR`, `GRBW`,
+  `WRGB` or `RWGB`. The value is case-insensitive. Including a `W` makes this a four channel RGBW strip.
 
 - All other options from [Light](/components/light#config-light).
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Documents the new `channel_colors` option on [esp32_rmt_led_strip](https://esphome.io/components/light/esp32_rmt_led_strip/), [beken_spi_led_strip](https://esphome.io/components/light/beken_spi_led_strip/) and [rp2040_pio_led_strip](https://esphome.io/components/light/rp2040_pio_led_strip/), which replaces `rgb_order`, `is_rgbw` and `is_wrgb`. Those three keys still work with a deprecation warning until 2027.3.0, but per convention the deprecated options are removed from the pages rather than documented.

Also removes `rgbw_order` from the esp32_rmt_led_strip page. It only ever existed in the 2026.8.0 beta (added by [esphome/esphome#18028](https://github.com/esphome/esphome/pull/18028)) and is dropped with no shim.

Two other notes: `rp2040_pio_led_strip` previously only supported `is_rgbw`, so its docs no longer imply the white channel must come last; and the `beken_spi_led_strip` LED-count limit (165, or 123 with a white channel) is now documented on `num_leds`.

The FastLED pages keep their own `rgb_order`, which is an unrelated FastLED `EOrder` template parameter.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- [esphome/esphome#18474](https://github.com/esphome/esphome/pull/18474)

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.