### PR TITLE
[hoermann_hcp] Document fragility of HCP2 bus

### DIFF
--- a/src/content/docs/components/cover/hoermann_hcp.mdx
+++ b/src/content/docs/components/cover/hoermann_hcp.mdx
@@ -28,12 +28,12 @@ The following Series 4 motors communicate over the HCP bus (Modbus RTU) and shou
 >
 > Disrupting Modbus connectivity for any reason may render the motor **temporarily inoperable**.
 >
-> If this happens, all controls will be unresponsive in this error state, including BiSecur hand remotes.
+> If this happens, the motor will be unresponsive to all controls in this error state, including BiSecur hand remotes.
 > Ensure you have emergency access to your garage at all times,
 > as this type of error can only be cleared by power-cycling the motor.
 
 > [!IMPORTANT]
-> Updating ESPHome via OTA **will** trigger the aforementioned motor error.
+> Restarting the ESPHome device (including OTA updates) **will** trigger the motor error described above.
 
 Communication with the motor happens over [Modbus](/components/modbus/) with the `role` set to
 `server`, which in turn requires a [UART bus](/components/uart/). The UART **must** be configured with

--- a/src/content/docs/components/cover/hoermann_hcp.mdx
+++ b/src/content/docs/components/cover/hoermann_hcp.mdx
@@ -23,6 +23,18 @@ The following Series 4 motors communicate over the HCP bus (Modbus RTU) and shou
 > This component implements the same protocol as the [HCPBridge](https://github.com/hkiam/HCPBridge)
 > project.
 
+> [!CAUTION]
+> HCP2 accessories are not hot-pluggable!
+>
+> Disrupting Modbus connectivity for any reason will render the motor **temporarily inoperable**.
+>
+> All controls will be unresponsive in this error state, including BiSecur hand remotes.
+> Ensure you have emergency access to your garage at all times,
+> as this type of error can only be cleared by power-cycling the motor.
+
+> [!IMPORTANT]
+> Updating ESPHome via OTA **will** trigger the aforementioned motor error.
+
 Communication with the motor happens over [Modbus](/components/modbus/) with the `role` set to
 `server`, which in turn requires a [UART bus](/components/uart/). The UART **must** be configured with
 a baud rate of `57600`, even parity and one stop bit.

--- a/src/content/docs/components/cover/hoermann_hcp.mdx
+++ b/src/content/docs/components/cover/hoermann_hcp.mdx
@@ -26,9 +26,9 @@ The following Series 4 motors communicate over the HCP bus (Modbus RTU) and shou
 > [!CAUTION]
 > HCP2 accessories are not hot-pluggable!
 >
-> Disrupting Modbus connectivity for any reason will render the motor **temporarily inoperable**.
+> Disrupting Modbus connectivity for any reason may render the motor **temporarily inoperable**.
 >
-> All controls will be unresponsive in this error state, including BiSecur hand remotes.
+> If this happens, all controls will be unresponsive in this error state, including BiSecur hand remotes.
 > Ensure you have emergency access to your garage at all times,
 > as this type of error can only be cleared by power-cycling the motor.
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

As described in the linked issue, the HCP2 bus is somewhat fragile and doesn't tolerate accessories suddenly disappearing. This includes but is not limited to ESPHome OTA updates or manual restarts.

There's also a health & safety aspect to this. Again, see the original issue for context. 😳

**Related issue (if applicable):** https://github.com/esphome/esphome/issues/18739

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- N/A

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.