### PR TITLE
[zigbee][time]Update Zigbee time source documentation

### DIFF
--- a/src/content/docs/components/time/zigbee.mdx
+++ b/src/content/docs/components/time/zigbee.mdx
@@ -4,8 +4,8 @@ title: "Zigbee Time Source"
 ---
 
 The `zigbee` time platform synchronizes time from the Zigbee coordinator.
-When the device joins the network, it requests the current time from the coordinator
-and on `ESP32` it updates according to `update_interval`.
+When the device joins the network, it requests the current time from the coordinator.
+On `ESP32` the device additionally re-requests the time from the coordinator every `update_interval`.
 
 You first need to set up the [Zigbee](/components/zigbee/) component.
 
@@ -18,7 +18,9 @@ time:
 ## Configuration variables
 
 - **update_interval** (*Optional*, [Time](/guides/configuration-types/)):
-  How often to update the time attribute on `nrf52`. Defaults to `1s` on `nrf52`, for `ESP32` see [Base Time Configuration](/components/time#base_time_config).
+  On `nRF52`, how often the time attribute is updated. Defaults to `1s`.
+  On `ESP32`, how often the time is re-requested from the coordinator; this is the option from
+  [Base Time Configuration](/components/time#base_time_config) and defaults to `15min`.
 - All other options from [Base Time Configuration](/components/time#base_time_config).
 
 ## See Also

--- a/src/content/docs/components/time/zigbee.mdx
+++ b/src/content/docs/components/time/zigbee.mdx
@@ -4,9 +4,8 @@ title: "Zigbee Time Source"
 ---
 
 The `zigbee` time platform synchronizes time from the Zigbee coordinator.
-When the device joins the network, it requests the current time from the coordinator.
-
-This component is only available on **nRF52** platforms.
+When the device joins the network, it requests the current time from the coordinator
+and on `ESP32` it updates according to `update_interval`.
 
 You first need to set up the [Zigbee](/components/zigbee/) component.
 
@@ -19,7 +18,7 @@ time:
 ## Configuration variables
 
 - **update_interval** (*Optional*, [Time](/guides/configuration-types/)):
-  How often to update the time attribute. Defaults to `1s`.
+  How often to update the time attribute on `nrf52`. Defaults to `1s` on `nrf52`, for `ESP32` see [Base Time Configuration](/components/time#base_time_config).
 - All other options from [Base Time Configuration](/components/time#base_time_config).
 
 ## See Also


### PR DESCRIPTION
Add zigbee time component on esp32

<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#18656

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.
