### PR TITLE
[blog] Add "Read more" links to post cards on blog listings

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -3,6 +3,7 @@ import EditLink from "virtual:starlight/components/EditLink";
 import LastUpdated from "virtual:starlight/components/LastUpdated";
 import CrosspostBadges from "./CrosspostBadges.astro";
 import DiscourseComments from "./DiscourseComments.astro";
+import ReadMoreLinks from "./ReadMoreLinks.astro";
 
 const isBlogPage = Astro.url.pathname.startsWith("/blog");
 
@@ -54,6 +55,7 @@ const footerLinks = [
 ---
 
 {isBlogPage && <CrosspostBadges />}
+{isBlogPage && !isBlogPost && <ReadMoreLinks />}
 {isBlogPost && isProduction && !isCrosspost && <DiscourseComments />}
 
 <footer class="sl-flex">

--- a/src/components/ReadMoreLinks.astro
+++ b/src/components/ReadMoreLinks.astro
@@ -1,0 +1,69 @@
+---
+// Adds a "Read more" link to every post card on the blog listing pages. The card
+// title and cover image are the only links starlight-blog renders, so the excerpt
+// itself gives the reader nothing to click. Preview.astro (starlight-blog) has no
+// override hook, so this patches the DOM client-side (same approach as
+// CrosspostBadges.astro).
+---
+
+<script is:inline>
+  const arrowIconSvg =
+    '<svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true"><path d="M13.29 5.29a1 1 0 0 1 1.42 0l6 6a1 1 0 0 1 0 1.42l-6 6a1 1 0 0 1-1.42-1.42l4.3-4.29H4a1 1 0 1 1 0-2h13.59l-4.3-4.29a1 1 0 0 1 0-1.42Z"/></svg>';
+
+  const decorate = (article) => {
+    const link = article.querySelector(":scope > header > a.preview-link");
+    if (!link || article.querySelector("a.read-more")) return;
+
+    const readMore = document.createElement("a");
+    readMore.className = "read-more";
+    readMore.href = link.getAttribute("href");
+    readMore.append(document.createTextNode("Read more"));
+    readMore.insertAdjacentHTML("beforeend", arrowIconSvg);
+
+    // The link text repeats on every card, so name the post for screen readers.
+    const title = link.querySelector("h2")?.textContent?.trim();
+    if (title) readMore.setAttribute("aria-label", `Read more: ${title}`);
+
+    // After the excerpt where one exists, otherwise straight after the header.
+    const excerpt = article.querySelector(":scope > .sl-markdown-content");
+    (excerpt ?? link.parentElement).insertAdjacentElement("afterend", readMore);
+  };
+
+  const init = () => {
+    for (const article of document.querySelectorAll("article.preview")) {
+      decorate(article);
+    }
+  };
+
+  init();
+  document.addEventListener("astro:page-load", init);
+</script>
+
+<style is:global>
+  article.preview a.read-more {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    width: fit-content;
+    color: var(--sl-color-text-accent);
+    font-size: var(--sl-text-sm);
+    font-weight: 600;
+    text-decoration: none;
+  }
+  article.preview a.read-more:hover {
+    color: var(--sl-color-white);
+  }
+  article.preview a.read-more svg {
+    flex-shrink: 0;
+    fill: currentColor;
+    transition: transform 0.15s ease;
+  }
+  article.preview a.read-more:hover svg {
+    transform: translateX(0.15rem);
+  }
+  @media (prefers-reduced-motion: reduce) {
+    article.preview a.read-more svg {
+      transition: none;
+    }
+  }
+</style>

--- a/src/components/ReadMoreLinks.astro
+++ b/src/components/ReadMoreLinks.astro
@@ -12,11 +12,12 @@
 
   const decorate = (article) => {
     const link = article.querySelector(":scope > header > a.preview-link");
-    if (!link || article.querySelector("a.read-more")) return;
+    const href = link?.getAttribute("href");
+    if (!href || article.querySelector(":scope > a.read-more")) return;
 
     const readMore = document.createElement("a");
     readMore.className = "read-more";
-    readMore.href = link.getAttribute("href");
+    readMore.href = href;
     readMore.append(document.createTextNode("Read more"));
     readMore.insertAdjacentHTML("beforeend", arrowIconSvg);
 

--- a/src/components/ReadMoreLinks.astro
+++ b/src/components/ReadMoreLinks.astro
@@ -65,5 +65,8 @@
     article.preview a.read-more svg {
       transition: none;
     }
+    article.preview a.read-more:hover svg {
+      transform: none;
+    }
   }
 </style>


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

On the blog listing pages only the post title and cover image linked into a post, so the excerpt text gave the reader nothing to click. Each card now gets a "Read more" link with an arrow, placed between the excerpt and the tag footer, pointing at the same URL as the title.

starlight-blog's `Preview.astro` has no override hook and importing its internals trips the rolldown exports-field error already noted in `Footer.astro`, so the link is added client-side - the same approach `CrosspostBadges.astro` already uses for that component. The link carries an `aria-label` naming the post so screen readers do not hear a run of identical "Read more" links, and the arrow's hover nudge is suppressed under `prefers-reduced-motion`. It renders on the blog index, pagination, tag and author listings, not on individual posts.

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.