### PR TITLE
[epaper_spi] Document full_refresh_after_deep_sleep

### DIFF
--- a/src/content/docs/components/display/epaper_spi.mdx
+++ b/src/content/docs/components/display/epaper_spi.mdx
@@ -112,6 +112,23 @@ but can be overridden if needed.
   use `never` to only manually update the screen via `component.update`.
 - **full_update_every** (*Optional*, int): On screens that support partial updates, this sets the number of updates
   before a full update is forced. Defaults to `1` which will make every update a full update.
+- **full_refresh_after_deep_sleep** (*Optional*, boolean): Whether to force a full update on the first refresh after
+  waking from [deep sleep](/components/deep_sleep). Defaults to `true`. Only has an effect when `full_update_every`
+  is greater than `1`.
+
+  The count of updates since the last full update is kept in RAM, so it is normally lost during deep sleep and the
+  first refresh after each wake is a full one. Set this to `false` to save the count and carry on with the partial
+  update cycle after waking, which avoids the flicker and the extra power of a full refresh on every wake.
+
+  > [!WARNING]
+  > Only set this to `false` if your board keeps the display powered while the ESP32 sleeps. A partial update draws
+  > only the pixels that changed, so it needs the previous image still held in the display's own memory. If the
+  > display loses power during sleep that image is gone, and partial updates will leave artefacts on screen until
+  > the next full update.
+
+  Only a wake from deep sleep continues the cycle. After any other reset, such as a power cycle or a reboot, the
+  first refresh is a full update. Carrying the cycle across deep sleep is supported on the ESP32 only; on other
+  platforms setting this to `false` has no effect and every wake still starts with a full update.
 - **spi_id** (*Optional*, [ID](/guides/configuration-types#id)): Required to specify the ID of the [SPI Component](/components/spi) if your
   configuration defines multiple SPI buses. If only a single SPI bus is configured, this is optional.
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID used for code generation.


### PR DESCRIPTION
Documents the option added in esphome/esphome#18074.

<!-- markdownlint-disable -->

## Description

Documents the new `full_refresh_after_deep_sleep` option on the `epaper_spi` display, added under
`full_update_every` since it changes how that option behaves across deep sleep.

The entry covers the default (`true`, unchanged behaviour), what setting it to `false` does, and the
two conditions a reader needs to know about: the panel must stay powered while the ESP32 sleeps, and
only a wake from deep sleep resumes the cycle.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#18074

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.
  Not applicable: this documents an option on the existing `epaper_spi` page, which is already linked in the index.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
