### PR TITLE
Fix test_release_wednesday failing on Sundays

### DIFF
--- a/tests/test_generate_release_notes.py
+++ b/tests/test_generate_release_notes.py
@@ -91,7 +91,7 @@ def _prepare_assembly_inputs(grn: ModuleType, workspace: Path, generator) -> Non
 def test_release_wednesday(grn: ModuleType) -> None:
     wednesday = grn.ReleaseNotesGenerator._release_wednesday()
     assert wednesday.weekday() == 2
-    assert abs(wednesday - datetime.now()) <= timedelta(days=4)
+    assert abs(wednesday - datetime.now()) < timedelta(days=5)
 
 
 def test_blog_post_path_prefers_existing_post(


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

`test_release_wednesday` fails on every Sunday (UTC). `_release_wednesday()` returns `now + timedelta(days=2 - now.weekday())`, which on a Sunday is exactly four days before the `now` it captured. The test then calls `datetime.now()` a second time a few microseconds later, so `abs(wednesday - datetime.now())` comes out as 4 days plus the slop and the `<= timedelta(days=4)` assertion fails:

```
assert datetime.timedelta(days=4, microseconds=9) <= datetime.timedelta(days=4)
```

Seen on #7250, runs [32611659838](https://github.com/esphome/esphome.io/actions/runs/32611659838) and [32611792573](https://github.com/esphome/esphome.io/actions/runs/32611792573); a re-run on the same day fails identically. Any PR against `current` opened on a Sunday hits it.

This compares with `< timedelta(days=5)` instead. The same-week Wednesday is never more than four days away, and a wrong-week result would still be at least seven days off, so the check keeps its intent. Verified by monkeypatching `now()` for each of Mon to Sun with a 10 µs gap between calls: the old assertion fails only on Sunday, the new one passes all seven.

**Related issue (if applicable):** n/a

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- n/a

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
