### PR TITLE
[web_server] Document access point mode

### DIFF
--- a/src/content/docs/components/captive_portal.mdx
+++ b/src/content/docs/components/captive_portal.mdx
@@ -36,9 +36,9 @@ captive_portal:
 
 > [!NOTE]
 > If the device only ever runs its own access point and you want the [web server](/components/web_server/)
-> interface instead of the WiFi setup page, leave `captive_portal:` out: with `wifi: ap:` and `web_server:`
-> alone (on the default port 80), the web server opens automatically on the access point. See
-> [Access point mode](/components/web_server/#access-point-mode).
+> interface instead of the WiFi setup page, leave `captive_portal:` out: with just an `ap:` block under
+> `wifi:` and `web_server:` on the default port 80, the web server opens automatically on the access
+> point. See [Access point mode](/components/web_server/#access-point-mode).
 
 ## Configuration variables
 

--- a/src/content/docs/components/captive_portal.mdx
+++ b/src/content/docs/components/captive_portal.mdx
@@ -37,7 +37,7 @@ captive_portal:
 > [!NOTE]
 > If the device only ever runs its own access point and you want the [web server](/components/web_server/)
 > interface instead of the WiFi setup page, leave `captive_portal:` out: with `wifi: ap:` and `web_server:`
-> alone, the web server opens automatically on the access point. See
+> alone (on the default port 80), the web server opens automatically on the access point. See
 > [Access point mode](/components/web_server/#access-point-mode).
 
 ## Configuration variables

--- a/src/content/docs/components/captive_portal.mdx
+++ b/src/content/docs/components/captive_portal.mdx
@@ -34,6 +34,12 @@ wifi:
 captive_portal:
 ```
 
+> [!NOTE]
+> If the device only ever runs its own access point and you want the [web server](/components/web_server/)
+> interface instead of the WiFi setup page, leave `captive_portal:` out: with `wifi: ap:` and `web_server:`
+> alone, the web server opens automatically on the access point. See
+> [Access point mode](/components/web_server/#access-point-mode).
+
 ## Configuration variables
 
 - **compression** (*Optional*, string): The compression algorithm used for the embedded web assets.

--- a/src/content/docs/components/web_server.mdx
+++ b/src/content/docs/components/web_server.mdx
@@ -270,8 +270,10 @@ web_server:
 
 In this mode:
 
-- The web interface is embedded in the firmware (`local` defaults to `true`), since a phone or laptop
-  connected to the access point usually has no internet to download it from.
+- The web interface is embedded in the firmware (`local` defaults to `true`). A phone or laptop
+  connected to the access point cannot load the hosted interface: the access point has no internet,
+  and a phone that still has mobile data does not route the page's downloads over both networks, so
+  the page just stalls.
 - While the access point is up, the web server acts as a captive portal: it answers every DNS name
   with the device's address and sends unknown URLs to its page, so the interface opens by itself
   when a device joins the network, the same way a hotel login page does. It is also reachable by

--- a/src/content/docs/components/web_server.mdx
+++ b/src/content/docs/components/web_server.mdx
@@ -274,14 +274,15 @@ In this mode:
 - The web interface is embedded in the firmware (`local` defaults to `true`, adding roughly 13 KB of
   flash on version 2 and 78 KB on version 3; set `local: false` to opt out). A phone or laptop
   connected to the access point cannot load the hosted interface: the access point has no internet,
-  and a phone that still has mobile data does not route the page's downloads over both networks, so
-  the page just stalls.
+  and even a phone that still has mobile data typically does not fetch the page's downloads over
+  the other network, so the page stays blank.
 - While the access point is up, the web server acts as a captive portal: it answers every DNS name
   with the device's address and sends unknown URLs to its page, so the interface opens by itself
-  when a device joins the network, the same way a hotel login page does. It is also reachable by
-  opening [http://192.168.4.1/](http://192.168.4.1/) manually. This needs the default `port: 80`,
-  since captive portal detection only works there; on another port, nothing opens automatically and
-  the interface must be opened manually at `http://192.168.4.1:<port>/`.
+  when a device joins the network, the same way a hotel login page does. This needs the default
+  `port: 80`, since captive portal detection only works there; on another port nothing opens
+  automatically. Either way the interface can also be opened manually at
+  [http://192.168.4.1/](http://192.168.4.1/) (or the AP's `manual_ip` address, if set), with
+  `:<port>` appended when a custom port is used.
 
 A configuration with both a network to join and an `ap:` fallback gets the same captive behavior
 when `local: true` is set. When [Captive Portal](/components/captive_portal/) is configured it stays

--- a/src/content/docs/components/web_server.mdx
+++ b/src/content/docs/components/web_server.mdx
@@ -109,7 +109,8 @@ web_server:
 
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID used for code generation.
 - **local** (*Optional*, boolean): Include supporting javascript locally allowing it to work without internet access.
-  Defaults to `false`.
+  Defaults to `false`, except when the [WiFi](/components/wifi/) configuration has only an access point
+  (`ap:` and no `ssid`/`networks`), where it defaults to `true`; see [Access point mode](#access-point-mode).
 
 - **compression** (*Optional*, string): The compression algorithm used for embedded web assets when `local` is enabled.
   Options are `gzip` or `br` (Brotli). Brotli provides smaller embedded web assets (~10% smaller than gzip), but some
@@ -250,6 +251,35 @@ web_server:
 # OTA will only be accessible when captive portal is active
 captive_portal:
 ```
+
+## Access point mode
+
+A device that never joins a WiFi network, such as one in a car, boat or camper, can still be
+used through its own access point without any internet connection. Configure an `ap:` in
+[WiFi](/components/wifi/) without any network to join, and the `web_server`:
+
+```yaml
+# Example configuration entry
+wifi:
+  ap:
+    ssid: "My Boat"
+    password: !secret wifi_ap_password
+
+web_server:
+```
+
+In this mode:
+
+- The web interface is embedded in the firmware (`local` defaults to `true`), since a phone or laptop
+  connected to the access point usually has no internet to download it from.
+- While the access point is up, the web server acts as a captive portal: it answers every DNS name
+  with the device's address and sends unknown URLs to its page, so the interface opens by itself
+  when a device joins the network, the same way a hotel login page does. It is also reachable by
+  opening [http://192.168.4.1/](http://192.168.4.1/) manually.
+
+A configuration with both a network to join and an `ap:` fallback gets the same captive behavior
+when `local: true` is set. When [Captive Portal](/components/captive_portal/) is configured it stays
+in charge of the access point and shows its own WiFi setup page instead.
 
 ## Advanced usage
 

--- a/src/content/docs/components/web_server.mdx
+++ b/src/content/docs/components/web_server.mdx
@@ -108,7 +108,8 @@ web_server:
   maintaining it for captive portal access. To enable OTA for web server, use the `web_server` OTA platform instead.
 
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID used for code generation.
-- **local** (*Optional*, boolean): Include supporting javascript locally allowing it to work without internet access.
+- **local** (*Optional*, boolean): Include the supporting JavaScript locally, allowing it to work without
+  internet access.
   Defaults to `false`, except when the [WiFi](/components/wifi/) configuration has only an access point
   (`ap:` and no `ssid`/`networks`), where it defaults to `true` on version 2 and 3 (version 1 has no
   local mode); see [Access point mode](#access-point-mode).

--- a/src/content/docs/components/web_server.mdx
+++ b/src/content/docs/components/web_server.mdx
@@ -110,7 +110,8 @@ web_server:
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID used for code generation.
 - **local** (*Optional*, boolean): Include supporting javascript locally allowing it to work without internet access.
   Defaults to `false`, except when the [WiFi](/components/wifi/) configuration has only an access point
-  (`ap:` and no `ssid`/`networks`), where it defaults to `true`; see [Access point mode](#access-point-mode).
+  (`ap:` and no `ssid`/`networks`), where it defaults to `true` on version 2 and 3 (version 1 has no
+  local mode); see [Access point mode](#access-point-mode).
 
 - **compression** (*Optional*, string): The compression algorithm used for embedded web assets when `local` is enabled.
   Options are `gzip` or `br` (Brotli). Brotli provides smaller embedded web assets (~10% smaller than gzip), but some
@@ -270,14 +271,17 @@ web_server:
 
 In this mode:
 
-- The web interface is embedded in the firmware (`local` defaults to `true`). A phone or laptop
+- The web interface is embedded in the firmware (`local` defaults to `true`, adding roughly 13 KB of
+  flash on version 2 and 78 KB on version 3; set `local: false` to opt out). A phone or laptop
   connected to the access point cannot load the hosted interface: the access point has no internet,
   and a phone that still has mobile data does not route the page's downloads over both networks, so
   the page just stalls.
 - While the access point is up, the web server acts as a captive portal: it answers every DNS name
   with the device's address and sends unknown URLs to its page, so the interface opens by itself
   when a device joins the network, the same way a hotel login page does. It is also reachable by
-  opening [http://192.168.4.1/](http://192.168.4.1/) manually.
+  opening [http://192.168.4.1/](http://192.168.4.1/) manually. This needs the default `port: 80`,
+  since captive portal detection only works there; on another port, nothing opens automatically and
+  the interface must be opened manually at `http://192.168.4.1:<port>/`.
 
 A configuration with both a network to join and an `ap:` fallback gets the same captive behavior
 when `local: true` is set. When [Captive Portal](/components/captive_portal/) is configured it stays

--- a/src/content/docs/components/wifi.mdx
+++ b/src/content/docs/components/wifi.mdx
@@ -207,6 +207,9 @@ wifi:
     password: "W1PBGyrokfLz"
 ```
 
+For a device that only ever uses its access point, add [`web_server:`](/components/web_server/#access-point-mode)
+to control it from a phone without any internet connection.
+
 ## User Entered Credentials
 
 Some components such as [Captive Portal](/components/captive_portal/), [Improv Serial](/components/improv_serial/) and


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Documents the web_server access point mode: with `wifi: ap:` and no network to join, `local` now defaults to `true` and the web server acts as a captive portal while the access point is up, so the interface opens by itself on a phone without any internet connection. Adds an "Access point mode" section and the new `local` default to the web_server page, a note on the captive_portal page, and a pointer from the WiFi access point section.

**Related issue (if applicable):** fixes esphome/esphome#18510

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#18517

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.
