### PR TITLE
2026.8.0b6

### DIFF
--- a/data/version.yaml
+++ b/data/version.yaml
@@ -1,2 +1,2 @@
-release: 2026.8.0b5
+release: 2026.8.0b6
 version: '2026.8'

--- a/src/components/InstallSelector.astro
+++ b/src/components/InstallSelector.astro
@@ -4,7 +4,7 @@ import { Code, Tabs, TabItem, LinkButton } from "@astrojs/starlight/components";
 // Every esphome-desktop release publishes a version-independent `latest.json`,
 // so the download links resolve at build time and never go stale. The constant
 // is only a fallback for when the fetch fails (offline build, GitHub outage).
-const FALLBACK_VERSION = "1.0.2";
+const FALLBACK_VERSION = "1.1.0";
 const LATEST_JSON = "https://github.com/esphome/esphome-desktop/releases/latest/download/latest.json";
 
 // Every download this page offers, as `${platform}-${kind}` keys into the

--- a/src/content/docs/changelog/2026.8.0.mdx
+++ b/src/content/docs/changelog/2026.8.0.mdx
@@ -920,6 +920,20 @@ For detailed migration guides and API documentation, see the
 - [socket] Fix multi-second TCP stalls on ESP8266 by yielding to the SYS context [esphome#18455](https://github.com/esphome/esphome/pull/18455) by [@bdraco](https://github.com/bdraco)
 - [light] Replace rgb_order/is_rgbw/is_wrgb with channel_colors [esphome#18474](https://github.com/esphome/esphome/pull/18474) by [@jesserockz](https://github.com/jesserockz) (new-feature)
 - [gpio_expander][pcf8574][pca9554][tca9555][pca6416a][pi4ioe5v6408][mcp23016][mcp23xxx_base] Reject unsupported interrupt_pin options (inverted, allow_other_uses) [esphome#18472](https://github.com/esphome/esphome/pull/18472) by [@bdraco](https://github.com/bdraco)
+- [api] Bump noise-c to 0.1.20 [esphome#18482](https://github.com/esphome/esphome/pull/18482) by [@bdraco](https://github.com/bdraco)
+- [ci] Fail the benchmark job when the C++ benchmark build fails [esphome#18480](https://github.com/esphome/esphome/pull/18480) by [@bdraco](https://github.com/bdraco)
+- [api] Bump noise-c to 0.1.21 [esphome#18484](https://github.com/esphome/esphome/pull/18484) by [@bdraco](https://github.com/bdraco)
+- [modbus] CRC scan all unknown function codes [esphome#18483](https://github.com/esphome/esphome/pull/18483) by [@exciton](https://github.com/exciton)
+- [platformio] Give the ccache wrapper a cmd.exe safe path [esphome#18495](https://github.com/esphome/esphome/pull/18495) by [@bdraco](https://github.com/bdraco)
+- [vscode] Report the origin of an unexpected exception during validation [esphome#18494](https://github.com/esphome/esphome/pull/18494) by [@bdraco](https://github.com/bdraco)
+- [esp32] Fix ESP32-P4 bootloop on rev3 (v3.x) chips when only variant is set [esphome#18500](https://github.com/esphome/esphome/pull/18500) by [@swoboda1337](https://github.com/swoboda1337)
+- [ci] Stop persisting the integration test ccache [esphome#18504](https://github.com/esphome/esphome/pull/18504) by [@swoboda1337](https://github.com/swoboda1337)
+- Bump bundled esphome-device-builder to 1.11.3 [esphome#18505](https://github.com/esphome/esphome/pull/18505) by [@esphome[bot]](https://github.com/apps/esphome)
+- Bump bundled esphome-device-builder to 1.11.4 [esphome#18506](https://github.com/esphome/esphome/pull/18506) by [@esphome[bot]](https://github.com/apps/esphome)
+- Bump bundled esphome-device-builder to 1.11.5 [esphome#18507](https://github.com/esphome/esphome/pull/18507) by [@esphome[bot]](https://github.com/apps/esphome)
+- Bump bundled esphome-device-builder to 1.12.0 [esphome#18514](https://github.com/esphome/esphome/pull/18514) by [@esphome[bot]](https://github.com/apps/esphome)
+- [image] Restore defaults:/files: support for platform entries [esphome#18032](https://github.com/esphome/esphome/pull/18032) by [@clydebarrow](https://github.com/clydebarrow) (new-feature)
+- [ci] Stop jobs hanging on apt by restoring the cached apt action and bounding raw apt calls [esphome#18518](https://github.com/esphome/esphome/pull/18518) by [@bdraco](https://github.com/bdraco)
 {/* BETA_CHANGES_END */}
 
 ### All changes
@@ -1308,6 +1322,20 @@ For detailed migration guides and API documentation, see the
 - [socket] Fix multi-second TCP stalls on ESP8266 by yielding to the SYS context [esphome#18455](https://github.com/esphome/esphome/pull/18455) by [@bdraco](https://github.com/bdraco)
 - [light] Replace rgb_order/is_rgbw/is_wrgb with channel_colors [esphome#18474](https://github.com/esphome/esphome/pull/18474) by [@jesserockz](https://github.com/jesserockz) (new-feature)
 - [gpio_expander][pcf8574][pca9554][tca9555][pca6416a][pi4ioe5v6408][mcp23016][mcp23xxx_base] Reject unsupported interrupt_pin options (inverted, allow_other_uses) [esphome#18472](https://github.com/esphome/esphome/pull/18472) by [@bdraco](https://github.com/bdraco)
+- [api] Bump noise-c to 0.1.20 [esphome#18482](https://github.com/esphome/esphome/pull/18482) by [@bdraco](https://github.com/bdraco)
+- [ci] Fail the benchmark job when the C++ benchmark build fails [esphome#18480](https://github.com/esphome/esphome/pull/18480) by [@bdraco](https://github.com/bdraco)
+- [api] Bump noise-c to 0.1.21 [esphome#18484](https://github.com/esphome/esphome/pull/18484) by [@bdraco](https://github.com/bdraco)
+- [modbus] CRC scan all unknown function codes [esphome#18483](https://github.com/esphome/esphome/pull/18483) by [@exciton](https://github.com/exciton)
+- [platformio] Give the ccache wrapper a cmd.exe safe path [esphome#18495](https://github.com/esphome/esphome/pull/18495) by [@bdraco](https://github.com/bdraco)
+- [vscode] Report the origin of an unexpected exception during validation [esphome#18494](https://github.com/esphome/esphome/pull/18494) by [@bdraco](https://github.com/bdraco)
+- [esp32] Fix ESP32-P4 bootloop on rev3 (v3.x) chips when only variant is set [esphome#18500](https://github.com/esphome/esphome/pull/18500) by [@swoboda1337](https://github.com/swoboda1337)
+- [ci] Stop persisting the integration test ccache [esphome#18504](https://github.com/esphome/esphome/pull/18504) by [@swoboda1337](https://github.com/swoboda1337)
+- Bump bundled esphome-device-builder to 1.11.3 [esphome#18505](https://github.com/esphome/esphome/pull/18505) by [@esphome[bot]](https://github.com/apps/esphome)
+- Bump bundled esphome-device-builder to 1.11.4 [esphome#18506](https://github.com/esphome/esphome/pull/18506) by [@esphome[bot]](https://github.com/apps/esphome)
+- Bump bundled esphome-device-builder to 1.11.5 [esphome#18507](https://github.com/esphome/esphome/pull/18507) by [@esphome[bot]](https://github.com/apps/esphome)
+- Bump bundled esphome-device-builder to 1.12.0 [esphome#18514](https://github.com/esphome/esphome/pull/18514) by [@esphome[bot]](https://github.com/apps/esphome)
+- [image] Restore defaults:/files: support for platform entries [esphome#18032](https://github.com/esphome/esphome/pull/18032) by [@clydebarrow](https://github.com/clydebarrow) (new-feature)
+- [ci] Stop jobs hanging on apt by restoring the cached apt action and bounding raw apt calls [esphome#18518](https://github.com/esphome/esphome/pull/18518) by [@bdraco](https://github.com/bdraco)
 {/* ALL_CHANGES_END */}
 
 </details>

--- a/src/content/docs/changelog/2026.8.0.mdx
+++ b/src/content/docs/changelog/2026.8.0.mdx
@@ -35,7 +35,9 @@ faulting address. The release also delivers multi-interface networking with Ethe
 major Modbus overhaul with the new `modbus_client` component, multi-key OTA signature verification, and runtime
 wake word management, alongside new components including the LD6002B 60 GHz presence radar and Hörmann garage
 door support. The bundled Device Builder brings faster startup, parallel uploads, and one-click config
-migration.
+migration. The beta cycle also fixed ESP32 BLE trackers and proxies missing advertisements alongside WiFi on
+ESP-IDF 5.5.5, and encrypted API connections and OTA uploads on ESP8266 that stalled for seconds now complete in
+well under one second.
 {/* RELEASE_OVERVIEW_END */}
 
 ## Upgrade Checklist
@@ -62,6 +64,10 @@ migration.
   `internal_temperature` component
 - If your automations relied on non-iBeacon Apple manufacturer payloads being parsed as iBeacons, note these no
   longer match
+- If you use `rgb_order`, `is_rgbw` or `is_wrgb` on `esp32_rmt_led_strip`, `beken_spi_led_strip` or
+  `rp2040_pio_led_strip`, switch to the single `channel_colors` key (the old keys warn until 2027.3.0)
+- If you set `inverted: true` or `allow_other_uses: true` on an `interrupt_pin` for `pcf8574`, `pca9554`,
+  `tca9555`, `pca6416a`, `pi4ioe5v6408` or `mcp23016`, remove them; both are now rejected at validation
 {/* UPGRADE_CHECKLIST_END */}
 
 {/* FEATURE_HIGHLIGHTS_START */}
@@ -98,6 +104,15 @@ BLE devices through a Pico W proxy. BK72xx gained active scanning by packing the
 One config note: on migrated sensor platforms the auto-generated tracker reference key `esp32_ble_id:` is now
 `ble_hub_id:`. Most configs never set it explicitly; those that do keep validating with a warning until
 2027.2.0. See the Breaking Changes section for details.
+
+**ESP32 scan window with WiFi:** ESP-IDF 5.5.5 fixed a coexistence bug that made BLE scans run far longer than
+the configured window, and the default 30 ms window in a 320 ms interval had been relying on it; with the fix the
+scanner listened only 9.4% of the time and trackers and proxies missed most advertisements alongside WiFi from
+2026.7.1 on. With WiFi coexistence on ESP-IDF 5.5.5 or newer the
+[esp32_ble_tracker](/components/esp32_ble_tracker/) `window` now defaults to the `interval`, as Espressif
+recommends; an explicit `window` is never changed ([#18356](https://github.com/esphome/esphome/pull/18356)).
+`bk72xx_ble` also stops code generation with a clear message on Beken chips without a BLE 5.x stack (BK7231T,
+BK7251, BK7231Q) instead of failing minutes into the build ([#18406](https://github.com/esphome/esphome/pull/18406)).
 
 ## ESPHome Device Builder
 
@@ -152,7 +167,13 @@ spelling, which is read on load and respelled to the canonical form on write
 has a pending migration shows a dot on its card and table row, and clicking it opens the editor to apply the migration
 ([#2563](https://github.com/esphome/device-builder/pull/2563),
 [frontend#1652](https://github.com/esphome/device-builder-frontend/pull/1652),
-[frontend#1653](https://github.com/esphome/device-builder-frontend/pull/1653)).
+[frontend#1653](https://github.com/esphome/device-builder-frontend/pull/1653)). The offer now names each change it
+will make and shows a preview ([frontend#1662](https://github.com/esphome/device-builder-frontend/pull/1662)),
+only proposes migrations the installed ESPHome supports
+([#2602](https://github.com/esphome/device-builder/pull/2602)), and covers the LED strip `channel_colors` rename
+introduced in this release ([#2585](https://github.com/esphome/device-builder/pull/2585),
+[#2596](https://github.com/esphome/device-builder/pull/2596),
+[#2600](https://github.com/esphome/device-builder/pull/2600)).
 
 **The Structured Editor Rounds Out**
 
@@ -278,7 +299,12 @@ Compilation now runs through `ccache` when it is installed on ESP8266, LibreTiny
 [#17728](https://github.com/esphome/esphome/pull/17728)), matching what ESP-IDF builds already did. The cache is
 shared across devices and projects, so a fleet of similar devices compiles almost entirely from cache: in testing,
 six Sonoff S31 devices built in 15 seconds for the first and 4 to 5 seconds for each of the rest. Set
-`ESPHOME_CCACHE_ENABLE=0` to opt out; `esphome clean-all` removes the cache.
+`ESPHOME_CCACHE_ENABLE=0` to opt out; `esphome clean-all` removes the cache. A `ccache` on
+`PATH` that does not run (a stale shim or a `.bat` wrapper on Windows) is now detected and skipped instead of
+failing every compile step ([#18407](https://github.com/esphome/esphome/pull/18407)), the wrapper path is made
+safe for `cmd.exe` so the ccache bundled with ESPHome Desktop works
+([#18495](https://github.com/esphome/esphome/pull/18495)), and framework downloads retry transient network
+errors with a short backoff ([#18330](https://github.com/esphome/esphome/pull/18330)).
 
 ESP-IDF installs also slimmed down considerably:
 
@@ -308,6 +334,16 @@ helpful tip instead of crashing ([#18280](https://github.com/esphome/esphome/pul
 ([#17110](https://github.com/esphome/esphome/pull/17110)), so a device with `web_server:` but no `api:` can
 finally be followed from the CLI. The native API is still preferred, then MQTT, then the web server.
 
+The beta cycle also removed some stalls. `esphome logs` no longer blocks for up to 25 seconds on MQTT IP
+discovery when it already has a usable address; the lookup runs concurrently and feeds any address it finds
+into the running client ([#18313](https://github.com/esphome/esphome/pull/18313)). `esphome upload` retries
+network-level OTA failures such as a connect timeout or the device closing the connection mid-handshake, while
+device-reported errors still fail immediately ([#18332](https://github.com/esphome/esphome/pull/18332)). The
+component alias map is read from a generated registry instead of scanning all 744 component directories on every
+CLI start, the source of a startup regression on slow hosts like the HA Green
+([#18335](https://github.com/esphome/esphome/pull/18335)), and `PYTHONPATH` no longer leaks into build
+subprocesses ([#18360](https://github.com/esphome/esphome/pull/18360)).
+
 ## Better ESP32 Crash Reports
 
 The `esp32` crash handler now captures the faulting memory address (EXCVADDR on Xtensa, MTVAL on RISC-V) and the
@@ -315,7 +351,8 @@ raw exception cause, so heap corruption and pointer bugs leave a usable trail in
 ([#17769](https://github.com/esphome/esphome/pull/17769)). Crash records are also stamped with the build they
 were captured by ([#17770](https://github.com/esphome/esphome/pull/17770)): a record left over from a previous
 firmware is flagged instead of being decoded against the wrong ELF, which used to produce convincing but
-meaningless backtraces.
+meaningless backtraces. The addr2line hint is now one line per core, so decoders no longer merge two unrelated
+stacks into one impossible call chain ([#18418](https://github.com/esphome/esphome/pull/18418)).
 
 ## Ethernet and WiFi Together: Multi-Interface Networking
 
@@ -326,6 +363,28 @@ arbitrated at runtime from that list ([#17797](https://github.com/esphome/esphom
 connected interface in your priority order carries the traffic, DNS follows the active interface, and failover
 plus failback happen automatically within milliseconds of a link change. Verified on hardware with cable pulls,
 VLAN changes and runtime enable/disable cycles. See [network](/components/network/) for configuration.
+
+## ESP8266 Networking and Stability
+
+Encrypted API connections took 2.5 to 3.3 seconds to establish on ESP8266, against about 63 ms on ESP32. WiFi
+and lwIP run in a cooperative context that only executes when the sketch yields, so a busy main loop let the WiFi
+RX queue overflow and TCP stalled on retransmission. Rate-limited yields in the raw TCP read and write paths
+([#18455](https://github.com/esphome/esphome/pull/18455)) and inside the handshake crypto
+([#18473](https://github.com/esphome/esphome/pull/18473)) took a device that stalled on every attempt to 0 stalls
+in 24 attempts, with a 357 ms median. OTA uses the same paths and benefits equally. The noise-c library behind
+the encrypted API was also bumped from 0.1.11 to 0.1.21 along the way, freeing about 670 bytes of heap per
+encrypted connection and making message encryption and decryption 13 to 31% faster in benchmarks
+([#18451](https://github.com/esphome/esphome/pull/18451), [#18482](https://github.com/esphome/esphome/pull/18482),
+[#18484](https://github.com/esphome/esphome/pull/18484)).
+
+Three crash classes are gone as well: a `LoadProhibited` in `cnx_node_search` after a WiFi disconnect, seen on
+ratgdo and Athom devices, fixed by taking the STA interface down before lwIP can transmit into the freed driver
+([#18333](https://github.com/esphome/esphome/pull/18333)); watchdog resets from the software serial RX interrupt
+posting a main loop wake for every byte, now only when no wake is pending
+([#18416](https://github.com/esphome/esphome/pull/18416)); and a reboot when the captive portal shut down after
+WiFi connected, because deleting the web server also deleted the captive portal mid-teardown, which broke Improv
+serial provisioning on the esphome-web ESP8266 image and applies to every ESPAsyncWebServer platform (ESP8266,
+RP2040, LibreTiny, LN882x) ([#18324](https://github.com/esphome/esphome/pull/18324)).
 
 ## Performance Optimizations
 
@@ -421,9 +480,14 @@ or LVGL can draw, with optional cross-fade transitions.
   ([#17717](https://github.com/esphome/esphome/pull/17717))
 - **OpenThread diagnostics** by [@Ardumine](https://github.com/Ardumine): 13 new numeric sensors exposing MAC and
   MLE counters plus parent link quality and RSSI ([#17276](https://github.com/esphome/esphome/pull/17276))
-- **RGBW channel ordering** for [esp32_rmt_led_strip](/components/light/esp32_rmt_led_strip/) by
-  [@peterkeen](https://github.com/peterkeen): the new `rgbw_order` option places the white channel anywhere,
-  matching `neopixelbus` ([#18028](https://github.com/esphome/esphome/pull/18028))
+- **Addressable LED channel order** by [@peterkeen](https://github.com/peterkeen) and
+  [@jesserockz](https://github.com/jesserockz): [esp32_rmt_led_strip](/components/light/esp32_rmt_led_strip/),
+  [beken_spi_led_strip](/components/light/beken_spi_led_strip/) and
+  [rp2040_pio_led_strip](/components/light/rp2040_pio_led_strip/) now describe their channel layout with a single
+  `channel_colors` key, any permutation of `R`, `G` and `B` with an optional `W` anywhere (`GRBW`, `WRGB`, `RWGB`),
+  replacing `rgb_order`, `is_rgbw` and `is_wrgb`; the RP2040 strip gains white-channel positioning as a result,
+  and the old keys keep working with a warning naming the replacement until 2027.3.0
+  ([#18028](https://github.com/esphome/esphome/pull/18028), [#18474](https://github.com/esphome/esphome/pull/18474))
 - **Haier short IR messages** for [remote_transmitter](/components/remote_transmitter/) and
   [remote_receiver](/components/remote_receiver/) by [@ssieb](https://github.com/ssieb)
   ([#17826](https://github.com/esphome/esphome/pull/17826)), and configurable I2S PDM microphone downsampling by
@@ -453,11 +517,46 @@ or LVGL can draw, with optional cross-fade transitions.
   network failure, leave-on-factory-reset, sensor resolution attributes and more units
   ([#18009](https://github.com/esphome/esphome/pull/18009),
   [#18008](https://github.com/esphome/esphome/pull/18008),
-  [#17973](https://github.com/esphome/esphome/pull/17973))
+  [#17973](https://github.com/esphome/esphome/pull/17973)); esp-zigbee-sdk is bumped to 2.0.4, which lets the
+  coordinator remove an end device that is not its direct child and has routers send an explicit rejoin request
+  ([#18415](https://github.com/esphome/esphome/pull/18415))
 - **CC1101 tuning options** by [@hn](https://github.com/hn): frequency offset compensation and bit
   synchronization registers are now configurable from YAML for narrowband protocols like wM-Bus
   ([#17577](https://github.com/esphome/esphome/pull/17577))
 - **Modbus garage doors and more** covered in the Modbus section above
+
+## Notable Bug Fixes
+
+- **ESP32-P4**: `variant: esp32p4` without a `board:` built the pre-v3 bootloader layout since 2026.7.0 and
+  bootlooped on production (v3.x) silicon; the production layout is now the default, with `engineering_sample`
+  still available for pre-release chips ([#18500](https://github.com/esphome/esphome/pull/18500))
+- **image**: `defaults:` and `files:` work again on `image:` platform entries (`file`, `animation`,
+  `online_image`) to share options across several images, not only through the legacy format migration
+  ([#18032](https://github.com/esphome/esphome/pull/18032))
+- **ld2420**: An unknown command error from the radar indexed past a three-entry message table and caused a boot
+  loop ([#18322](https://github.com/esphome/esphome/pull/18322)), and the component no longer shares the UART
+  bus setup priority, which could run its setup before the bus was ready and leave the bus dead on ESP-IDF
+  ([#18428](https://github.com/esphome/esphome/pull/18428))
+- **Modbus custom commands**: Responses with a function code outside the user-defined ranges (65-72 and 100-110),
+  such as the `0x49` used by Sofar inverters, were dropped as parse failures since 2026.7 because only user-defined
+  codes fell back to the CRC scan for the frame end. Every function code of unknown length is now CRC-scanned, and
+  a server hub answers such a request with `ILLEGAL_FUNCTION` instead of silence
+  ([#18483](https://github.com/esphome/esphome/pull/18483))
+- **Sensor delta filter**: NaN passes through again, so a `timeout:` filter followed by `delta:` marks the sensor
+  unavailable instead of holding the last valid reading forever; this had been lost in 2026.2.0
+  ([#18400](https://github.com/esphome/esphome/pull/18400))
+- **Entity keys**: The beta hashed API entity keys from the raw name, which made Home Assistant recreate every
+  entity on first connect and drop helpers tied to them. Keys are back to the sanitized object ID hash for this
+  release; the config-time duplicate check is kept ([#18361](https://github.com/esphome/esphome/pull/18361))
+- **rotary_encoder**: The reset pin now sets `min_value` instead of `0` when the minimum is above zero
+  ([#18197](https://github.com/esphome/esphome/pull/18197))
+- **esp32_ble**: The `LOCAL_IR` and `LOCAL_ER` GAP events the stack raises on first boot after a flash no longer
+  log an "unexpected GAP event" warning ([#18359](https://github.com/esphome/esphome/pull/18359))
+- **cv.parse_esphome_version**: Restored as a deprecated helper after its removal broke external components that
+  call it; it warns and points at `cv.require_esphome_version`, and goes away in 2027.2.0
+  ([#18366](https://github.com/esphome/esphome/pull/18366))
+- **sendspin**: sendspin-cpp 0.7.2 fixes the artwork image's `on_clear` never firing
+  ([#18316](https://github.com/esphome/esphome/pull/18316))
 {/* FEATURE_HIGHLIGHTS_END */}
 
 ## Thank You, Contributors
@@ -561,6 +660,13 @@ pre-releases, and helped in the community.
 - **RC522 I²C**: The default I²C address changed from `0x2C` to `0x28` to match the documentation and typical
   board wiring. If your reader relied on the old default, set `address: 0x2C` explicitly
   [#17566](https://github.com/esphome/esphome/pull/17566)
+- **Addressable LED strips**: `rgb_order`, `is_rgbw` and `is_wrgb` on `esp32_rmt_led_strip`,
+  `beken_spi_led_strip` and `rp2040_pio_led_strip` are deprecated in favour of `channel_colors`; they migrate
+  automatically with a warning until removal in 2027.3.0 [#18474](https://github.com/esphome/esphome/pull/18474)
+- **GPIO expanders**: `inverted: true` and `allow_other_uses: true` on `interrupt_pin` are now validation errors
+  for `pcf8574`, `pca9554`, `tca9555`, `pca6416a`, `pi4ioe5v6408` and `mcp23016`; an inverted pin caused an
+  endless I²C read loop and a shared pin never delivered interrupts
+  [#18472](https://github.com/esphome/esphome/pull/18472)
 
 ### Modbus
 

--- a/src/content/docs/components/image/animation.mdx
+++ b/src/content/docs/components/image/animation.mdx
@@ -86,6 +86,12 @@ Moves the animation to a specific frame. This is equivalent to the
 - **id** (**Required**, [ID](/guides/configuration-types#id)): The ID of the animation to animate.
 - **frame** (**Required**, int): The frame index to show next.
 
+## Sharing Options Across Files
+
+If you have several `animation` images that share most of their options,
+see [Setting Defaults](/components/image#setting-defaults)
+on the [image](/components/image/) component page.
+
 ## See Also
 
 - [Images](/components/image/)

--- a/src/content/docs/components/image/file.mdx
+++ b/src/content/docs/components/image/file.mdx
@@ -56,7 +56,7 @@ image:
   the discussion on transparency in the [image component](/components/image#transparency-options).
 - **invert_alpha** (*Optional*, boolean): Applicable to binary and grayscale only, this will invert the colors, i.e. make black white and vice versa. Useful for e-ink displays. Defaults to `false`.
 
-- **dither** (*Optional*): Specifies which dither method used to process the image, only used in GRAYSCALE and BINARY type image. Defaults to `NONE`. You can read more about it on the [Pillow documentation](https://pillow.readthedocs.io/en/stable/reference/Image.html?highlight=Dither#PIL.Image.Image.convert) and on [Wikipedia](https://en.wikipedia.org/wiki/Dither).
+- **dither** (*Optional*): Specifies which dither method is used to process the image, only used for `BINARY` type images. Defaults to `NONE`. You can read more about it on the [Pillow documentation](https://pillow.readthedocs.io/en/stable/reference/Image.html?highlight=Dither#PIL.Image.Image.convert) and on [Wikipedia](https://en.wikipedia.org/wiki/Dither).
 
   - `NONE`  : Every pixel converts to its nearest color.
   - `FLOYDSTEINBERG`  : Uses Floyd-Steinberg dither to approximate the original image luminosity levels.
@@ -98,6 +98,12 @@ image:
 - **path** (**Required** for `local`, string): The path (relative to where the .yaml file is) of the image file.
 - **url** (**Required** for `web`, url): The URL to download the image file from.
 - **icon** (**Required** for `mdi`, `mdil` and `memory`, string): The icon name, without the `mdi:` style prefix.
+
+## Sharing Options Across Files
+
+If you have several `file` images that share most of their options,
+see [Setting Defaults](/components/image#setting-defaults)
+on the [image](/components/image/) component page.
 
 ## See Also
 

--- a/src/content/docs/components/image/index.mdx
+++ b/src/content/docs/components/image/index.mdx
@@ -81,18 +81,49 @@ display:
 You can also use this to invert images in two color displays, use `COLOR_OFF` then `COLOR_ON`
 as the additional parameters.
 
+## Setting Defaults
+
+If you have several images that share most of their options (`type`, `transparency`, `resize`, ...), a platform entry
+can use `defaults:` together with `files:` instead of repeating those options on every image:
+
+```yaml
+image:
+  - platform: file
+    defaults:
+      type: RGB565
+      transparency: opaque
+      resize: 100x100
+    files:
+      - id: image_one
+        file: "image1.png"
+      - id: image_two
+        file: "image2.png"
+        type: GRAYSCALE # overrides the default type for this image only
+```
+
+Each entry in `files:` is merged with `defaults:`, with the entry's own options taking priority. `defaults:` can only
+be used together with `files:`. This works the same way for every image platform
+([`file`](/components/image/file/), [`animation`](/components/image/animation/) and
+[`online_image`](/components/image/online_image/)) — just replace the entries in `files:` with the options normally
+used for that platform.
+
+- **defaults** (*Optional*, mapping): Options merged into every entry in `files:`.
+- **files** (*Optional*, list): A list of images, each using the normal configuration variables of the selected
+  platform.
+
 ## Transparency Options
 
-By default transparency is not used. If `transparency: chroma_key` is set then a specific colour will be used to
-replace any transparent or partially transparent portions of the image. This will not be drawn when rendering the
-image, allowing the background to be visible.
+The `transparency` option controls how the alpha channel of the input image is handled. Possible values are:
 
-If `transparency: alpha_channel` is set, then each pixel of the image will be assigned an additional byte with a
-transparency value. This is useful mainly when using [LVGL](/components/lvgl/) as the `alpha_channel` transparency
-will enable smooth blending of transparent images with the background. This choice is not available for binary
-images.
-When using the display lambda image drawing functions these will draw or not draw the pixel, no blending with the
-background will be done.
+- `opaque` (default): Transparency is not used; the image is drawn fully opaque.
+- `chroma_key`: A specific colour is used to represent any transparent or partially transparent portions of the
+  image. Pixels of that colour will not be drawn when rendering the image, allowing the background to be visible.
+- `alpha_channel`: Each pixel of the image is assigned an additional byte with a transparency value. This is useful
+  mainly when using [LVGL](/components/lvgl/), as `alpha_channel` transparency enables smooth blending of
+  transparent images with the background. This choice is not available for binary images. When using the display
+  lambda image drawing functions, these will only draw or not draw the pixel; no blending with the background will
+  be done.
+
 The `BINARY` format with `chroma_key` transparency effectively turns the image into an alpha mask with one bit per
 pixel. GRAYSCALE images with transparency store the alpha channel only, and remain 1 byte per pixel.
 

--- a/src/content/docs/components/image/online_image.mdx
+++ b/src/content/docs/components/image/online_image.mdx
@@ -43,9 +43,8 @@ image:
 
 - **format** (**Required**): The format that the image is encoded with.
 
-  - `AUTO`  : The format is detected automatically from the downloaded image content.
   - `BMP`  : The image on the server is encoded in BMP format.
-  - `JPEG`  : The image on the server is encoded in JPEG format.
+  - `JPEG` (or `JPG`) : The image on the server is encoded in JPEG format.
   - `PNG`  : The image on the server is encoded in PNG format.
 - **resize** (*Optional*, string): If set, this will resize the image to fit inside the given dimensions `WIDTHxHEIGHT`
   and preserve the aspect ratio.
@@ -191,6 +190,12 @@ wifi:
   on_connect:
     - component.update: my_online_image
 ```
+
+## Sharing Options Across Files
+
+If you have several `online_image` images that share most of their options,
+see [Setting Defaults](/components/image#setting-defaults)
+on the [image](/components/image/) component page.
 
 ## See Also
 

--- a/src/content/docs/guides/supporters.mdx
+++ b/src/content/docs/guides/supporters.mdx
@@ -2317,6 +2317,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Artur 'Wodor' Wielogorski (@wodor)](https://github.com/wodor)
 - [Rick van Hattem (@wolph)](https://github.com/wolph)
 - [workingmanrob (@workingmanrob)](https://github.com/workingmanrob)
+- [Wouter (@wouterpotters)](https://github.com/wouterpotters)
 - [Peter Zsak (@wroadd)](https://github.com/wroadd)
 - [Dawid Wróbel (@wrobelda)](https://github.com/wrobelda)
 - [wrt54g (@wrt54g)](https://github.com/wrt54g)
@@ -2386,4 +2387,4 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Josef Zweck (@zweckj)](https://github.com/zweckj)
 - [Zynth-dev (@Zynth-dev)](https://github.com/Zynth-dev)
 
-*This page was last updated August 18, 2026.*
+*This page was last updated August 20, 2026.*


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- [install] Bump Device Builder fallback version to 1.1.0 [docs#7218](https://github.com/esphome/esphome.io/pull/7218)
- Add 2026.8.0 beta fixes to release notes [docs#7217](https://github.com/esphome/esphome.io/pull/7217)
- [image] Document `defaults` option [docs#7102](https://github.com/esphome/esphome.io/pull/7102)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
