### PR TITLE
2026.8.0b5

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -13,4 +13,4 @@ jobs:
     permissions:
       issues: write         # issues.lock on closed issues
       pull-requests: write  # issues.lock on closed pull requests
-    uses: esphome/workflows/.github/workflows/lock.yml@9f6577fd37b5cf773ab1b9be929714a0dcd15661  # 2026.7.0
+    uses: esphome/workflows/.github/workflows/lock.yml@0fdd5e311b7e744069166696072a1a9cbc5fbeb6  # 2026.8.1

--- a/data/version.yaml
+++ b/data/version.yaml
@@ -1,2 +1,2 @@
-release: 2026.8.0b4
+release: 2026.8.0b5
 version: '2026.8'

--- a/src/content/docs/changelog/2026.8.0.mdx
+++ b/src/content/docs/changelog/2026.8.0.mdx
@@ -804,6 +804,16 @@ For detailed migration guides and API documentation, see the
 - [bk72xx_ble] Fail early with a clear error on non BLE 5.x SoCs [esphome#18406](https://github.com/esphome/esphome/pull/18406) by [@bdraco](https://github.com/bdraco)
 - [core] Skip redundant ESP8266 main loop wake posts from ISR context [esphome#18416](https://github.com/esphome/esphome/pull/18416) by [@bdraco](https://github.com/bdraco)
 - [esp32] Split crash handler addr2line hint per core [esphome#18418](https://github.com/esphome/esphome/pull/18418) by [@bdraco](https://github.com/bdraco)
+- Bump aioesphomeapi from 45.10.1 to 45.10.2 [esphome#18357](https://github.com/esphome/esphome/pull/18357) by [@esphome[bot]](https://github.com/apps/esphome)
+- [ld2420] Drop the setup priority override so setup runs after the UART bus [esphome#18428](https://github.com/esphome/esphome/pull/18428) by [@bdraco](https://github.com/bdraco)
+- Bump aioesphomeapi from 45.10.2 to 45.10.3 [esphome#18433](https://github.com/esphome/esphome/pull/18433) by [@esphome[bot]](https://github.com/apps/esphome)
+- [api] Bump noise-c to 0.1.18 [esphome#18451](https://github.com/esphome/esphome/pull/18451) by [@bdraco](https://github.com/bdraco)
+- Bump bundled esphome-device-builder to 1.11.1 [esphome#18475](https://github.com/esphome/esphome/pull/18475) by [@esphome[bot]](https://github.com/apps/esphome)
+- [api] Bump noise-c to 0.1.19 [esphome#18473](https://github.com/esphome/esphome/pull/18473) by [@bdraco](https://github.com/bdraco)
+- Bump bundled esphome-device-builder to 1.11.2 [esphome#18477](https://github.com/esphome/esphome/pull/18477) by [@esphome[bot]](https://github.com/apps/esphome)
+- [socket] Fix multi-second TCP stalls on ESP8266 by yielding to the SYS context [esphome#18455](https://github.com/esphome/esphome/pull/18455) by [@bdraco](https://github.com/bdraco)
+- [light] Replace rgb_order/is_rgbw/is_wrgb with channel_colors [esphome#18474](https://github.com/esphome/esphome/pull/18474) by [@jesserockz](https://github.com/jesserockz) (new-feature)
+- [gpio_expander][pcf8574][pca9554][tca9555][pca6416a][pi4ioe5v6408][mcp23016][mcp23xxx_base] Reject unsupported interrupt_pin options (inverted, allow_other_uses) [esphome#18472](https://github.com/esphome/esphome/pull/18472) by [@bdraco](https://github.com/bdraco)
 {/* BETA_CHANGES_END */}
 
 ### All changes
@@ -1182,6 +1192,16 @@ For detailed migration guides and API documentation, see the
 - [bk72xx_ble] Fail early with a clear error on non BLE 5.x SoCs [esphome#18406](https://github.com/esphome/esphome/pull/18406) by [@bdraco](https://github.com/bdraco)
 - [core] Skip redundant ESP8266 main loop wake posts from ISR context [esphome#18416](https://github.com/esphome/esphome/pull/18416) by [@bdraco](https://github.com/bdraco)
 - [esp32] Split crash handler addr2line hint per core [esphome#18418](https://github.com/esphome/esphome/pull/18418) by [@bdraco](https://github.com/bdraco)
+- Bump aioesphomeapi from 45.10.1 to 45.10.2 [esphome#18357](https://github.com/esphome/esphome/pull/18357) by [@esphome[bot]](https://github.com/apps/esphome)
+- [ld2420] Drop the setup priority override so setup runs after the UART bus [esphome#18428](https://github.com/esphome/esphome/pull/18428) by [@bdraco](https://github.com/bdraco)
+- Bump aioesphomeapi from 45.10.2 to 45.10.3 [esphome#18433](https://github.com/esphome/esphome/pull/18433) by [@esphome[bot]](https://github.com/apps/esphome)
+- [api] Bump noise-c to 0.1.18 [esphome#18451](https://github.com/esphome/esphome/pull/18451) by [@bdraco](https://github.com/bdraco)
+- Bump bundled esphome-device-builder to 1.11.1 [esphome#18475](https://github.com/esphome/esphome/pull/18475) by [@esphome[bot]](https://github.com/apps/esphome)
+- [api] Bump noise-c to 0.1.19 [esphome#18473](https://github.com/esphome/esphome/pull/18473) by [@bdraco](https://github.com/bdraco)
+- Bump bundled esphome-device-builder to 1.11.2 [esphome#18477](https://github.com/esphome/esphome/pull/18477) by [@esphome[bot]](https://github.com/apps/esphome)
+- [socket] Fix multi-second TCP stalls on ESP8266 by yielding to the SYS context [esphome#18455](https://github.com/esphome/esphome/pull/18455) by [@bdraco](https://github.com/bdraco)
+- [light] Replace rgb_order/is_rgbw/is_wrgb with channel_colors [esphome#18474](https://github.com/esphome/esphome/pull/18474) by [@jesserockz](https://github.com/jesserockz) (new-feature)
+- [gpio_expander][pcf8574][pca9554][tca9555][pca6416a][pi4ioe5v6408][mcp23016][mcp23xxx_base] Reject unsupported interrupt_pin options (inverted, allow_other_uses) [esphome#18472](https://github.com/esphome/esphome/pull/18472) by [@bdraco](https://github.com/bdraco)
 {/* ALL_CHANGES_END */}
 
 </details>

--- a/src/content/docs/components/light/beken_spi_led_strip.mdx
+++ b/src/content/docs/components/light/beken_spi_led_strip.mdx
@@ -13,7 +13,7 @@ This is a component using the Beken SPI DMA interface to drive addressable LED s
 ```yaml
 light:
   - platform: beken_spi_led_strip
-    rgb_order: GRB
+    channel_colors: GRB
     pin: P16
     num_leds: 30
     chipset: ws2812
@@ -23,23 +23,19 @@ light:
 ## Configuration variables
 
 - **pin** (**Required**, [Pin](/guides/configuration-types#pin)): The pin for the data line of the light.
-- **num_leds** (**Required**, int): The number of LEDs in the strip.
+- **num_leds** (**Required**, int): The number of LEDs in the strip. The DMA buffer limits this to 165 LEDs, or 123
+  LEDs when `channel_colors` contains a `W`.
+
 - **chipset** (**Required**, enum): The chipset to apply known timings from.
   - `WS2812`
   - `SK6812`
   - `APA106`
   - `SM16703`
 
-- **rgb_order** (**Required**, string): The RGB order of the strip.
-  - `RGB`
-  - `RBG`
-  - `GRB`
-  - `GBR`
-  - `BGR`
-  - `BRG`
+- **channel_colors** (**Required**, string): The order in which the strip expects its color channels. List each of
+  `R`, `G` and `B` exactly once, optionally with a single `W` in any position; for example `GRB`, `BGR`, `GRBW`,
+  `WRGB` or `RWGB`. The value is case-insensitive. Including a `W` makes this a four channel RGBW strip.
 
-- **is_rgbw** (*Optional*, boolean): Set to `true` if the strip is RGBW. Defaults to `false`.
-- **is_wrgb** (*Optional*, boolean): Set to `true` if the strip is WRGB. Defaults to `false`.
 - **max_refresh_rate** (*Optional*, [Time](/guides/configuration-types#time)):
   A time interval used to limit the number of commands a light can handle per second. For example
   16ms will limit the light to a refresh rate of about 60Hz. Defaults to sending commands as quickly as

--- a/src/content/docs/components/light/esp32_rmt_led_strip.mdx
+++ b/src/content/docs/components/light/esp32_rmt_led_strip.mdx
@@ -13,7 +13,7 @@ This is a component using the ESP32 RMT peripheral to drive most addressable LED
 ```yaml
 light:
   - platform: esp32_rmt_led_strip
-    rgb_order: GRB
+    channel_colors: GRB
     pin: GPIOXX
     num_leds: 30
     chipset: ws2812
@@ -33,18 +33,10 @@ light:
   - `APA106`
   - `SM16703`
 
-- **rgb_order** (**Optional**, string): The RGB order of the strip.
+- **channel_colors** (**Required**, string): The order in which the strip expects its color channels. List each of
+  `R`, `G` and `B` exactly once, optionally with a single `W` in any position; for example `GRB`, `BGR`, `GRBW`,
+  `WRGB` or `RWGB`. The value is case-insensitive. Including a `W` makes this a four channel RGBW strip.
 
-  - `RGB`
-  - `RBG`
-  - `GRB`
-  - `GBR`
-  - `BGR`
-  - `BRG`
-
-- **is_rgbw** (*Optional*, boolean): Set to `true` if the strip is RGBW. Defaults to `false`.
-- **is_wrgb** (*Optional*, boolean): Set to `true` if the strip is WRGB. Defaults to `false`.
-- **rgbw_order** (**Optional**, string): The RGBW order of the strip. Options are the same as `rgb_order` but with the `W` channel placed at an arbitrary location in the order. Note that this is mutually exclusive with `rgb_order`, `is_rgbw`, and `is_wrgb`.
 - **max_refresh_rate** (*Optional*, [Time](/guides/configuration-types#time)): A time interval used to limit the number of commands a light
   can handle per second. For example, `16ms` will limit the light to a refresh rate of about 60Hz. Defaults to
   sending commands as quickly as changes are made to the lights.

--- a/src/content/docs/components/light/rp2040_pio_led_strip.mdx
+++ b/src/content/docs/components/light/rp2040_pio_led_strip.mdx
@@ -13,7 +13,7 @@ light:
     pin: GPIOXX
     num_leds: 10
     pio: 0
-    rgb_order: GRB
+    channel_colors: GRB
     chipset: WS2812B
 ```
 
@@ -29,15 +29,9 @@ light:
   - `SK6812`
   - `SM16703`
 
-- **rgb_order** (**Required**, string): The RGB order of the strip.
-  - `RGB`
-  - `RBG`
-  - `GRB`
-  - `GBR`
-  - `BGR`
-  - `BRG`
-
-- **is_rgbw** (*Optional*, boolean): Set to `true` if the strip is RGBW. Defaults to `false`.
+- **channel_colors** (**Required**, string): The order in which the strip expects its color channels. List each of
+  `R`, `G` and `B` exactly once, optionally with a single `W` in any position; for example `GRB`, `BGR`, `GRBW`,
+  `WRGB` or `RWGB`. The value is case-insensitive. Including a `W` makes this a four channel RGBW strip.
 
 - All other options from [Light](/components/light#config-light).
 

--- a/src/content/docs/guides/supporters.mdx
+++ b/src/content/docs/guides/supporters.mdx
@@ -2386,4 +2386,4 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Josef Zweck (@zweckj)](https://github.com/zweckj)
 - [Zynth-dev (@Zynth-dev)](https://github.com/Zynth-dev)
 
-*This page was last updated August 17, 2026.*
+*This page was last updated August 18, 2026.*


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- Bump shared lock workflow pin to 2026.8.1 [docs#7194](https://github.com/esphome/esphome.io/pull/7194)
- [light] Replace rgb_order/is_rgbw/is_wrgb with channel_colors [docs#7213](https://github.com/esphome/esphome.io/pull/7213)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
