### PR TITLE
[sx126x] Document RX/TX enable pin options

### DIFF
--- a/src/content/docs/components/sx126x.mdx
+++ b/src/content/docs/components/sx126x.mdx
@@ -51,7 +51,8 @@ sx126x:
 - **hw_version** (**Required**, enum): Valid values are `sx1261`, `sx1262`, `sx1268` or `llcc68`.
 - **modulation** (**Required**, enum): Modulation can be `FSK` or `LORA`.
 - **enable_pins_inverted** (*Optional*, boolean): If true, the logic levels of the RX and TX enable pins
-  are inverted. Defaults to `false`.
+  are inverted. Defaults to `false` (active-high: the pin matching the current mode is driven high, the
+  other is driven low).
 - **rx_enable_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): RX enable pin,
   used to control an external RX enable switch. Must be configured together with `tx_enable_pin`.
 - **tx_enable_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): TX enable pin,

--- a/src/content/docs/components/sx126x.mdx
+++ b/src/content/docs/components/sx126x.mdx
@@ -50,6 +50,12 @@ sx126x:
 - **frequency** (**Required**, frequency): Frequency in Hz of the transceiver.
 - **hw_version** (**Required**, enum): Valid values are `sx1261`, `sx1262`, `sx1268` or `llcc68`.
 - **modulation** (**Required**, enum): Modulation can be `FSK` or `LORA`.
+- **enable_pins_inverted** (*Optional*, boolean): If true, the logic levels of the RX and TX enable pins
+  are inverted. Defaults to `false`.
+- **rx_enable_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): RX enable pin,
+  used to control an external RX enable switch. Must be configured together with `tx_enable_pin`.
+- **tx_enable_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): TX enable pin,
+  used to control an external TX enable switch. Must be configured together with `rx_enable_pin`.
 - **pa_power** (**Optional**, int): Transmitter power, range is from -3 to 15 dBm when `hw_version` is
   `sx1261` and from -3 to 22 dBm otherwise.
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**
https://github.com/esphome/esphome/pull/18589

- esphome/esphome#18589

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New RX/TX enable pin options for sx126x component</strong></summary>
added the documentation to describe functionality
</details>
