### PR TITLE
[voice_assistant] Document TTS playback start timeout

### DIFF
--- a/src/content/docs/components/voice_assistant.mdx
+++ b/src/content/docs/components/voice_assistant.mdx
@@ -45,6 +45,8 @@ voice_assistant:
 - **use_wake_word** (*Optional*, boolean): Enable wake word on the assist pipeline. Defaults to `false`.
 - **conversation_timeout** (*Optional*, [Time](/guides/configuration-types#time)): How long to wait before resetting the `conversation_id`
   sent to the voice assist pipeline, which contains the context of the current assist pipeline. Defaults to `300s`.
+- **tts_playback_start_timeout** (*Optional*, [Time](/guides/configuration-types#time)): How long to wait for TTS
+  playback to start before considering the response finished. Defaults to `2s`.
 
 - **on_intent_start** (*Optional*, [Automation](/automations)): An automation to perform when intent processing starts.
 - **on_intent_progress** (*Optional*, [Automation](/automations)): An automation to perform when intent progress happens.


### PR DESCRIPTION
## Description

Documents the optional `tts_playback_start_timeout` setting for the Voice Assistant component, including its purpose and 2 second default. A configurable value accommodates TTS engines such as XTTS when synthesis takes longer than the default before playback begins.

**Related issue (if applicable):** No related issue.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#18707

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull request in [esphome](https://github.com/esphome/esphome) as linked above.
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.
- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook. Not applicable, this updates an existing component page.

Validation:

- ESPHome documentation linter passed.
- Prettier check passed for the changed file.
