### PR TITLE
[projects] Document the serial proxy port URL

### DIFF
--- a/src/data/readyMadeProjects.ts
+++ b/src/data/readyMadeProjects.ts
@@ -348,7 +348,7 @@ export const PROJECT_TYPES: ProjectType[] = [
         title: "M5Stack AtomS3 Lite with ATOMIC RS485 Base",
         body: [
           "Turn an M5Stack AtomS3 Lite into an RS-485 proxy for Home Assistant. This lets Home Assistant talk to Modbus and other RS-485 devices over the network. Mount the AtomS3 Lite on the ATOMIC RS485 Base to connect the two.",
-          'Home Assistant finds the serial port on its own. Other software must address the port with a URL like <code>esphome://atoms3-lite-rs485-a1b2c3.local/?port_name=RS-485</code>. Replace the host with the hostname or IP address of your device. The serial port is named <code>RS-485</code> by the <a href="https://github.com/esphome/serial-proxies">project configuration</a>. Add <code>&amp;noise_psk=&lt;key&gt;</code> if the device uses API encryption.',
+          'Home Assistant finds the serial port on its own. Other software must address the port with a URL like <code>esphome://atoms3-lite-rs485-a1b2c3.local/?port_name=RS-485</code>. Replace the host with the hostname or IP address of your device. The serial port is named <code>RS-485</code> by the <a href="https://github.com/esphome/serial-proxies">project configuration</a>. Add <code>&amp;noise_psk=&lt;key&gt;</code> if the device uses API encryption. Percent-encode the key first. A base64 key can contain <code>+</code>, and a URL reads <code>+</code> as a space, so write it as <code>%2B</code>.',
         ],
         linksLabel: "This project requires two devices from M5Stack:",
         links: [

--- a/src/data/readyMadeProjects.ts
+++ b/src/data/readyMadeProjects.ts
@@ -348,6 +348,7 @@ export const PROJECT_TYPES: ProjectType[] = [
         title: "M5Stack AtomS3 Lite with ATOMIC RS485 Base",
         body: [
           "Turn an M5Stack AtomS3 Lite into an RS-485 proxy for Home Assistant. This lets Home Assistant talk to Modbus and other RS-485 devices over the network. Mount the AtomS3 Lite on the ATOMIC RS485 Base to connect the two.",
+          'Home Assistant finds the serial port on its own. Other software must address the port with a URL like <code>esphome://atoms3-lite-rs485-a1b2c3.local/?port_name=RS-485</code>. Replace the host with the hostname or IP address of your device. The serial port is named <code>RS-485</code> by the <a href="https://github.com/esphome/serial-proxies">project configuration</a>. Add <code>&amp;noise_psk=&lt;key&gt;</code> if the device uses API encryption.',
         ],
         linksLabel: "This project requires two devices from M5Stack:",
         links: [

--- a/src/data/readyMadeProjects.ts
+++ b/src/data/readyMadeProjects.ts
@@ -348,7 +348,7 @@ export const PROJECT_TYPES: ProjectType[] = [
         title: "M5Stack AtomS3 Lite with ATOMIC RS485 Base",
         body: [
           "Turn an M5Stack AtomS3 Lite into an RS-485 proxy for Home Assistant. This lets Home Assistant talk to Modbus and other RS-485 devices over the network. Mount the AtomS3 Lite on the ATOMIC RS485 Base to connect the two.",
-          'Home Assistant finds the serial port on its own. Other software must address the port with a URL like <code>esphome://atoms3-lite-rs485-a1b2c3.local/?port_name=RS-485</code>. Replace the host with the hostname or IP address of your device. The serial port is named <code>RS-485</code> by the <a href="https://github.com/esphome/serial-proxies">project configuration</a>. Add <code>&amp;noise_psk=&lt;key&gt;</code> if the device uses API encryption. Percent-encode the key first. A base64 key can contain <code>+</code>, and a URL reads <code>+</code> as a space, so write it as <code>%2B</code>.',
+          'Home Assistant finds the serial port on its own. Other software must address the port with a URL like <code>esphome://atoms3-lite-rs485-a1b2c3.local/?port_name=RS-485</code>. Replace the hostname portion ("atoms3-lite-rs485-a1b2c3.local") with the actual hostname or IP address of your device. The serial port is named <code>RS-485</code> by the <a href="https://github.com/esphome/serial-proxies">project configuration</a>. Add <code>&amp;noise_psk=&lt;key&gt;</code> if the device uses API encryption. Percent-encode the key first. A base64 key can contain <code>+</code>, and a URL reads <code>+</code> as a space, so write it as <code>%2B</code>.',
         ],
         linksLabel: "This project requires two devices from M5Stack:",
         links: [


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Home Assistant discovers the serial proxy port on its own and autocompletes it, so the project page never had to state a port address. Other software has no such discovery and needs the `esphome://` URL.

Adds a paragraph to the Serial & Modbus proxy project description giving the URL, the `RS-485` port name set by the project YAML, and the `noise_psk` query argument for encrypted devices.

The port name and URL format match what the code actually uses: Home Assistant passes the `serial_proxy` `name:` through verbatim as `port_name`, and `serialx` parses `port_name`, `noise_psk`/`key` and `password` from the query string with the API port defaulting to `6053`.

The same information is being added to the [serial-proxies](https://github.com/esphome/serial-proxies) README.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- N/A

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>

---
_Generated by [Claude Code](https://claude.ai/code/session_01DM4HSaCvtQBsH7BsZjh2zq)_