### PR TITLE
[rp2_ble_tracker] Document automation triggers and scan actions

### DIFF
--- a/src/content/docs/components/rp2_ble_tracker.mdx
+++ b/src/content/docs/components/rp2_ble_tracker.mdx
@@ -3,6 +3,7 @@ description: "Instructions for setting up the RP2 BLE tracker to scan for Blueto
 title: "RP2 BLE Tracker"
 ---
 
+import APIClass from '@components/APIClass.astro';
 import APIRef from '@components/APIRef.astro';
 
 The `rp2_ble_tracker` component scans for Bluetooth Low Energy advertisements on the
@@ -12,9 +13,8 @@ Raspberry Pi **Pico W** and **Pico 2 W** — the platform analog of
 
 Scanning is **active by default**: the tracker sends scan requests asking devices for
 more data, and the scan response (which can carry extra data such as some device names)
-arrives as a separate advertisement report rather than being merged into the
-advertisement. Set `active: false` under `scan_parameters` for a lighter passive
-scan. The radio is shared
+is merged into the advertisement before it is delivered. Set `active: false` under
+`scan_parameters` for a lighter passive scan. The radio is shared
 between WiFi and Bluetooth on these boards; the default scan parameters use a 30% duty
 cycle to leave the radio mostly free for WiFi.
 
@@ -47,18 +47,88 @@ rp2_ble_tracker:
     non-continuous mode the scan stops after this long. Must cover at least three scan
     intervals. Defaults to `5min`.
   - **active** (*Optional*, boolean): Whether to send scan requests asking devices for
-    more data after their advertisement. The scan response arrives as a separate report;
-    it is not merged into the advertisement. Turning this off saves power on the
-    advertising devices and radio time on the shared CYW43439. Defaults to `true`.
+    more data after their advertisement. The scan response is merged into the
+    advertisement before delivery. Turning this off saves power on the advertising
+    devices and radio time on the shared CYW43439. Defaults to `true`.
   - **continuous** (*Optional*, boolean): If true, scanning starts at boot and runs
-    forever. If false, scanning does **not** start automatically; a scan must be started
-    from a lambda (`id(my_tracker).start_scan();`) and stops again after `duration`.
-    Defaults to `true`.
+    forever. If false, scanning does **not** start automatically; a scan is started with
+    the [`rp2_ble_tracker.start_scan` action](#rp2_ble_tracker-start_scan-action) and
+    stops again after `duration`. Defaults to `true`.
 
 - **rp2040_ble_id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify
   the ID of the [RP2040 BLE](/components/rp2040_ble/) component this tracker uses.
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID used
   to reference this component.
+
+Automations:
+
+- **on_ble_advertise** (*Optional*, [Automation](/automations)): An automation to perform
+  when a BLE advertising packet is received. Optionally filtered to a list of
+  `mac_address`es. A variable `x` of type
+  <APIClass text="ble_device_base::ESPBTDevice" path="ble_device_base::ESPBTDevice" /> is
+  passed to the automation for use in lambdas. The shared trigger classes and variables are
+  identical to
+  [ESP32 BLE Tracker](/components/esp32_ble_tracker/#esp32_ble_tracker-on_ble_advertise).
+- **on_ble_manufacturer_data_advertise** (*Optional*, [Automation](/automations)): An
+  automation to perform when a BLE advertising packet with matching manufacturer data is
+  received (`manufacturer_id` required, `mac_address` optional). A variable `x` of type
+  `std::vector<uint8_t>` holds the manufacturer data.
+- **on_ble_service_data_advertise** (*Optional*, [Automation](/automations)): An
+  automation to perform when a BLE advertising packet with service data for
+  `service_uuid` is received (`mac_address` optional). A variable `x` of type
+  `std::vector<uint8_t>` holds the service data.
+- **on_scan_end** (*Optional*, [Automation](/automations)): An automation to perform when
+  a scan period ends: once per `duration` while `continuous` is `true`, when the
+  `duration` of a one-shot scan elapses, and on `rp2_ble_tracker.stop_scan`.
+
+## `rp2_ble_tracker.start_scan` Action
+
+Start a Bluetooth scan. The optional [templatable](/automations/templates#config-templatable)
+`continuous` overrides the scan mode until the next `start_scan` or `stop_scan` (the
+YAML-configured value itself is untouched); without it the mode configured under
+`scan_parameters` is restored (a previous `stop_scan` does not stick as "one-shot"). This
+differs from `esp32_ble_tracker.start_scan`, where an omitted `continuous` always forces a
+one-shot scan. Invoked while a scan is already running, a mode switch re-anchors the running
+scan's `duration` window; a same-mode call is a no-op.
+
+```yaml
+rp2_ble_tracker:
+  scan_parameters:
+    continuous: false
+
+api:
+  on_client_connected:
+    - rp2_ble_tracker.start_scan:
+        continuous: true
+  on_client_disconnected:
+    # fires for EVERY departing client (log viewer, CLI) — state_subscription_only
+    # ignores logger-only clients, so scanning stops only when Home Assistant is gone
+    - if:
+        condition:
+          not:
+            api.connected:
+              state_subscription_only: true
+        then:
+          - rp2_ble_tracker.stop_scan:
+```
+
+### Configuration variables
+
+- **continuous** (*Optional*, [templatable](/automations/templates#config-templatable), boolean):
+  Override the scan mode until the next `start_scan` or `stop_scan` (the YAML-configured value
+  itself is untouched). When omitted, the mode configured under `scan_parameters` is
+  restored — a previous `stop_scan` does not stick as "one-shot".
+
+## `rp2_ble_tracker.stop_scan` Action
+
+Stop the running Bluetooth scan; also cancels a start latched before setup. Accepts the
+bare-id shorthand (`rp2_ble_tracker.stop_scan: my_tracker`). It can be restarted with
+`rp2_ble_tracker.start_scan`.
+
+```yaml
+on_...:
+  - rp2_ble_tracker.stop_scan:
+```
 
 ## See Also
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Documents the automation surface added in [esphome/esphome#18717](https://github.com/esphome/esphome/pull/18717): the four advertisement/scan-end triggers and the `start_scan`/`stop_scan` actions with the restore-configured-mode semantics, replacing the previous lambda-only guidance and the stale non-merged scan-response note. Follows the structure of the bk72xx/ln882h tracker pages.

**Related issue (if applicable):** n/a

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#18717

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.
  <!-- Not applicable: `rp2_ble_tracker` is an existing page, already linked. -->
