### PR TITLE
Use explicit !lambda for homeassistant action variables

### DIFF
--- a/src/content/docs/components/api.mdx
+++ b/src/content/docs/components/api.mdx
@@ -173,7 +173,8 @@ on_...:
   This is evaluated on the Home Assistant side with Home Assistant's templating engine.
 
 - **variables** (*Optional*, mapping): Optional variables that can be used in the `data_template`.
-  Values are [lambdas](/automations/templates#config-lambda) and will be evaluated before sending the request.
+  A value tagged with `!lambda` is a [lambda](/automations/templates#config-lambda) evaluated on the device
+  before sending the request; any other value is sent as a static string.
 
 ### `homeassistant.action` Action
 
@@ -199,7 +200,7 @@ on_...:
       data_template:
         message: The humidity is {{ my_variable }}%.
       variables:
-        my_variable: |-
+        my_variable: !lambda |-
           return id(my_sensor).state;
 ```
 
@@ -213,7 +214,8 @@ on_...:
   This is evaluated on the Home Assistant side with Home Assistant's templating engine.
 
 - **variables** (*Optional*, mapping): Optional variables that can be used in the `data_template`.
-  Values are [lambdas](/automations/templates#config-lambda) and will be evaluated before sending the request.
+  A value tagged with `!lambda` is a [lambda](/automations/templates#config-lambda) evaluated on the device
+  before sending the request; any other value is sent as a static string.
 
 - **capture_response** (*Optional*, boolean): Enable capturing the response from the Home Assistant action call.
   When enabled, `on_success` must be configured. Defaults to `false`.


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

`variables` values for `homeassistant.event` and `homeassistant.action` are being changed to require an explicit `!lambda` tag; a plain string that looks like lambda source keeps working for six months with a deprecation warning, any other plain string is sent as a static value. During the window a value containing both a semicolon and the word return is treated as lambda source, so such literal text fails the C++ build instead of being sent verbatim. This updates the example and the option descriptions to the explicit form. Note that `homeassistant.action` previously rejected an untagged non lambda string with a validation error; such values are now sent as static text, as the updated descriptions state.

**Related issue (if applicable):** fixes esphome/issues#5394

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#18759

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.
