### PR TITLE
[blog] Point 2026.8.0 release notes at the Starter Kit

### DIFF
--- a/src/content/docs/blog/2026/08/19/esphome-2026-8.mdx
+++ b/src/content/docs/blog/2026/08/19/esphome-2026-8.mdx
@@ -53,6 +53,13 @@ import ImgTable from "@components/ImgTable.astro";
   ["Modbus Client", "/components/modbus_client/", "modbus.png"],
 ]} />
 
+## The ESPHome Starter Kit Is Here
+
+Before we get to what's new in this release: the [ESPHome Starter Kit](/starter-kit/) is now available. It's the
+easiest way to start building your own smart home devices, with no soldering, breadboarding, or coding required.
+Read the [announcement post](/blog/2026/08/12/the-esphome-starter-kit-is-here/) for the full story, or head to the
+[Starter Kit page](/starter-kit/) to see what's in the box and to get yours.
+
 ## Release Overview
 
 {/* RELEASE_OVERVIEW_START */}


### PR DESCRIPTION
## Description

Adds a short section to the ESPHome 2026.8.0 release blog post, between the featured-components table and the release overview, linking to the Starter Kit announcement post and the `/starter-kit` page.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.