### PR TITLE
[modbus_controller] Document reuse_previous_range; retire register_count and force_new_range

### DIFF
--- a/src/content/docs/components/binary_sensor/modbus_controller.mdx
+++ b/src/content/docs/components/binary_sensor/modbus_controller.mdx
@@ -28,8 +28,8 @@ and requires [Modbus Controller](/components/modbus_controller/) to be configure
   register type, ascending address order). `auto` (default) joins when the addresses are adjacent and the item's
   position in the reply is exact; `true` joins unconditionally, reading across address gaps and past registers with a
   non-standard `response_size`; `false` always starts a new range here (later items may still extend it). See
-  [Register ranges](/components/modbus_controller/#modbus_register_count). Replaces the removed `force_new_range` and
-  `register_count` options, which auto-migrate with a warning and are removed in 2027.3.0.
+  [Register ranges](/components/modbus_controller/#modbus_register_count). Replaces the deprecated `force_new_range` and
+  `register_count` options, which auto-migrate with a warning and will be removed in 2027.3.0.
 - **custom_pdu** (*Optional*, list of bytes): The modbus PDU (function code + data) for a custom command. This allows
   using non-standard commands. The device address (taken from the controller's `address:`) and the CRC are added
   automatically, so do not include a leading device-address byte. If `custom_pdu` is used, `address` and

--- a/src/content/docs/components/binary_sensor/modbus_controller.mdx
+++ b/src/content/docs/components/binary_sensor/modbus_controller.mdx
@@ -24,7 +24,12 @@ and requires [Modbus Controller](/components/modbus_controller/) to be configure
   To poll some registers less often, place those sensors on a second `modbus_controller` with the same `address:` and a
   slower `update_interval:`.
 - **response_size** (*Optional*, int): Number of bytes the poll reads to cover this binary sensor. For the register types (`holding`/`read`) it defaults to `2` (one register); raise it only when the bit you are reading sits in a wider response, such as a `custom_pdu` reply spanning several registers. It sets the size of the read, not which bit is published — the bit is always selected by `offset` and `bitmask`. It has no effect on the `coil` and `discrete_input` types, which are always read as a single bit.
-- **force_new_range** (*Optional*, boolean): If possible sensors with sequential addresses are grouped together and requested in one range. Setting `force_new_range: true` enforces the start of a new range at that address.
+- **reuse_previous_range** (*Optional*): How this item relates to the register range built just before it (same
+  register type, ascending address order). `auto` (default) joins when the addresses are adjacent and the item's
+  position in the reply is exact; `true` joins unconditionally, reading across address gaps and past registers with a
+  non-standard `response_size`; `false` always starts a new range here (later items may still extend it). See
+  [Register ranges](/components/modbus_controller/#modbus_register_count). Replaces the removed `force_new_range` and
+  `register_count` options, which auto-migrate with a warning and are removed in 2027.3.0.
 - **custom_pdu** (*Optional*, list of bytes): The modbus PDU (function code + data) for a custom command. This allows
   using non-standard commands. The device address (taken from the controller's `address:`) and the CRC are added
   automatically, so do not include a leading device-address byte. If `custom_pdu` is used, `address` and

--- a/src/content/docs/components/binary_sensor/modbus_controller.mdx
+++ b/src/content/docs/components/binary_sensor/modbus_controller.mdx
@@ -29,7 +29,7 @@ and requires [Modbus Controller](/components/modbus_controller/) to be configure
   position in the reply is exact; `true` joins unconditionally, reading across address gaps and past registers with a
   non-standard `response_size`; `false` always starts a new range here (later items may still extend it). See
   [Register ranges](/components/modbus_controller/#modbus_register_count). Replaces the deprecated `force_new_range` and
-  `register_count` options, which auto-migrate with a warning and will be removed in 2027.3.0.
+  `register_count` options, which will be removed in 2027.3.0 — the linked section covers migration.
 - **custom_pdu** (*Optional*, list of bytes): The modbus PDU (function code + data) for a custom command. This allows
   using non-standard commands. The device address (taken from the controller's `address:`) and the CRC are added
   automatically, so do not include a leading device-address byte. If `custom_pdu` is used, `address` and

--- a/src/content/docs/components/binary_sensor/modbus_controller.mdx
+++ b/src/content/docs/components/binary_sensor/modbus_controller.mdx
@@ -24,12 +24,13 @@ and requires [Modbus Controller](/components/modbus_controller/) to be configure
   To poll some registers less often, place those sensors on a second `modbus_controller` with the same `address:` and a
   slower `update_interval:`.
 - **response_size** (*Optional*, int): Number of bytes the poll reads to cover this binary sensor. For the register types (`holding`/`read`) it defaults to `2` (one register); raise it only when the bit you are reading sits in a wider response, such as a `custom_pdu` reply spanning several registers. It sets the size of the read, not which bit is published — the bit is always selected by `offset` and `bitmask`. It has no effect on the `coil` and `discrete_input` types, which are always read as a single bit.
-- **reuse_previous_range** (*Optional*): How this item relates to the register range built just before it (same
-  register type, ascending address order). `auto` (default) joins when the addresses are adjacent and the item's
-  position in the reply is exact; `true` joins unconditionally, reading across address gaps and past registers with a
-  non-standard `response_size`; `false` always starts a new range here (later items may still extend it). See
-  [Register ranges](/components/modbus_controller/#modbus_register_count). Replaces the deprecated `force_new_range` and
-  `register_count` options, which will be removed in 2027.3.0 — the linked section covers migration.
+- **reuse_previous_range** (*Optional*, boolean or `auto`): How this item relates to the register range built just
+  before it (same register type, ascending address order). `auto` (default) joins when the addresses are adjacent and
+  the item's position in the reply is exact; `true` joins unconditionally, reading across address gaps and past
+  registers with a non-standard `response_size`; `false` always starts a new range here (later items may still extend
+  it). See [Register ranges](/components/modbus_controller/#modbus_register_count). Replaces the deprecated
+  `force_new_range` and `register_count` options, which will be removed in 2027.3.0 — the linked section covers
+  migration.
 - **custom_pdu** (*Optional*, list of bytes): The modbus PDU (function code + data) for a custom command. This allows
   using non-standard commands. The device address (taken from the controller's `address:`) and the CRC are added
   automatically, so do not include a leading device-address byte. If `custom_pdu` is used, `address` and

--- a/src/content/docs/components/modbus_controller.mdx
+++ b/src/content/docs/components/modbus_controller.mdx
@@ -356,8 +356,8 @@ sensor:
 ## Register ranges
 
 Sensors of the same register type are grouped into register ranges, and each range is read with one modbus command.
-The number of registers an item spans is derived from its `value_type` (or from `response_size` for RAW values and
-text sensors), and the `reuse_previous_range` option controls how an item relates to the range built just before it:
+The number of registers an item spans is derived from its `value_type` (or from `response_size` for text sensors),
+and the `reuse_previous_range` option controls how an item relates to the range built just before it:
 
 - `auto` (default): join when the addresses are adjacent and the item's position in the reply is exact - never past a
   register with a non-standard `response_size`, where the position depends on the device honoring it.

--- a/src/content/docs/components/modbus_controller.mdx
+++ b/src/content/docs/components/modbus_controller.mdx
@@ -369,6 +369,8 @@ and the `reuse_previous_range` option controls how an item relates to the range 
 The deprecated `force_new_range` and `register_count` options migrate automatically: `force_new_range: true` becomes
 `reuse_previous_range: false` with a deprecation warning, and a `register_count` equal to the derived width warns
 that it is redundant (a different value fails validation with instructions). Both will be removed in 2027.3.0.
+The old recipe for a device that packs a wider value into a single register - `register_count: 1` with
+`response_size: 4` for an FP32 - has no replacement: a typed value's width now always comes from its `value_type`.
 
 An example is an SDM meter, with interesting data in register addresses 0, 2, 4 and 6:
 

--- a/src/content/docs/components/modbus_controller.mdx
+++ b/src/content/docs/components/modbus_controller.mdx
@@ -366,9 +366,9 @@ text sensors), and the `reuse_previous_range` option controls how an item relate
   join starts a new range with a warning instead of sending an out-of-spec request.
 - `false`: always start a new range at this item; later items may still extend it.
 
-The removed `force_new_range` and `register_count` options migrate automatically: `force_new_range: true` becomes
+The deprecated `force_new_range` and `register_count` options migrate automatically: `force_new_range: true` becomes
 `reuse_previous_range: false` with a deprecation warning, and a `register_count` equal to the derived width warns
-that it is redundant (a different value fails validation with instructions). Both are removed in 2027.3.0.
+that it is redundant (a different value fails validation with instructions). Both will be removed in 2027.3.0.
 
 An example is an SDM meter, with interesting data in register addresses 0, 2, 4 and 6:
 
@@ -402,7 +402,7 @@ An example is an SDM meter, with interesting data in register addresses 0, 2, 4 
 The configuration above will generate *one* modbus command *read multiple registers from 0 to 6*.
 
 Maybe you don't care about the data in register addresses 2 and 4, which are voltage values for Phase 2 and Phase 3 (or you have a SDM-120).
-Of course, you can delete the sensors your don't care about, but then you'd have a gap in the addresses. If you
+Of course, you can delete the sensors you don't care about, but then you'd have a gap in the addresses. If you
 remove the registers at address 2 and 4, *two* commands will be generated -- *read register 0* and *read register 6*.
 To avoid generating multiple commands and thus reduce activity on the bus, `reuse_previous_range: true` joins across
 the gap:

--- a/src/content/docs/components/modbus_controller.mdx
+++ b/src/content/docs/components/modbus_controller.mdx
@@ -158,7 +158,6 @@ text_sensor:
   internal: true
   register_type: holding
   address: 0x9013
-  register_count: 3
   raw_encode: HEXBYTES
   response_size: 6
 ```
@@ -354,13 +353,22 @@ sensor:
 
 <span id="modbus_register_count"></span>
 
-## Optimizing modbus communications
+## Register ranges
 
-`register_count` is an option only required for uncommon response encodings or to optimizie modbus communications.
+Sensors of the same register type are grouped into register ranges, and each range is read with one modbus command.
+The number of registers an item spans is derived from its `value_type` (or from `response_size` for RAW values and
+text sensors), and the `reuse_previous_range` option controls how an item relates to the range built just before it:
 
-It describes the number of registers this data point spans, overriding the defaults determined by `value_type`. If no value for `register_count` is provided, it is calculated based on the register type. The default size for one register is 16 bits (one word). Some devices are not adhering to this convention and have registers larger than 16 bits. In this case, `register_count` and `response_size` must be set. For example, if your Modbus device uses one register for a FP32 value (instead of the default of two), set `register_count: 1` and `response_size: 4`.
+- `auto` (default): join when the addresses are adjacent and the item's position in the reply is exact - never past a
+  register with a non-standard `response_size`, where the position depends on the device honoring it.
+- `true`: join unconditionally, reading across address gaps (the gap registers are read and ignored) and past
+  registers with a non-standard `response_size`. Joined ranges are capped at the protocol read limits; an over-long
+  join starts a new range with a warning instead of sending an out-of-spec request.
+- `false`: always start a new range at this item; later items may still extend it.
 
-`register_count` can also be used to skip a number of registers in consecutive range.
+The removed `force_new_range` and `register_count` options migrate automatically: `force_new_range: true` becomes
+`reuse_previous_range: false` with a deprecation warning, and a `register_count` equal to the derived width warns
+that it is redundant (a different value fails validation with instructions). Both are removed in 2027.3.0.
 
 An example is an SDM meter, with interesting data in register addresses 0, 2, 4 and 6:
 
@@ -394,7 +402,10 @@ An example is an SDM meter, with interesting data in register addresses 0, 2, 4 
 The configuration above will generate *one* modbus command *read multiple registers from 0 to 6*.
 
 Maybe you don't care about the data in register addresses 2 and 4, which are voltage values for Phase 2 and Phase 3 (or you have a SDM-120).
-Of course, you can delete the sensors your don't care about, but then you'd have a gap in the addresses. If you remove the registers at address 2 and 4, *two* commands will be generated -- *read register 0* and *read register 6*. To avoid generating multiple commands and thus reduce activity on the bus, `register_count` can be used to fill the gaps:
+Of course, you can delete the sensors your don't care about, but then you'd have a gap in the addresses. If you
+remove the registers at address 2 and 4, *two* commands will be generated -- *read register 0* and *read register 6*.
+To avoid generating multiple commands and thus reduce activity on the bus, `reuse_previous_range: true` joins across
+the gap:
 
 ```yaml
 - platform: modbus_controller
@@ -403,19 +414,17 @@ Of course, you can delete the sensors your don't care about, but then you'd have
   unit_of_measurement: "V"
   register_type: "read"
   value_type: FP32
-  register_count: 6
 
 - platform: modbus_controller
   name: "Current Phase 1"
   address: 6
   register_type: "read"
   value_type: FP32
+  reuse_previous_range: true
 ```
 
-Because the option `register_count: 6` is used for the first sensor, *one* command *read multiple registers from 0 to 6* will be used but the values in between will be ignored.
-
-> [!NOTE]
-> *Calculation:* FP32 is a 32 bit value and uses 2 registers. Therefore, to skip the 2 FP32 registers the size of these 2 registers must be added to the default size for the first register. So we have 2 for address 0, 2 for address 2 and 2 for address 4 thus `register_count` must be 6.
+Because `reuse_previous_range: true` is set on the sensor at address 6, *one* command *read multiple registers from
+0 to 6* will be used and the gap registers in between are read and ignored - no size arithmetic required.
 
 ## Protocol decoding example
 
@@ -505,7 +514,7 @@ sensor:
 ```
 
 To minimize the required transactions all registers with the same base address are read in one request.
-The response is mapped to the sensor based on `register_count` and offset in bytes. For example:
+The response is mapped to the sensor based on each sensor's register width and offset in bytes. For example:
 
 **Request:**
 

--- a/src/content/docs/components/number/modbus_controller.mdx
+++ b/src/content/docs/components/number/modbus_controller.mdx
@@ -49,7 +49,7 @@ When the Number is updated a modbus write command is created sent to the device.
   position in the reply is exact; `true` joins unconditionally, reading across address gaps and past registers with a
   non-standard `response_size`; `false` always starts a new range here (later items may still extend it). See
   [Register ranges](/components/modbus_controller/#modbus_register_count). Replaces the deprecated `force_new_range` and
-  `register_count` options, which auto-migrate with a warning and will be removed in 2027.3.0.
+  `register_count` options, which will be removed in 2027.3.0 — the linked section covers migration.
 - **offset** (*Optional*, int): Offset from start address in bytes (only required for uncommon response encodings). If more than one register is written in a command this value is used to find the start of this datapoint relative to start address. The component calculates the size of the range based on offset and size of the value type.
 - **custom_pdu** (*Optional*, list of bytes): The modbus PDU (function code + data) for a custom command. This allows
   using non-standard commands. The device address (taken from the controller's `address:`) and the CRC are added

--- a/src/content/docs/components/number/modbus_controller.mdx
+++ b/src/content/docs/components/number/modbus_controller.mdx
@@ -44,7 +44,12 @@ When the Number is updated a modbus write command is created sent to the device.
   To poll some registers less often, place those sensors on a second `modbus_controller` with the same `address:` and a
   slower `update_interval:`.
 - **response_size** (*Optional*): Size of the response for the register in bytes. If unset, defaults to the size implied by `value_type` (2 bytes per register).
-- **force_new_range** (*Optional*, boolean): If possible sensors with sequential addresses are grouped together and requested in one range. Setting `force_new_range: true` enforces the start of a new range at that address.
+- **reuse_previous_range** (*Optional*): How this item relates to the register range built just before it (same
+  register type, ascending address order). `auto` (default) joins when the addresses are adjacent and the item's
+  position in the reply is exact; `true` joins unconditionally, reading across address gaps and past registers with a
+  non-standard `response_size`; `false` always starts a new range here (later items may still extend it). See
+  [Register ranges](/components/modbus_controller/#modbus_register_count). Replaces the removed `force_new_range` and
+  `register_count` options, which auto-migrate with a warning and are removed in 2027.3.0.
 - **offset** (*Optional*, int): Offset from start address in bytes (only required for uncommon response encodings). If more than one register is written in a command this value is used to find the start of this datapoint relative to start address. The component calculates the size of the range based on offset and size of the value type.
 - **custom_pdu** (*Optional*, list of bytes): The modbus PDU (function code + data) for a custom command. This allows
   using non-standard commands. The device address (taken from the controller's `address:`) and the CRC are added

--- a/src/content/docs/components/number/modbus_controller.mdx
+++ b/src/content/docs/components/number/modbus_controller.mdx
@@ -48,8 +48,8 @@ When the Number is updated a modbus write command is created sent to the device.
   register type, ascending address order). `auto` (default) joins when the addresses are adjacent and the item's
   position in the reply is exact; `true` joins unconditionally, reading across address gaps and past registers with a
   non-standard `response_size`; `false` always starts a new range here (later items may still extend it). See
-  [Register ranges](/components/modbus_controller/#modbus_register_count). Replaces the removed `force_new_range` and
-  `register_count` options, which auto-migrate with a warning and are removed in 2027.3.0.
+  [Register ranges](/components/modbus_controller/#modbus_register_count). Replaces the deprecated `force_new_range` and
+  `register_count` options, which auto-migrate with a warning and will be removed in 2027.3.0.
 - **offset** (*Optional*, int): Offset from start address in bytes (only required for uncommon response encodings). If more than one register is written in a command this value is used to find the start of this datapoint relative to start address. The component calculates the size of the range based on offset and size of the value type.
 - **custom_pdu** (*Optional*, list of bytes): The modbus PDU (function code + data) for a custom command. This allows
   using non-standard commands. The device address (taken from the controller's `address:`) and the CRC are added

--- a/src/content/docs/components/number/modbus_controller.mdx
+++ b/src/content/docs/components/number/modbus_controller.mdx
@@ -44,12 +44,13 @@ When the Number is updated a modbus write command is created sent to the device.
   To poll some registers less often, place those sensors on a second `modbus_controller` with the same `address:` and a
   slower `update_interval:`.
 - **response_size** (*Optional*): Size of the response for the register in bytes. If unset, defaults to the size implied by `value_type` (2 bytes per register).
-- **reuse_previous_range** (*Optional*): How this item relates to the register range built just before it (same
-  register type, ascending address order). `auto` (default) joins when the addresses are adjacent and the item's
-  position in the reply is exact; `true` joins unconditionally, reading across address gaps and past registers with a
-  non-standard `response_size`; `false` always starts a new range here (later items may still extend it). See
-  [Register ranges](/components/modbus_controller/#modbus_register_count). Replaces the deprecated `force_new_range` and
-  `register_count` options, which will be removed in 2027.3.0 — the linked section covers migration.
+- **reuse_previous_range** (*Optional*, boolean or `auto`): How this item relates to the register range built just
+  before it (same register type, ascending address order). `auto` (default) joins when the addresses are adjacent and
+  the item's position in the reply is exact; `true` joins unconditionally, reading across address gaps and past
+  registers with a non-standard `response_size`; `false` always starts a new range here (later items may still extend
+  it). See [Register ranges](/components/modbus_controller/#modbus_register_count). Replaces the deprecated
+  `force_new_range` and `register_count` options, which will be removed in 2027.3.0 — the linked section covers
+  migration.
 - **offset** (*Optional*, int): Offset from start address in bytes (only required for uncommon response encodings). If more than one register is written in a command this value is used to find the start of this datapoint relative to start address. The component calculates the size of the range based on offset and size of the value type.
 - **custom_pdu** (*Optional*, list of bytes): The modbus PDU (function code + data) for a custom command. This allows
   using non-standard commands. The device address (taken from the controller's `address:`) and the CRC are added

--- a/src/content/docs/components/select/modbus_controller.mdx
+++ b/src/content/docs/components/select/modbus_controller.mdx
@@ -47,8 +47,8 @@ registers.
   register type, ascending address order). `auto` (default) joins when the addresses are adjacent and the item's
   position in the reply is exact; `true` joins unconditionally, reading across address gaps and past registers with a
   non-standard `response_size`; `false` always starts a new range here (later items may still extend it). See
-  [Register ranges](/components/modbus_controller/#modbus_register_count). Replaces the removed `force_new_range` and
-  `register_count` options, which auto-migrate with a warning and are removed in 2027.3.0.
+  [Register ranges](/components/modbus_controller/#modbus_register_count). Replaces the deprecated `force_new_range` and
+  `register_count` options, which auto-migrate with a warning and will be removed in 2027.3.0.
 
 - **lambda** (*Optional*, [lambda](/automations/templates#config-lambda)): Lambda to be evaluated every update interval
   to get the current option of the select.

--- a/src/content/docs/components/select/modbus_controller.mdx
+++ b/src/content/docs/components/select/modbus_controller.mdx
@@ -38,19 +38,17 @@ registers.
 > the same as `_R` (word order reversed / **low word first** across multiple registers).
 
 
-- **register_count** (*Optional*): The number of registers which are used for this Select. Only
-  required for uncommon response encodings or to
-  [optimize modbus communications](/components/modbus_controller#modbus_register_count). Overrides the defaults determined
-  by `value_type`.
-
 - **skip_updates** (*Optional*, int): **Deprecated and no longer has any effect** — every register range is polled on
   each `update_interval`. The key is still accepted (logging a config-time warning) and will be removed in 2027.3.0.
   To poll some registers less often, place those sensors on a second `modbus_controller` with the same `address:` and a
   slower `update_interval:`.
 
-- **force_new_range** (*Optional*, boolean): If possible sensors with sequential addresses are
-  grouped together and requested in one range. Setting this to `true` enforces the start of a new
-  range at that address.
+- **reuse_previous_range** (*Optional*): How this item relates to the register range built just before it (same
+  register type, ascending address order). `auto` (default) joins when the addresses are adjacent and the item's
+  position in the reply is exact; `true` joins unconditionally, reading across address gaps and past registers with a
+  non-standard `response_size`; `false` always starts a new range here (later items may still extend it). See
+  [Register ranges](/components/modbus_controller/#modbus_register_count). Replaces the removed `force_new_range` and
+  `register_count` options, which auto-migrate with a warning and are removed in 2027.3.0.
 
 - **lambda** (*Optional*, [lambda](/automations/templates#config-lambda)): Lambda to be evaluated every update interval
   to get the current option of the select.

--- a/src/content/docs/components/select/modbus_controller.mdx
+++ b/src/content/docs/components/select/modbus_controller.mdx
@@ -43,12 +43,12 @@ registers.
   To poll some registers less often, place those sensors on a second `modbus_controller` with the same `address:` and a
   slower `update_interval:`.
 
-- **reuse_previous_range** (*Optional*): How this item relates to the register range built just before it (same
-  register type, ascending address order). `auto` (default) joins when the addresses are adjacent and the item's
-  position in the reply is exact; `true` joins unconditionally, reading across address gaps and past registers with a
-  non-standard `response_size`; `false` always starts a new range here (later items may still extend it). See
-  [Register ranges](/components/modbus_controller/#modbus_register_count). Replaces the deprecated `force_new_range` and
-  `register_count` options, which will be removed in 2027.3.0 — the linked section covers migration.
+- **reuse_previous_range** (*Optional*, boolean or `auto`): How this item relates to the register range built just
+  before it (same register type, ascending address order). `auto` (default) joins when the addresses are adjacent and
+  the item's position in the reply is exact; `true` joins unconditionally, reading across address gaps; `false` always
+  starts a new range here (later items may still extend it). See
+  [Register ranges](/components/modbus_controller/#modbus_register_count). Replaces the deprecated `force_new_range`
+  and `register_count` options, which will be removed in 2027.3.0 — the linked section covers migration.
 
 - **lambda** (*Optional*, [lambda](/automations/templates#config-lambda)): Lambda to be evaluated every update interval
   to get the current option of the select.

--- a/src/content/docs/components/select/modbus_controller.mdx
+++ b/src/content/docs/components/select/modbus_controller.mdx
@@ -48,7 +48,7 @@ registers.
   position in the reply is exact; `true` joins unconditionally, reading across address gaps and past registers with a
   non-standard `response_size`; `false` always starts a new range here (later items may still extend it). See
   [Register ranges](/components/modbus_controller/#modbus_register_count). Replaces the deprecated `force_new_range` and
-  `register_count` options, which auto-migrate with a warning and will be removed in 2027.3.0.
+  `register_count` options, which will be removed in 2027.3.0 — the linked section covers migration.
 
 - **lambda** (*Optional*, [lambda](/automations/templates#config-lambda)): Lambda to be evaluated every update interval
   to get the current option of the select.

--- a/src/content/docs/components/sensor/modbus_controller.mdx
+++ b/src/content/docs/components/sensor/modbus_controller.mdx
@@ -51,8 +51,8 @@ and requires [Modbus Controller](/components/modbus_controller/) to be configure
   register type, ascending address order). `auto` (default) joins when the addresses are adjacent and the item's
   position in the reply is exact; `true` joins unconditionally, reading across address gaps and past registers with a
   non-standard `response_size`; `false` always starts a new range here (later items may still extend it). See
-  [Register ranges](/components/modbus_controller/#modbus_register_count). Replaces the removed `force_new_range` and
-  `register_count` options, which auto-migrate with a warning and are removed in 2027.3.0.
+  [Register ranges](/components/modbus_controller/#modbus_register_count). Replaces the deprecated `force_new_range` and
+  `register_count` options, which auto-migrate with a warning and will be removed in 2027.3.0.
 - **lambda** (*Optional*, [lambda](/automations/templates#config-lambda)):
   Lambda to be evaluated every update interval to get the new value of the sensor.
 

--- a/src/content/docs/components/sensor/modbus_controller.mdx
+++ b/src/content/docs/components/sensor/modbus_controller.mdx
@@ -47,12 +47,13 @@ and requires [Modbus Controller](/components/modbus_controller/) to be configure
   slower `update_interval:`.
 - **response_size** (*Optional*, int): Size of the response for the register in bytes. If unset, defaults to the
   size implied by `value_type` (2 bytes per register).
-- **reuse_previous_range** (*Optional*): How this item relates to the register range built just before it (same
-  register type, ascending address order). `auto` (default) joins when the addresses are adjacent and the item's
-  position in the reply is exact; `true` joins unconditionally, reading across address gaps and past registers with a
-  non-standard `response_size`; `false` always starts a new range here (later items may still extend it). See
-  [Register ranges](/components/modbus_controller/#modbus_register_count). Replaces the deprecated `force_new_range` and
-  `register_count` options, which will be removed in 2027.3.0 — the linked section covers migration.
+- **reuse_previous_range** (*Optional*, boolean or `auto`): How this item relates to the register range built just
+  before it (same register type, ascending address order). `auto` (default) joins when the addresses are adjacent and
+  the item's position in the reply is exact; `true` joins unconditionally, reading across address gaps and past
+  registers with a non-standard `response_size`; `false` always starts a new range here (later items may still extend
+  it). See [Register ranges](/components/modbus_controller/#modbus_register_count). Replaces the deprecated
+  `force_new_range` and `register_count` options, which will be removed in 2027.3.0 — the linked section covers
+  migration.
 - **lambda** (*Optional*, [lambda](/automations/templates#config-lambda)):
   Lambda to be evaluated every update interval to get the new value of the sensor.
 

--- a/src/content/docs/components/sensor/modbus_controller.mdx
+++ b/src/content/docs/components/sensor/modbus_controller.mdx
@@ -52,7 +52,7 @@ and requires [Modbus Controller](/components/modbus_controller/) to be configure
   position in the reply is exact; `true` joins unconditionally, reading across address gaps and past registers with a
   non-standard `response_size`; `false` always starts a new range here (later items may still extend it). See
   [Register ranges](/components/modbus_controller/#modbus_register_count). Replaces the deprecated `force_new_range` and
-  `register_count` options, which auto-migrate with a warning and will be removed in 2027.3.0.
+  `register_count` options, which will be removed in 2027.3.0 — the linked section covers migration.
 - **lambda** (*Optional*, [lambda](/automations/templates#config-lambda)):
   Lambda to be evaluated every update interval to get the new value of the sensor.
 

--- a/src/content/docs/components/sensor/modbus_controller.mdx
+++ b/src/content/docs/components/sensor/modbus_controller.mdx
@@ -45,9 +45,14 @@ and requires [Modbus Controller](/components/modbus_controller/) to be configure
   each `update_interval`. The key is still accepted (logging a config-time warning) and will be removed in 2027.3.0.
   To poll some registers less often, place those sensors on a second `modbus_controller` with the same `address:` and a
   slower `update_interval:`.
-- **register_count** (*Optional*, int): The number of consecutive registers this read request should span or skip in a single command. Defaults to the number of registers implied by `value_type` (1 for the word types). See [Optimizing modbus communications](/components/modbus_controller#modbus_register_count) for more details.
-- **response_size** (*Optional*, int): Size of the response for the register in bytes. If unset, defaults to `register_count` × 2 (2 bytes per register).
-- **force_new_range** (*Optional*, boolean): If possible sensors with sequential addresses are grouped together and requested in one range. Setting `force_new_range: true` enforces the start of a new range at that address.
+- **response_size** (*Optional*, int): Size of the response for the register in bytes. If unset, defaults to the
+  size implied by `value_type` (2 bytes per register).
+- **reuse_previous_range** (*Optional*): How this item relates to the register range built just before it (same
+  register type, ascending address order). `auto` (default) joins when the addresses are adjacent and the item's
+  position in the reply is exact; `true` joins unconditionally, reading across address gaps and past registers with a
+  non-standard `response_size`; `false` always starts a new range here (later items may still extend it). See
+  [Register ranges](/components/modbus_controller/#modbus_register_count). Replaces the removed `force_new_range` and
+  `register_count` options, which auto-migrate with a warning and are removed in 2027.3.0.
 - **lambda** (*Optional*, [lambda](/automations/templates#config-lambda)):
   Lambda to be evaluated every update interval to get the new value of the sensor.
 

--- a/src/content/docs/components/text_sensor/modbus_controller.mdx
+++ b/src/content/docs/components/text_sensor/modbus_controller.mdx
@@ -20,8 +20,8 @@ and requires [Modbus Controller](/components/modbus_controller/) to be configure
   each `update_interval`. The key is still accepted (logging a config-time warning) and will be removed in 2027.3.0.
   To poll some registers less often, place those sensors on a second `modbus_controller` with the same `address:` and a
   slower `update_interval:`.
-- **register_count** (*Optional*, int): The number of consecutive registers this read request should span or skip in a single command. Unset by default - the response length is taken from `response_size` instead. See [Optimizing modbus communications](/components/modbus_controller#modbus_register_count) for more details.
-- **response_size** (*Optional*, int): Number of bytes of the response. Defaults to `2` (one register); the text sensor reads `response_size / 2` registers, so increase it for values that span more registers.
+- **response_size** (*Optional*, int): Number of bytes of the response. Defaults to `2` (one register); the text
+  sensor spans `response_size / 2` registers rounded up, so increase it for values that span more registers.
 - **raw_encode** (*Optional*, enum): If the response is binary it can't be published directly. Since a text sensor only publishes strings the binary data can be encoded. Defaults to `ANSI`. Possible encodings are:
 
   - `NONE`  : Don't encode data.
@@ -32,7 +32,12 @@ and requires [Modbus Controller](/components/modbus_controller/) to be configure
 > [!NOTE]
 > From version 2024.7, default encoding is `ANSI`. Thus, all control characters are now ignored. If you need to receive all characters, use `NONE` encoding.
 
-- **force_new_range** (*Optional*, boolean): If possible sensors with sequential addresses are grouped together and requested in one range. Setting `force_new_range: true` enforces the start of a new range at that address.
+- **reuse_previous_range** (*Optional*): How this item relates to the register range built just before it (same
+  register type, ascending address order). `auto` (default) joins when the addresses are adjacent and the item's
+  position in the reply is exact; `true` joins unconditionally, reading across address gaps and past registers with a
+  non-standard `response_size`; `false` always starts a new range here (later items may still extend it). See
+  [Register ranges](/components/modbus_controller/#modbus_register_count). Replaces the removed `force_new_range` and
+  `register_count` options, which auto-migrate with a warning and are removed in 2027.3.0.
 - **custom_pdu** (*Optional*, list of bytes): The modbus PDU (function code + data) for a custom command. This allows
   using non-standard commands. The device address (taken from the controller's `address:`) and the CRC are added
   automatically, so do not include a leading device-address byte. If `custom_pdu` is used, `address` and

--- a/src/content/docs/components/text_sensor/modbus_controller.mdx
+++ b/src/content/docs/components/text_sensor/modbus_controller.mdx
@@ -37,7 +37,7 @@ and requires [Modbus Controller](/components/modbus_controller/) to be configure
   position in the reply is exact; `true` joins unconditionally, reading across address gaps and past registers with a
   non-standard `response_size`; `false` always starts a new range here (later items may still extend it). See
   [Register ranges](/components/modbus_controller/#modbus_register_count). Replaces the deprecated `force_new_range` and
-  `register_count` options, which auto-migrate with a warning and will be removed in 2027.3.0.
+  `register_count` options, which will be removed in 2027.3.0 — the linked section covers migration.
 - **custom_pdu** (*Optional*, list of bytes): The modbus PDU (function code + data) for a custom command. This allows
   using non-standard commands. The device address (taken from the controller's `address:`) and the CRC are added
   automatically, so do not include a leading device-address byte. If `custom_pdu` is used, `address` and

--- a/src/content/docs/components/text_sensor/modbus_controller.mdx
+++ b/src/content/docs/components/text_sensor/modbus_controller.mdx
@@ -32,12 +32,13 @@ and requires [Modbus Controller](/components/modbus_controller/) to be configure
 > [!NOTE]
 > From version 2024.7, default encoding is `ANSI`. Thus, all control characters are now ignored. If you need to receive all characters, use `NONE` encoding.
 
-- **reuse_previous_range** (*Optional*): How this item relates to the register range built just before it (same
-  register type, ascending address order). `auto` (default) joins when the addresses are adjacent and the item's
-  position in the reply is exact; `true` joins unconditionally, reading across address gaps and past registers with a
-  non-standard `response_size`; `false` always starts a new range here (later items may still extend it). See
-  [Register ranges](/components/modbus_controller/#modbus_register_count). Replaces the deprecated `force_new_range` and
-  `register_count` options, which will be removed in 2027.3.0 — the linked section covers migration.
+- **reuse_previous_range** (*Optional*, boolean or `auto`): How this item relates to the register range built just
+  before it (same register type, ascending address order). `auto` (default) joins when the addresses are adjacent and
+  the item's position in the reply is exact; `true` joins unconditionally, reading across address gaps and past
+  registers with a non-standard `response_size`; `false` always starts a new range here (later items may still extend
+  it). See [Register ranges](/components/modbus_controller/#modbus_register_count). Replaces the deprecated
+  `force_new_range` and `register_count` options, which will be removed in 2027.3.0 — the linked section covers
+  migration.
 - **custom_pdu** (*Optional*, list of bytes): The modbus PDU (function code + data) for a custom command. This allows
   using non-standard commands. The device address (taken from the controller's `address:`) and the CRC are added
   automatically, so do not include a leading device-address byte. If `custom_pdu` is used, `address` and

--- a/src/content/docs/components/text_sensor/modbus_controller.mdx
+++ b/src/content/docs/components/text_sensor/modbus_controller.mdx
@@ -36,8 +36,8 @@ and requires [Modbus Controller](/components/modbus_controller/) to be configure
   register type, ascending address order). `auto` (default) joins when the addresses are adjacent and the item's
   position in the reply is exact; `true` joins unconditionally, reading across address gaps and past registers with a
   non-standard `response_size`; `false` always starts a new range here (later items may still extend it). See
-  [Register ranges](/components/modbus_controller/#modbus_register_count). Replaces the removed `force_new_range` and
-  `register_count` options, which auto-migrate with a warning and are removed in 2027.3.0.
+  [Register ranges](/components/modbus_controller/#modbus_register_count). Replaces the deprecated `force_new_range` and
+  `register_count` options, which auto-migrate with a warning and will be removed in 2027.3.0.
 - **custom_pdu** (*Optional*, list of bytes): The modbus PDU (function code + data) for a custom command. This allows
   using non-standard commands. The device address (taken from the controller's `address:`) and the CRC are added
   automatically, so do not include a leading device-address byte. If `custom_pdu` is used, `address` and


### PR DESCRIPTION
# Description:

Documents the `reuse_previous_range` option added in esphome/esphome#18085, which replaces `register_count` and `force_new_range`.

The main page's optimization section becomes **Register ranges** (the `modbus_register_count` anchor is kept for existing links): it explains the grouping, the three modes, and the automatic migration (warnings now, removal in 2027.3.0), with the SDM gap example rewritten around `reuse_previous_range: true` - no size arithmetic.
Every platform page that documented `force_new_range`/`register_count` (sensor, binary_sensor, text_sensor, number, select) swaps them for a shared `reuse_previous_range` bullet, and `response_size` stands alone for RAW and text block reads.

**Related issue or feature (if applicable):**

- esphome/esphome#18085 (merge together)

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#18085

## Checklist:

  - [x] Branch: `next` for changes not yet released, `current` for released features
  - [x] Link added in `/index.mdx` when creating new documents for new components or cookbook (N/A - existing pages)
