### PR TITLE
Add button documentation hoermann_hcp

### DIFF
--- a/src/content/docs/components/cover/hoermann_hcp.mdx
+++ b/src/content/docs/components/cover/hoermann_hcp.mdx
@@ -152,7 +152,7 @@ cover:
 
 ## Button
 
-The `hoermann_hcp` button platform exposes the motor's built-in vent and half-open commands. 
+The `hoermann_hcp` button platform exposes the motor's built-in vent and half-open commands.
 
 ```yaml
 button:
@@ -167,8 +167,8 @@ button:
 
 - **hoermann_hcp_id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID of the
   `hoermann_hcp` hub. Only required if you have more than one hub.
-- **vent** (*Optional*): Moves the door to its built-in vent position.
-- **half_open** (*Optional*): Moves the door to its built-in half-open position.
+- **vent** (*Optional*): Configuration for the vent button. When pressed, moves the door to its built-in vent position.
+- **half_open** (*Optional*): Configuration for the half-open button. When pressed, moves the door to its built-in half-open position.
 
 Both buttons support all options from [Button](/components/button#config-button).
 

--- a/src/content/docs/components/cover/hoermann_hcp.mdx
+++ b/src/content/docs/components/cover/hoermann_hcp.mdx
@@ -150,6 +150,28 @@ cover:
   `hoermann_hcp` hub. Only required if you have more than one hub.
 - All other options from [Cover](/components/cover#config-cover).
 
+## Button
+
+The `hoermann_hcp` button platform exposes the motor's built-in vent and half-open commands. 
+
+```yaml
+button:
+  - platform: hoermann_hcp
+    vent:
+      name: Garage Vent
+    half_open:
+      name: Garage Half Open
+```
+
+### Configuration variables
+
+- **hoermann_hcp_id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID of the
+  `hoermann_hcp` hub. Only required if you have more than one hub.
+- **vent** (*Optional*): Moves the door to its built-in vent position.
+- **half_open** (*Optional*): Moves the door to its built-in half-open position.
+
+Both buttons support all options from [Button](/components/button#config-button).
+
 ## Light
 
 The `hoermann_hcp` light platform controls the courtesy light built into the motor. It is an on/off
@@ -200,11 +222,13 @@ binary_sensor:
 ## See Also
 
 - [Cover Component](/components/cover/)
+- [Button Component](/components/button/)
 - [Binary Sensor Component](/components/binary_sensor/)
 - [Light Component](/components/light/)
 - [Modbus](/components/modbus/)
 - [HCPBridge project](https://github.com/hkiam/HCPBridge)
 - [Automation](/automations)
 - <APIRef text="hoermann_hcp_cover.h" path="hoermann_hcp/cover/hoermann_hcp_cover.h" />
+- <APIRef text="hoermann_hcp_button.h" path="hoermann_hcp/button/hoermann_hcp_button.h" />
 - <APIRef text="hoermann_hcp_light.h" path="hoermann_hcp/light/hoermann_hcp_light.h" />
 - <APIRef text="hoermann_hcp_binary_sensor.h" path="hoermann_hcp/binary_sensor/hoermann_hcp_binary_sensor.h" />


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Add the documentation for the hoermann buttons.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#18544

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
