### PR TITLE
[esp32_ble_tracker] on_ble_advertise fix

### DIFF
--- a/src/content/docs/components/esp32_ble_tracker.mdx
+++ b/src/content/docs/components/esp32_ble_tracker.mdx
@@ -133,20 +133,21 @@ esp32_ble_tracker:
       then:
         - lambda: |-
             ESP_LOGD("ble_adv", "New BLE device");
-            char addr[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
-            ESP_LOGD("ble_adv", "  address: %s", x.address_str_to(addr));
+            char addrbuf[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
+            char uuidbuf[esphome::ble_device_base::UUID_STR_LEN];
+            ESP_LOGD("ble_adv", "  address: %s", x.address_str_to(addrbuf));
             ESP_LOGD("ble_adv", "  name: %s", x.get_name().c_str());
             ESP_LOGD("ble_adv", "  Advertised service UUIDs:");
             for (auto uuid : x.get_service_uuids()) {
-                ESP_LOGD("ble_adv", "    - %s", uuid.to_string().c_str());
+                ESP_LOGD("ble_adv", "    - %s", uuid.to_str(uuidbuf));
             }
             ESP_LOGD("ble_adv", "  Advertised service data:");
             for (auto data : x.get_service_datas()) {
-                ESP_LOGD("ble_adv", "    - %s: (length %i)", data.uuid.to_string().c_str(), data.data.size());
+                ESP_LOGD("ble_adv", "    - %s (length %i)", data.uuid.to_str(uuidbuf), data.data.size());
             }
             ESP_LOGD("ble_adv", "  Advertised manufacturer data:");
             for (auto data : x.get_manufacturer_datas()) {
-                ESP_LOGD("ble_adv", "    - %s: (length %i)", data.uuid.to_string().c_str(), data.data.size());
+               ESP_LOGD("ble_adv", "    - %s (length %i)", data.uuid.to_str(uuidbuf), data.data.size());
             }
 ```
 


### PR DESCRIPTION
refactoring `esp32_ble_tracker`'s `on_ble_advertise` sample code to remove use of ESPBTUUID::to_string() which was deprecated months ago and finally removed by https://github.com/esphome/esphome/pull/17590 in 2026.08

<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes https://github.com/esphome/esphome.io/issues/6471

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [X] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.