### PR TITLE
[mipi_rgb] Add Crowpanel Advance 7

### DIFF
--- a/src/content/docs/components/display/mipi_rgb.mdx
+++ b/src/content/docs/components/display/mipi_rgb.mdx
@@ -27,9 +27,9 @@ specified, or a custom init sequence can be provided.
 
 | Driver Chip | Typical Dimensions |
 | ----------- | ------------------ |
-| ST7701S     | 480x480            |
-| RPI         | varies             |
 | CUSTOM      | varies             |
+| RPI         | varies             |
+| ST7701S     | 480x480            |
 
 The `RPI` driver chip represents displays without an SPI interface, so no init sequence is required. The `CUSTOM`
 model has no predefined config options so requires a full yaml configuration.
@@ -39,20 +39,21 @@ model has no predefined config options so requires a full yaml configuration.
 These boards have completely pre-filled configurations for the display driver, so the only required configuration
 option is `model`.
 
-| Board                        | Driver Chip | Manufacturer | Product link                                                     |
-|------------------------------|-------------| ------------ |------------------------------------------------------------------|
-| GUITION-4848S040             | ST7701s     | Guition      | [https://devices.esphome.io/devices/Guition-ESP32-S3-4848S040](https://devices.esphome.io/devices/Guition-ESP32-S3-4848S040)   |
-| T-PANEL-S3                   | ST7701s     | Lilygo       | [https://lilygo.cc/products/t-panel-s3](https://lilygo.cc/products/t-panel-s3)                          |
-| T-RGB-2.1                    | ST7701s     | Lilygo       | [https://lilygo.cc/products/t-rgb](https://lilygo.cc/products/t-rgb)                               |
-| T-RGB-2.8                    | ST7701s     | Lilygo       | [https://lilygo.cc/products/t-rgb](https://lilygo.cc/products/t-rgb)                               |
-| SEEED-INDICATOR-D1           | ST7701s     | Seeed Studio | [https://www.seeedstudio.com/SenseCAP-Indicator-D1L-p-5646.html](https://www.seeedstudio.com/SenseCAP-Indicator-D1L-p-5646.html) |
-| ESP32-8048S050              | RPI         | Sunton       | [https://www.makerfabs.com/sunton-esp32-s3-5-inch-ips-with-touch.html](https://www.makerfabs.com/sunton-esp32-s3-5-inch-ips-with-touch.html)  |
-| ESP32-8048S070              | RPI         | Sunton       | [https://www.makerfabs.com/sunton-esp32-s3-7-inch-tn-display-with-touch.html](https://www.makerfabs.com/sunton-esp32-s3-7-inch-tn-display-with-touch.html) |
-| ESP32-S3-TOUCH-LCD-4.3       | RPI         | Waveshare    | [https://www.waveshare.com/esp32-s3-touch-lcd-4.3.htm](https://www.waveshare.com/esp32-s3-touch-lcd-4.3.htm)           |
-| ESP32-S3-TOUCH-LCD-7-800X480 | RPI         | Waveshare    | [https://www.waveshare.com/esp32-s3-touch-lcd-7.htm](https://www.waveshare.com/esp32-s3-touch-lcd-7.htm)             |
-| WAVESHARE-3.16-320X820       | ST7701s     | Waveshare    | [https://www.waveshare.com/esp32-s3-lcd-3.16.htm](https://www.waveshare.com/esp32-s3-lcd-3.16.htm)                |
-| WAVESHARE-4-480X480          | RPI         | Waveshare    | [https://www.waveshare.com/esp32-s3-touch-lcd-4.htm](https://www.waveshare.com/esp32-s3-touch-lcd-4.htm)             |
-| WAVESHARE-5-1024X600         | RPI         | Waveshare    | [https://www.waveshare.com/esp32-s3-touch-lcd-5.htm](https://www.waveshare.com/esp32-s3-touch-lcd-5.htm)             |
+| Board                        | Driver Chip | Manufacturer | Product link                                                                                                                                                                                             |
+|------------------------------|-------------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| CROWPANEL-ADVANCE-7          | RPI         | Elecrow      | [https://www.elecrow.com/crowpanel-advance-7-hmi-esp32-ai-display-800x480-ai-ips-touch-screen.html](https://www.elecrow.com/crowpanel-advance-7-hmi-esp32-ai-display-800x480-ai-ips-touch-screen.html) |
+| ESP32-8048S050               | RPI         | Sunton       | [https://www.makerfabs.com/sunton-esp32-s3-5-inch-ips-with-touch.html](https://www.makerfabs.com/sunton-esp32-s3-5-inch-ips-with-touch.html)                                                           |
+| ESP32-8048S070               | RPI         | Sunton       | [https://www.makerfabs.com/sunton-esp32-s3-7-inch-tn-display-with-touch.html](https://www.makerfabs.com/sunton-esp32-s3-7-inch-tn-display-with-touch.html)                                             |
+| ESP32-S3-TOUCH-LCD-4.3       | RPI         | Waveshare    | [https://www.waveshare.com/esp32-s3-touch-lcd-4.3.htm](https://www.waveshare.com/esp32-s3-touch-lcd-4.3.htm)                                                                                           |
+| ESP32-S3-TOUCH-LCD-7-800X480 | RPI         | Waveshare    | [https://www.waveshare.com/esp32-s3-touch-lcd-7.htm](https://www.waveshare.com/esp32-s3-touch-lcd-7.htm)                                                                                               |
+| GUITION-4848S040             | ST7701s     | Guition      | [https://devices.esphome.io/devices/Guition-ESP32-S3-4848S040](https://devices.esphome.io/devices/Guition-ESP32-S3-4848S040)                                                                           |
+| SEEED-INDICATOR-D1           | ST7701s     | Seeed Studio | [https://www.seeedstudio.com/SenseCAP-Indicator-D1L-p-5646.html](https://www.seeedstudio.com/SenseCAP-Indicator-D1L-p-5646.html)                                                                       |
+| T-PANEL-S3                   | ST7701s     | Lilygo       | [https://lilygo.cc/products/t-panel-s3](https://lilygo.cc/products/t-panel-s3)                                                                                                                         |
+| T-RGB-2.1                    | ST7701s     | Lilygo       | [https://lilygo.cc/products/t-rgb](https://lilygo.cc/products/t-rgb)                                                                                                                                   |
+| T-RGB-2.8                    | ST7701s     | Lilygo       | [https://lilygo.cc/products/t-rgb](https://lilygo.cc/products/t-rgb)                                                                                                                                   |
+| WAVESHARE-3.16-320X820       | ST7701s     | Waveshare    | [https://www.waveshare.com/esp32-s3-lcd-3.16.htm](https://www.waveshare.com/esp32-s3-lcd-3.16.htm)                                                                                                     |
+| WAVESHARE-4-480X480          | RPI         | Waveshare    | [https://www.waveshare.com/esp32-s3-touch-lcd-4.htm](https://www.waveshare.com/esp32-s3-touch-lcd-4.htm)                                                                                               |
+| WAVESHARE-5-1024X600         | RPI         | Waveshare    | [https://www.waveshare.com/esp32-s3-touch-lcd-5.htm](https://www.waveshare.com/esp32-s3-touch-lcd-5.htm)                                                                                               |
 
 ## Usage
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#18810

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
