### PR TITLE
2026.8.1

### DIFF
--- a/data/version.json
+++ b/data/version.json
@@ -1,5 +1,5 @@
 {
-  "release": "2026.8.0",
+  "release": "2026.8.1",
   "version": "2026.8",
   "blog_url": "/blog/2026/08/19/esphome-2026-8/"
 }

--- a/src/content/docs/blog/2026/08/19/esphome-2026-8.mdx
+++ b/src/content/docs/blog/2026/08/19/esphome-2026-8.mdx
@@ -779,6 +779,31 @@ For detailed migration guides and API documentation, see the
 [ESPHome Developers Documentation](https://developers.esphome.io/).
 {/* BREAKING_CHANGES_DEVELOPERS_END */}
 
+{/* markdownlint-disable MD013 */}
+
+## Release 2026.8.1 - August 24
+
+- [wifi] Take the lwIP core lock around sntp_servermode_dhcp() [esphome#18511](https://github.com/esphome/esphome/pull/18511) by [@SoundGoof](https://github.com/SoundGoof)
+- Bump bundled esphome-device-builder to 1.12.1 [esphome#18541](https://github.com/esphome/esphome/pull/18541) by [@esphome[bot]](https://github.com/apps/esphome)
+- [nrf52] Rebuild the Python env when its interpreter symlink dangles [esphome#18540](https://github.com/esphome/esphome/pull/18540) by [@bdraco](https://github.com/bdraco)
+- [core] Keep templated !include filenames as strings so Windows path normalization cannot corrupt them [esphome#18549](https://github.com/esphome/esphome/pull/18549) by [@bdraco](https://github.com/bdraco)
+- Bump bundled esphome-device-builder to 1.12.2 [esphome#18573](https://github.com/esphome/esphome/pull/18573) by [@esphome[bot]](https://github.com/apps/esphome)
+- [espnow] Fix dump_config crash when enable_on_boot is false [esphome#18572](https://github.com/esphome/esphome/pull/18572) by [@bdraco](https://github.com/bdraco)
+- [emontx] Fix sensor state_class defaults not being applied correctly [esphome#17610](https://github.com/esphome/esphome/pull/17610) by [@FredM67](https://github.com/FredM67)
+- [esp32_hosted] Fire on_update_available trigger when update is detected [esphome#18591](https://github.com/esphome/esphome/pull/18591) by [@swoboda1337](https://github.com/swoboda1337)
+- Bump bundled esphome-device-builder to 1.12.3 [esphome#18601](https://github.com/esphome/esphome/pull/18601) by [@esphome[bot]](https://github.com/apps/esphome)
+- Bump bundled esphome-device-builder to 1.12.4 [esphome#18651](https://github.com/esphome/esphome/pull/18651) by [@esphome[bot]](https://github.com/apps/esphome)
+- [bk72xx_ble] Block BK7238 until the LibreTiny bonding partition fix lands [esphome#18649](https://github.com/esphome/esphome/pull/18649) by [@bdraco](https://github.com/bdraco)
+- [esp32_ble] Log connection parameter update results [esphome#18607](https://github.com/esphome/esphome/pull/18607) by [@bdraco](https://github.com/bdraco)
+- [esp8266] Don't report stale crash state after hardware WDT resets [esphome#18597](https://github.com/esphome/esphome/pull/18597) by [@bdraco](https://github.com/bdraco)
+- [core] Dump the main.cpp config comment with sorted keys [esphome#18653](https://github.com/esphome/esphome/pull/18653) by [@bdraco](https://github.com/bdraco)
+- [esp32] Report abort and task watchdog panics correctly in crash handler [esphome#18575](https://github.com/esphome/esphome/pull/18575) by [@bdraco](https://github.com/bdraco)
+- [core] Retry transient network errors when downloading external files [esphome#18538](https://github.com/esphome/esphome/pull/18538) by [@bdraco](https://github.com/bdraco)
+- [api] Fix loop stall that triggers the task watchdog when entity list sends block [esphome#18577](https://github.com/esphome/esphome/pull/18577) by [@bdraco](https://github.com/bdraco)
+- [esp32_ble_tracker] Scan at the default window while a GATT connection is active [esphome#18609](https://github.com/esphome/esphome/pull/18609) by [@bdraco](https://github.com/bdraco)
+
+{/* markdownlint-enable MD013 */}
+
 ## Full List of Changes
 
 For the complete list of every merged pull request in this release, see the

--- a/src/content/docs/components/esp32_ble_tracker.mdx
+++ b/src/content/docs/components/esp32_ble_tracker.mdx
@@ -79,6 +79,13 @@ sensor:
     WiFi is not using it. Without WiFi, or with `software_coexistence` disabled, it defaults
     to `30ms`.
 
+  - **connection_scan_window** (*Optional*, [Time](/guides/configuration-types#time)): The scan window used
+    while a BLE connection is active, for example while a Bluetooth proxy is connected to a device.
+    A window close to the `interval` value can starve active connections of radio time and cause
+    them to disconnect. Must not be larger than `interval`; the same range and step as `window` apply.
+    When `window` defaults to the `interval` value as described above, this defaults to `30ms`;
+    otherwise scanning keeps using `window` during connections unless this is set.
+
   - **duration** (*Optional*, [Time](/guides/configuration-types#time)): The duration of each complete scan. This has no real
     impact on the device but can be used to debug the BLE stack. Defaults to `5min`.
 

--- a/src/content/docs/guides/supporters.mdx
+++ b/src/content/docs/guides/supporters.mdx
@@ -514,6 +514,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [davidmonro (@davidmonro)](https://github.com/davidmonro)
 - [David Newgas (@davidn)](https://github.com/davidn)
 - [David Noyes (@davidnoyes)](https://github.com/davidnoyes)
+- [David van 't Wout (@DavidvtWout)](https://github.com/DavidvtWout)
 - [David Zovko (@davidzovko)](https://github.com/davidzovko)
 - [Davrosx (@Davrosx)](https://github.com/Davrosx)
 - [Davy Landman (@DavyLandman)](https://github.com/DavyLandman)
@@ -630,6 +631,7 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Mikkel Jeppesen (@Duckle29)](https://github.com/Duckle29)
 - [Sergey Dudanov (@dudanov)](https://github.com/dudanov)
 - [David Girón (@duhow)](https://github.com/duhow)
+- [DukeSniper (@DukeSniper)](https://github.com/DukeSniper)
 - [Duncan Findlay (@duncf)](https://github.com/duncf)
 - [David (@dvanderleij)](https://github.com/dvanderleij)
 - [Dwain Scheeren (@dwainscheeren)](https://github.com/dwainscheeren)
@@ -2387,4 +2389,4 @@ ESPHome was originally founded by [Otto Winter (@OttoWinter)](https://github.com
 - [Josef Zweck (@zweckj)](https://github.com/zweckj)
 - [Zynth-dev (@Zynth-dev)](https://github.com/Zynth-dev)
 
-*This page was last updated August 20, 2026.*
+*This page was last updated August 24, 2026.*


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- Move release notes to blog posts [docs#7230](https://github.com/esphome/esphome.io/pull/7230)
- [install] Bump Device Builder fallback version to 1.1.3 [docs#7224](https://github.com/esphome/esphome.io/pull/7224)
- [blog] Point 2026.8.0 release notes at the Starter Kit [docs#7240](https://github.com/esphome/esphome.io/pull/7240)
- [blog] Add "Read more" links to post cards on blog listings [docs#7241](https://github.com/esphome/esphome.io/pull/7241)
- [blog] Show the tag group in the blog sidebar [docs#7245](https://github.com/esphome/esphome.io/pull/7245)
- [blog] Move 2026 release notes to blog posts [docs#7242](https://github.com/esphome/esphome.io/pull/7242)
- [blog] Move 2024 release notes to blog posts [docs#7244](https://github.com/esphome/esphome.io/pull/7244)
- [blog] Move 2025 release notes to blog posts [docs#7243](https://github.com/esphome/esphome.io/pull/7243)
- Fix test_release_wednesday failing on Sundays [docs#7251](https://github.com/esphome/esphome.io/pull/7251)
- [esp32_ble_tracker] on_ble_advertise fix [docs#7255](https://github.com/esphome/esphome.io/pull/7255)
- [esp32_ble_tracker] Document connection_scan_window [docs#7238](https://github.com/esphome/esphome.io/pull/7238)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
