### PR TITLE
[remote_transmitter] non_blocking available on RTL8720C

### DIFF
--- a/src/content/docs/components/remote_transmitter.mdx
+++ b/src/content/docs/components/remote_transmitter.mdx
@@ -38,7 +38,8 @@ remote_transmitter:
   transmitters are connected to a single device.
 - **non_blocking** (*Optional*, boolean): If enabled, transmissions return immediately and complete in the
   background; the `on_complete` automation triggers once the transmission finishes. Only available on ESP32
-  variants with RMT hardware and on RTL8720C. Defaults to `true` on ESP32 and `false` on RTL8720C.
+  variants with RMT hardware and on RTL8720C, BK7231N and BK7238. Defaults to `true` on ESP32 and `false`
+  elsewhere.
 
 ### ESP32 RMT configuration variables
 

--- a/src/content/docs/components/remote_transmitter.mdx
+++ b/src/content/docs/components/remote_transmitter.mdx
@@ -36,6 +36,9 @@ remote_transmitter:
 
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID used for code generation. Useful when multiple
   transmitters are connected to a single device.
+- **non_blocking** (*Optional*, boolean): If enabled, transmissions return immediately and complete in the
+  background; the `on_complete` automation triggers once the transmission finishes. Only available on ESP32
+  variants with RMT hardware and on RTL8720C. Defaults to `true` on ESP32 and `false` on RTL8720C.
 
 ### ESP32 RMT configuration variables
 
@@ -60,8 +63,6 @@ remote_transmitter:
 | ESP32-S3      | 192 symbols      | 48 symbols |
 
 - **clock_resolution** (*Optional*, int): The clock resolution used by the RMT peripheral in Hz. Defaults to `1000000`.
-- **non_blocking** (*Optional*, boolean): If enabled, any transmit will return immediately and the RMT will run in the
-  background. The `on_complete` automation will trigger after the transmit completes. Defaults to `true`.
 - **use_dma** (*Optional*, boolean): Enable DMA on variants that support it. If enabled `rmt_symbols` controls
   the DMA buffer size and can be set to a large value.
 

--- a/src/content/docs/components/remote_transmitter.mdx
+++ b/src/content/docs/components/remote_transmitter.mdx
@@ -38,7 +38,7 @@ remote_transmitter:
   transmitters are connected to a single device.
 - **non_blocking** (*Optional*, boolean): If enabled, transmissions return immediately and complete in the
   background; the `on_complete` automation triggers once the transmission finishes. Only available on ESP32
-  variants with RMT hardware and on RTL8720C. Defaults to `true` on ESP32 and `false` on RTL8720C.
+  variants with RMT hardware, where it defaults to `true`, and on RTL8720C, where it defaults to `false`.
 
 ### ESP32 RMT configuration variables
 

--- a/src/content/docs/components/remote_transmitter.mdx
+++ b/src/content/docs/components/remote_transmitter.mdx
@@ -38,8 +38,7 @@ remote_transmitter:
   transmitters are connected to a single device.
 - **non_blocking** (*Optional*, boolean): If enabled, transmissions return immediately and complete in the
   background; the `on_complete` automation triggers once the transmission finishes. Only available on ESP32
-  variants with RMT hardware and on RTL8720C, BK7231N and BK7238. Defaults to `true` on ESP32 and `false`
-  elsewhere.
+  variants with RMT hardware and on RTL8720C. Defaults to `true` on ESP32 and `false` on RTL8720C.
 
 ### ESP32 RMT configuration variables
 


### PR DESCRIPTION
## Description

`non_blocking:` is now available on RTL8720C in addition to ESP32/RMT (implemented in the linked esphome PR). The option moves from the ESP32-RMT-only section to the general configuration variables, with a platform-availability note and per-platform defaults (`true` on ESP32, `false` on RTL8720C).

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#18648

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.
