### PR TITLE
[network] Document tcp_send_buffer

### DIFF
--- a/src/content/docs/components/network.mdx
+++ b/src/content/docs/components/network.mdx
@@ -20,6 +20,12 @@ network:
 Always `true` on nRF52 because IPv4 is not supported.
 - **min_ipv6_addr_count** (*Optional*, integer): ESPHome considers the network to be connected when it has one IPv4 address and this number of IPv6 addresses. Defaults to `0` so as to not hang on boot with networks where IPv6 is not enabled. `2` is typically a reasonable value for configurations requiring IPv6.
 - **enable_high_performance** (*Optional*, boolean): Explicitly enables or disables high-performance networking optimizations. Only supported on ESP32 devices. When not specified, this is automatically enabled by components that benefit from optimized network settings. Set to `false` to disable these optimizations if they cause memory issues on your device. Defaults to component-driven behavior.
+- **tcp_send_buffer** (*Optional*, bytes): The amount of outgoing data lwIP queues per TCP connection before
+  writes stall. Only supported on ESP32 devices. The framework default of 5744 bytes can stall senders that
+  produce data in bursts, for example a Bluetooth proxy streaming notifications; raise this if you see
+  "TCP buffer full" warnings in the logs. Accepts `2880` to `65535` bytes, with a cost in heap that scales
+  with the value whenever a connection has data in flight. An explicit value here overrides the size chosen
+  by `enable_high_performance`.
 - **priority** (*Optional*, list): Order of preference for network interfaces when more than one is configured. Only supported on the ESP32 family of devices.
   Each list entry names one of the supported interface types (`ethernet` or `wifi`); the first entry is the most
   preferred. Required when both `ethernet:` and `wifi:` are configured, and must then list every configured

--- a/src/content/docs/components/network.mdx
+++ b/src/content/docs/components/network.mdx
@@ -20,12 +20,13 @@ network:
 Always `true` on nRF52 because IPv4 is not supported.
 - **min_ipv6_addr_count** (*Optional*, integer): ESPHome considers the network to be connected when it has one IPv4 address and this number of IPv6 addresses. Defaults to `0` so as to not hang on boot with networks where IPv6 is not enabled. `2` is typically a reasonable value for configurations requiring IPv6.
 - **enable_high_performance** (*Optional*, boolean): Explicitly enables or disables high-performance networking optimizations. Only supported on ESP32 devices. When not specified, this is automatically enabled by components that benefit from optimized network settings. Set to `false` to disable these optimizations if they cause memory issues on your device. Defaults to component-driven behavior.
-- **tcp_send_buffer** (*Optional*, bytes): The amount of outgoing data lwIP queues per TCP connection before
-  writes stall. Only supported on ESP32 devices. The framework default of 5744 bytes can stall senders that
-  produce data in bursts, for example a Bluetooth proxy streaming notifications; raise this if you see
-  "TCP buffer full" warnings in the logs. Accepts `2880` to `65535` bytes, with a cost in heap that scales
-  with the value whenever a connection has data in flight. An explicit value here overrides the size chosen
-  by `enable_high_performance`.
+- **tcp_send_buffer** (*Optional*, int): The amount of outgoing data lwIP queues per TCP connection before
+  writes stall, in bytes. Only supported on ESP32 devices. The framework default of 5744 bytes can stall
+  senders that produce data in bursts, for example a Bluetooth proxy streaming notifications; raise this if
+  you see "TCP buffer full" warnings in the logs. Accepts `2880` to `65535` bytes; suffixed values such as
+  `16kB` are also accepted. Heap cost scales with the value whenever a connection has data in flight, so
+  prefer the smallest value that clears the warnings. An explicit value here overrides the size chosen by
+  `enable_high_performance`.
 - **priority** (*Optional*, list): Order of preference for network interfaces when more than one is configured. Only supported on the ESP32 family of devices.
   Each list entry names one of the supported interface types (`ethernet` or `wifi`); the first entry is the most
   preferred. Required when both `ethernet:` and `wifi:` are configured, and must then list every configured
@@ -52,6 +53,8 @@ The optimization level depends on whether PSRAM is guaranteed to be available (c
 - WiFi RX buffers: 64 dynamic buffers
 - WiFi TX buffers: 64 dynamic buffers
 - AMPDU aggregation: Standard block acknowledgment windows
+
+An explicit `tcp_send_buffer` overrides the send buffer size chosen here.
 
 > [!NOTE]
 > The [lwIP](https://savannah.nongnu.org/projects/lwip/) library used for the network component currently only implements IPv6 SLAAC according to [RFC4862](https://datatracker.ietf.org/doc/rfc4862/). The interface identifier (IID) is directly generated from the device MAC address.


### PR DESCRIPTION
## Description

Documents the new `tcp_send_buffer` option on the `network` component; it sets lwIP's per socket TCP send buffer on ESP-IDF for users who see "TCP buffer full" warnings.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#18610

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.
