### PR TITLE
[blog] Show the tag group in the blog sidebar

### DIFF
--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -110,12 +110,6 @@ dialog::backdrop {
   padding-block: 0.5em;
 }
 
-/* Hide the blog "Tags" group in the sidebar (added by starlight-blog). The group
-   is the only sidebar entry that links to /blog/tags/, so target it via :has(). */
-.sidebar-content li:has(> details a[href*="/blog/tags/"]) {
-  display: none;
-}
-
 /* Blog list post previews (starlight-blog): tighten the default 1.5rem gap
    between the title/metadata, excerpt paragraph and tags. */
 article.preview {


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

The `starlight-blog` plugin already builds a "Tags" group into the blog sidebar, listing each tag with its post count and linking to the corresponding `/blog/tags/<tag>/` page. A CSS rule added with the original blog work hid that group, so the tag pages were only reachable from the tag chips at the bottom of an individual post.

Removing the rule surfaces the categories in the sidebar on blog pages, between "Recent posts" and "Authors". No other change is needed; the tag pages themselves already build and render.

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.