### PR TITLE
[light] Document ``effect`` in ``initial_state``

### DIFF
--- a/src/content/docs/components/light/index.mdx
+++ b/src/content/docs/components/light/index.mdx
@@ -51,6 +51,10 @@ light:
   when the state is **not** restored based on `restore_mode` (below).
 
   - **state** (*Optional*, boolean, [templatable](/automations/templates)): The ON/OFF state for the light.
+  - **effect** (*Optional*, string): The name of the [effect](#light-effects) to start with, so the light can come up
+    already running an effect without an `on_boot` automation. Must match the name of one of the effects defined on
+    the same light, or `none` for no effect. This only has an effect when the light starts up ON: an effect is not
+    started for a light that boots OFF.
   - All other options from [light state](#light-state).
 
 - **restore_mode** (*Optional*): Control how the light attempts to restore state on bootup.

--- a/src/content/docs/components/light/index.mdx
+++ b/src/content/docs/components/light/index.mdx
@@ -54,7 +54,9 @@ light:
   - **effect** (*Optional*, string): The name of the [effect](#light-effects) to start with, so the light can come up
     already running an effect without an `on_boot` automation. Must match the name of one of the effects defined on
     the same light, or `none` for no effect. This only has an effect when the light starts up ON: an effect is not
-    started for a light that boots OFF.
+    started for a light that boots OFF. Note that turning the light off stops the running effect, so an effect does
+    not resume by itself the next time the light is turned on — select it again, or set it in `initial_state` and
+    let the light boot into it.
   - All other options from [light state](#light-state).
 
 - **restore_mode** (*Optional*): Control how the light attempts to restore state on bootup.


### PR DESCRIPTION
## Description

Documents the new `initial_state: effect:` option for lights, which lets a light come up with an effect already running instead of needing an `on_boot` + `light.turn_on` automation.

The wording calls out the two constraints a user would otherwise hit:

- the name must match an effect defined on the **same** light (validated at config time), or `none`
- it only applies when the light boots **ON** — an effect is cleared for a light that is turning off

## Related

Companion to esphome/esphome#18795, which adds the option.

## Checklist

- [x] I am merging into `current` because it documents a change that is not yet released.
