### PR TITLE
Add missing attribution to hoermann_hcp

### DIFF
--- a/src/content/docs/components/cover/hoermann_hcp.mdx
+++ b/src/content/docs/components/cover/hoermann_hcp.mdx
@@ -20,8 +20,7 @@ The following Series 4 motors communicate over the HCP bus (Modbus RTU) and shou
 > Only Series 4 motors are supported. Older motors use a different connector pinout and a
 > completely different protocol.
 >
-> This component implements the same protocol as the [HCPBridge](https://github.com/hkiam/HCPBridge) and is based off of [14yannick's ESPHome port](https://github.com/14yannick/esphome-hcpbridge)
-> project.
+> This component implements the same protocol as the [HCPBridge](https://github.com/hkiam/HCPBridge) project and is based on [14yannick's ESPHome port](https://github.com/14yannick/esphome-hcpbridge).
 
 Communication with the motor happens over [Modbus](/components/modbus/) with the `role` set to
 `server`, which in turn requires a [UART bus](/components/uart/). The UART **must** be configured with

--- a/src/content/docs/components/cover/hoermann_hcp.mdx
+++ b/src/content/docs/components/cover/hoermann_hcp.mdx
@@ -20,7 +20,7 @@ The following Series 4 motors communicate over the HCP bus (Modbus RTU) and shou
 > Only Series 4 motors are supported. Older motors use a different connector pinout and a
 > completely different protocol.
 >
-> This component implements the same protocol as the [HCPBridge](https://github.com/hkiam/HCPBridge)
+> This component implements the same protocol as the [HCPBridge](https://github.com/hkiam/HCPBridge) and is based off of [14yannick's ESPHome port](https://github.com/14yannick/esphome-hcpbridge)
 > project.
 
 Communication with the motor happens over [Modbus](/components/modbus/) with the `role` set to


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description
Adding missing attribution to original work.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
