### PR TITLE
[blog] Fix link to Signed OTA Verification documentation

### DIFF
--- a/src/content/docs/blog/2026/08/19/esphome-2026-8.mdx
+++ b/src/content/docs/blog/2026/08/19/esphome-2026-8.mdx
@@ -467,7 +467,7 @@ with a compiled-in trusted key list ([#17981](https://github.com/esphome/esphome
 accepted if any of up to three signature blocks matches a trusted key, which enables signing key rotation
 (dual-sign a bridge release with old and new keys) and independent backup keys across signing providers.
 Bootloader updates are now signature-checked as well, closing a path where they previously installed unverified.
-See the [OTA documentation](/components/ota/) for setup.
+See the [Signed OTA Verification documentation](/components/esp32/#signed-ota-verification) for setup.
 
 ## Voice and Media
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

The blog post section about OTA verification links to the OTA component for more information, but this is incorrect; the docs for OTA verification are in the `esp32` component docs.

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
