### PR TITLE
[tuya] Document forced time synchronization

### DIFF
--- a/src/content/docs/components/tuya.mdx
+++ b/src/content/docs/components/tuya.mdx
@@ -58,6 +58,10 @@ Here is another example output for a Tuya ME-81H thermostat:
 - **time_id** (*Optional*, [ID](/guides/configuration-types#id)): Some Tuya devices support obtaining local time from ESPHome.
   Specify the ID of the [Time](/components/time/) which will be used.
 
+- **force_time_sync** (*Optional*, boolean): ESPHome sends local time to the Tuya MCU when it observes a new minute.
+  Use this option for MCUs that do not keep their display clock stable between time updates. This option requires
+  `time_id` and defaults to `false`. This option supports MCUs that use the local-time protocol, not the GMT protocol.
+
 - **status_pin** (*Optional*, [Pin Schema](/guides/configuration-types#pin-schema)): Some Tuya devices support WiFi status reporting ONLY
   through gpio pin.
   Specify the pin reported in the config dump or leave empty otherwise.


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Document the optional `force_time_sync` setting for the Tuya component. This setting sends local time when ESPHome
observes a new minute. It helps Tuya MCUs that do not keep their display clock stable between time updates.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes:**

- esphome/esphome#18603

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull request in
  [esphome](https://github.com/esphome/esphome) as linked above.
- [ ] I am merging into `current` because this is a fix, change, or adjustment in the current documentation and is not
  for a new component or feature.
- [x] Not applicable: this change updates an existing component document and does not require an index link.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component
name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in
   **lower_case** format with **underscores** (for example, `bme280`, `sht3x`, or `dallas_temp`):

   ```text
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in the component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```text
@esphomebot generate image dht22
```

**Note:** Place all ImgTable images in `/public/images/`. The component resolves these images to absolute paths.

</details>
