### PR TITLE
[esp32_ble_tracker] Document connection_scan_window

### DIFF
--- a/src/content/docs/components/esp32_ble_tracker.mdx
+++ b/src/content/docs/components/esp32_ble_tracker.mdx
@@ -79,6 +79,13 @@ sensor:
     WiFi is not using it. Without WiFi, or with `software_coexistence` disabled, it defaults
     to `30ms`.
 
+  - **connection_scan_window** (*Optional*, [Time](/guides/configuration-types#time)): The scan window used
+    while a BLE connection is active, for example while a Bluetooth proxy is connected to a device.
+    A window close to the `interval` value can starve active connections of radio time and cause
+    them to disconnect. Must not be larger than `interval`; the same range and step as `window` apply.
+    When `window` defaults to the `interval` value as described above, this defaults to `30ms`;
+    otherwise scanning keeps using `window` during connections unless this is set.
+
   - **duration** (*Optional*, [Time](/guides/configuration-types#time)): The duration of each complete scan. This has no real
     impact on the device but can be used to debug the BLE stack. Defaults to `5min`.
 


### PR DESCRIPTION
## Description

Documents the new `connection_scan_window` option under `scan_parameters`; it sets the scan window used while a BLE connection is active, and defaults to `30ms` when the window was defaulted to the interval.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#18609

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.
