### PR TITLE
Add uart_id option to improv_serial

### DIFF
--- a/src/content/docs/components/improv_serial.mdx
+++ b/src/content/docs/components/improv_serial.mdx
@@ -8,7 +8,9 @@ import APIRef from '@components/APIRef.astro';
 The `improv_serial` component in ESPHome implements the open [Improv standard](https://www.improv-wifi.com/)
 for configuring Wi-Fi on an ESPHome device by using a serial connection to the device, eg. USB.
 
-The `improv_serial` component requires the serial `logger` to be configured.
+By default the `improv_serial` component shares the serial port used by the `logger`, which must be
+configured. With `uart_id` it uses a dedicated [UART bus](/components/uart) instead, leaving the
+logger's serial settings untouched.
 
 The `improv_serial` component will use the project name and version instead of ESPHomes version whenever it's available.
 
@@ -23,6 +25,7 @@ improv_serial:
 ## Configuration variables
 
 - **next_url** (*Optional*, url): A URL that can be used to forward the user to after setting credentials with improv.
+- **uart_id** (*Optional*, [ID](/guides/configuration-types#id)): Run Improv on this [UART bus](/components/uart) instead of the logger's serial port.
 
 ## Next URL
 

--- a/src/content/docs/components/improv_serial.mdx
+++ b/src/content/docs/components/improv_serial.mdx
@@ -8,9 +8,10 @@ import APIRef from '@components/APIRef.astro';
 The `improv_serial` component in ESPHome implements the open [Improv standard](https://www.improv-wifi.com/)
 for configuring Wi-Fi on an ESPHome device by using a serial connection to the device, eg. USB.
 
-The `improv_serial` component requires the `logger`. By default Improv shares the logger's serial
-port; with `uart_id` it runs on a dedicated [UART bus](/components/uart) instead, and the logger's
-serial settings are not used (serial logging may even be disabled with `baud_rate: 0`).
+The `improv_serial` component requires the [`logger`](/components/logger/) component. By default Improv
+shares the logger's serial port. When `uart_id` is set, Improv runs on a dedicated
+[UART bus](/components/uart/) instead and the logger's serial settings are unused, so serial logging can
+be disabled with `baud_rate: 0`.
 
 The `improv_serial` component will use the project name and version instead of ESPHomes version whenever it's available.
 
@@ -25,7 +26,8 @@ improv_serial:
 ## Configuration variables
 
 - **next_url** (*Optional*, url): A URL that can be used to forward the user to after setting credentials with improv.
-- **uart_id** (*Optional*, [ID](/guides/configuration-types#id)): Run Improv on this [UART bus](/components/uart) instead of the logger's serial port. The bus needs both `tx_pin` and `rx_pin`.
+- **uart_id** (*Optional*, [ID](/guides/configuration-types#id)): Run Improv on this [UART bus](/components/uart/)
+  instead of the logger's serial port. The bus needs both `tx_pin` and `rx_pin`.
 
 ## Next URL
 
@@ -40,6 +42,22 @@ that can be performed by ESPHome when wrapped in double braces `{{ }}`  :
 # Example next_url
 improv_serial:
   next_url: http://example.com/?device_name={{device_name}}&ip_address={{ip_address}}&esphome_version={{esphome_version}}
+```
+
+## Dedicated UART
+
+Improv normally shares the serial port used for logging. To run it on its own port instead, point
+`uart_id` at a UART bus with both pins configured:
+
+```yaml
+uart:
+  - id: improv_uart
+    tx_pin: GPIOXX
+    rx_pin: GPIOXX
+    baud_rate: 115200
+
+improv_serial:
+  uart_id: improv_uart
 ```
 
 ## See Also

--- a/src/content/docs/components/improv_serial.mdx
+++ b/src/content/docs/components/improv_serial.mdx
@@ -8,9 +8,9 @@ import APIRef from '@components/APIRef.astro';
 The `improv_serial` component in ESPHome implements the open [Improv standard](https://www.improv-wifi.com/)
 for configuring Wi-Fi on an ESPHome device by using a serial connection to the device, eg. USB.
 
-By default the `improv_serial` component shares the serial port used by the `logger`, which must be
-configured. With `uart_id` it uses a dedicated [UART bus](/components/uart) instead, leaving the
-logger's serial settings untouched.
+The `improv_serial` component requires the `logger`. By default Improv shares the logger's serial
+port; with `uart_id` it runs on a dedicated [UART bus](/components/uart) instead, and the logger's
+serial settings are not used (serial logging may even be disabled with `baud_rate: 0`).
 
 The `improv_serial` component will use the project name and version instead of ESPHomes version whenever it's available.
 
@@ -25,7 +25,7 @@ improv_serial:
 ## Configuration variables
 
 - **next_url** (*Optional*, url): A URL that can be used to forward the user to after setting credentials with improv.
-- **uart_id** (*Optional*, [ID](/guides/configuration-types#id)): Run Improv on this [UART bus](/components/uart) instead of the logger's serial port.
+- **uart_id** (*Optional*, [ID](/guides/configuration-types#id)): Run Improv on this [UART bus](/components/uart) instead of the logger's serial port. The bus needs both `tx_pin` and `rx_pin`.
 
 ## Next URL
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Documents the new optional `uart_id` setting for `improv_serial`; when set, Improv runs on a dedicated UART bus instead of the logger's serial port.

**Related issue (if applicable):**

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#18794

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
