### PR TITLE
[audio_http] Document persistent ring buffer

### DIFF
--- a/src/content/docs/components/media_source/audio_http.mdx
+++ b/src/content/docs/components/media_source/audio_http.mdx
@@ -54,6 +54,10 @@ only on trusted networks.
 - **buffer_size** (*Optional*, int): The size of the ring buffer in bytes used to transfer data
   between the HTTP reader and the audio decoder. Minimum is `5000`, maximum is `1000000`. Defaults
   to `50000`.
+- **persistent_ring_buffer** (*Optional*, boolean): Keep the decoder ring buffer allocated between
+  playback sessions. This avoids repeated allocation and release of a contiguous buffer, which can
+  help devices that run several memory-intensive components concurrently. The buffer continues to
+  consume `buffer_size` bytes while playback is stopped. Defaults to `false`.
 - **task_stack_in_psram** (*Optional*, boolean): If `true`, the FreeRTOS decode task stack is
   allocated in PSRAM instead of internal RAM. Requires the [psram](/components/psram/) component. Defaults to `false`.
 - All other options from [Media Source](/components/media_source/).

--- a/src/content/docs/components/media_source/audio_http.mdx
+++ b/src/content/docs/components/media_source/audio_http.mdx
@@ -54,10 +54,12 @@ only on trusted networks.
 - **buffer_size** (*Optional*, int): The size of the ring buffer in bytes used to transfer data
   between the HTTP reader and the audio decoder. Minimum is `5000`, maximum is `1000000`. Defaults
   to `50000`.
-- **persistent_ring_buffer** (*Optional*, boolean): Keep the decoder ring buffer allocated between
-  playback sessions. This avoids repeated allocation and release of a contiguous buffer, which can
-  help devices that run several memory-intensive components concurrently. The buffer continues to
-  consume `buffer_size` bytes while playback is stopped. Defaults to `false`.
+- **persistent_ring_buffer** (*Optional*, boolean): If `true`, pre-allocate the decoder ring buffer
+  when the media source is set up, normally during device startup, and retain it between URL playback
+  sessions. This avoids repeated allocation and release of a contiguous buffer, which can help devices
+  that run several memory-intensive components concurrently. The buffer consumes `buffer_size` bytes
+  while playback is stopped. If pre-allocation fails, allocation is retried when playback starts.
+  Defaults to `false`.
 - **task_stack_in_psram** (*Optional*, boolean): If `true`, the FreeRTOS decode task stack is
   allocated in PSRAM instead of internal RAM. Requires the [psram](/components/psram/) component. Defaults to `false`.
 - All other options from [Media Source](/components/media_source/).


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Document the new `audio_http` `persistent_ring_buffer` option introduced by the
matching ESPHome code change. The documentation explains the allocation
lifecycle, persistent memory cost, use case, and unchanged `false` default.

**Related issue (if applicable):** Not applicable

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#18708

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

No new component or image is added.

</details>
