### PR TITLE
[blog] Repoint cross-release links at release notes blog posts

### DIFF
--- a/src/content/docs/blog/2026/02/18/esphome-2026-2.mdx
+++ b/src/content/docs/blog/2026/02/18/esphome-2026-2.mdx
@@ -124,7 +124,7 @@ Memory allocations were also removed from discovery messages ([#13216](https://g
 
 ## Security Hardening
 
-Our first internal security audit in [2025.10.0](/blog/2025/10/15/esphome-2025-10/#security-enhancements) led to several deprecations, most of which were completed in [2026.1.0](/changelog/2026.1.0/). This release started a new review cycle. No issues requiring deprecation were found, but we identified several additional hardening opportunities.
+Our first internal security audit in [2025.10.0](/blog/2025/10/15/esphome-2025-10/#security-enhancements) led to several deprecations, most of which were completed in [2026.1.0](/blog/2026/01/21/esphome-2026-1/). This release started a new review cycle. No issues requiring deprecation were found, but we identified several additional hardening opportunities.
 
 - **Constant-time authentication** - The dashboard ([#13865](https://github.com/esphome/esphome/pull/13865)) and web server ([#13868](https://github.com/esphome/esphome/pull/13868)) now use constant-time string comparisons for Basic Auth credential checks, preventing timing-based side-channel attacks
 - **Cryptographic random generation** - The OTA component ([#13863](https://github.com/esphome/esphome/pull/13863)) and setup wizard ([#13864](https://github.com/esphome/esphome/pull/13864)) now use Python's `secrets` module for generating authentication nonces and fallback AP passwords, replacing less secure random sources
@@ -238,7 +238,7 @@ The existing `on_open` trigger has been renamed to `on_opened` (the old name is 
 
 ## Looking Ahead
 
-This release continues the work that began in [2025.10.0](/changelog/2025.10.0/) and accelerated in [2026.1.0](/changelog/2026.1.0/): making ESPHome leaner and more reliable on every platform. Fewer heap allocations, smaller firmware, and lower CPU usage all contribute to devices that stay stable for months and years. That focus on memory discipline and long-term stability will continue in future releases as we extend these improvements to more components and platforms.
+This release continues the work that began in [2025.10.0](/blog/2025/10/15/esphome-2025-10/) and accelerated in [2026.1.0](/blog/2026/01/21/esphome-2026-1/): making ESPHome leaner and more reliable on every platform. Fewer heap allocations, smaller firmware, and lower CPU usage all contribute to devices that stay stable for months and years. That focus on memory discipline and long-term stability will continue in future releases as we extend these improvements to more components and platforms.
 
 On the documentation side, [esphome.io](https://esphome.io) has migrated from Hugo to [Starlight](https://starlight.astro.build/), bringing faster page loads, improved search, and a modern documentation framework that will make it easier to maintain and contribute to the docs going forward.
 {/* FEATURE_HIGHLIGHTS_END */}

--- a/src/content/docs/blog/2026/04/15/esphome-2026-4.mdx
+++ b/src/content/docs/blog/2026/04/15/esphome-2026-4.mdx
@@ -266,7 +266,7 @@ This release introduces comprehensive C++ benchmarking infrastructure using [Cod
 - **Float zero checks**: Integer comparison instead of floating-point ([#15490](https://github.com/esphome/esphome/pull/15490))
 - **Code size reduction**: Buffer and nodelay optimizations ([#14797](https://github.com/esphome/esphome/pull/14797))
 - **Overflow buffer extracted**: Frame helper buffer management simplified ([#14871](https://github.com/esphome/esphome/pull/14871))
-- **Noise encryption speedup**: Continuing from the [ChaCha20-Poly1305 optimization in 2026.3.0](/changelog/2026.3.0) (which achieved 8-32% faster encryption), this release enables `HAVE_WEAK_SYMBOLS` and `HAVE_INLINE_ASM` for libsodium, replacing a volatile byte-by-byte `sodium_memzero()` fallback with word-sized `memset()`. Small messages (the common case for sensor updates and service calls) see the biggest gains: **24% faster on ESP32, 11% on ESP8266, 10% on RP2040** ([#15038](https://github.com/esphome/esphome/pull/15038))
+- **Noise encryption speedup**: Continuing from the [ChaCha20-Poly1305 optimization in 2026.3.0](/blog/2026/03/18/esphome-2026-3/#api-and-protobuf-performance) (which achieved 8-32% faster encryption), this release enables `HAVE_WEAK_SYMBOLS` and `HAVE_INLINE_ASM` for libsodium, replacing a volatile byte-by-byte `sodium_memzero()` fallback with word-sized `memset()`. Small messages (the common case for sensor updates and service calls) see the biggest gains: **24% faster on ESP32, 11% on ESP8266, 10% on RP2040** ([#15038](https://github.com/esphome/esphome/pull/15038))
 - **Noise handshake**: Split state_action_ to reduce stack pressure ([#15464](https://github.com/esphome/esphome/pull/15464))
 - **PSK update**: Avoided heap allocation in timeout lambda ([#14921](https://github.com/esphome/esphome/pull/14921))
 - **Batch encoding**: Simplified encode_to_buffer to single resize call, inlined DeferredBatch::add_item ([#15355](https://github.com/esphome/esphome/pull/15355), [#15353](https://github.com/esphome/esphome/pull/15353))
@@ -419,7 +419,7 @@ climate:
 
 ### Codebase Correctness Sweep
 
-Continuing the [correctness sweep started in 2026.3.0](/changelog/2026.3.0), [@swoboda1337](https://github.com/swoboda1337) contributed another **99 bug fix and validation PRs** in this release, addressing missing `state_class` and `device_class` on sensor schemas, incorrect config validation (wrong types, missing range checks, broken `ensure_list` usage), dead code removal, format specifier warnings, and codegen type mismatches across 100+ components. This sustained effort has significantly improved the reliability and correctness of the ESPHome codebase.
+Continuing the [correctness sweep started in 2026.3.0](/blog/2026/03/18/esphome-2026-3/#codebase-correctness-sweep), [@swoboda1337](https://github.com/swoboda1337) contributed another **99 bug fix and validation PRs** in this release, addressing missing `state_class` and `device_class` on sensor schemas, incorrect config validation (wrong types, missing range checks, broken `ensure_list` usage), dead code removal, format specifier warnings, and codegen type mismatches across 100+ components. This sustained effort has significantly improved the reliability and correctness of the ESPHome codebase.
 
 ## Thank You, Contributors
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Follow-up to #7242, #7243 and #7244. Those PRs moved the human-written release notes out of the changelog pages and into dated blog posts, but because they were developed in parallel, links that crossed between year ranges could not be fixed on any single branch.

Four links in the 2026.2.0 and 2026.4.0 posts still pointed at changelog pages for narrative that now lives on the blog:

- `esphome-2026-2.mdx` - `[2026.1.0]` in the Security Hardening paragraph (its sibling link in the same sentence already pointed at the blog post), and `[2025.10.0]` / `[2026.1.0]` in Looking Ahead.
- `esphome-2026-4.mdx` - `[ChaCha20-Poly1305 optimization in 2026.3.0]` and `[correctness sweep started in 2026.3.0]`, now pointing at the `#api-and-protobuf-performance` and `#codebase-correctness-sweep` sections of the 2026.3.0 post. These two were also missing the trailing slash.

Only link targets changed; no prose was rewritten. The `[full YYYY.M.0 changelog]` links at the foot of each post still point at the changelog pages, which is correct.

A full sweep of `src/` found no remaining links to anchors that no longer exist on the changelog pages, and all 30 changelog pointer paragraphs for 2024-2026 target their own blog post. Verified by parsing every anchored internal `href` out of the built `dist/**/*.html` and checking the target `id` exists.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.