### PR TITLE
[http_request] Document the ESP32 watchdog_timeout default

### DIFF
--- a/src/content/docs/components/http_request.mdx
+++ b/src/content/docs/components/http_request.mdx
@@ -18,6 +18,8 @@ http_request:
 - **follow_redirects** (*Optional*, boolean): Enable following HTTP redirects. Defaults to `true`.
 - **redirect_limit** (*Optional*, integer): Maximum amount of redirects to follow when enabled. Defaults to `3`.
 - **timeout** (*Optional*, [Time](/guides/configuration-types#time)): Timeout for request. Defaults to `4.5s`.
+  On ESP32 this applies to each network operation (DNS lookup, connect, TLS handshake, every read and write)
+  rather than to the request as a whole.
 - **useragent** (*Optional*, string): User-Agent header for requests. Defaults to
   `ESPHome/<version> (https://esphome.io)` where `<version>` is the version of ESPHome the device is running.
   For example: `ESPHome/2024.6.0 (https://esphome.io)`
@@ -28,7 +30,10 @@ http_request:
   Mozilla's NSS root certificate store. **Supported on ESP32 only; must be explicitly set to false on other platforms.**
 
 - **watchdog_timeout** (*Optional*, [Time](/guides/configuration-types#time)): Change the watchdog timeout during connection/data transfer.
-  May be useful on slow connections or connections with high latency. **Do not change this value unless you are
+  May be useful on slow connections or connections with high latency. On ESP32 this defaults to three times
+  `timeout` plus one second, and never less than the `watchdog_timeout` set in the [ESP32 platform](/components/esp32)
+  configuration; requests run on the main loop, so without this the task watchdog could reboot the device while a
+  request waits on a slow server. On RP2040 there is no default. **Do not raise this value unless you are
   experiencing device reboots due to watchdog timeouts;** doing so may prevent the device from rebooting due to a
   legitimate problem. **Only available on ESP32 and RP2040**.
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

`http_request` now defaults `watchdog_timeout` on ESP32 to three times `timeout` plus one second, never below the ESP32 platform `watchdog_timeout`; this documents that default and notes that `timeout` applies per network operation on ESP32.

**Related issue (if applicable):** related to https://github.com/esphome/esphome/issues/18016

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#18732

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
