### PR TITLE
[ufm01] Add ScioSense image attribution

### DIFF
--- a/src/content/docs/components/ufm01.mdx
+++ b/src/content/docs/components/ufm01.mdx
@@ -17,7 +17,7 @@ The UFM-01 flow meter communicates using a specific UART protocol at 2400 baud w
 <Figure
   src="/images/ufm01.png"
   alt="UFM-01 ultrasonic flow meter"
-  caption="UFM-01 flow meter"
+  caption="UFM-01 flow meter. Image by [ScioSense](https://www.sciosense.com/ufm-01-ultrasonic-flow-sensing-module/)."
   layout="constrained"
   width={236}
   height={278}


### PR DESCRIPTION
## Description

Attribute the UFM-01 product photo to ScioSense in the figure caption, matching how other component pages credit manufacturer images.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- N/A

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

Made with [Cursor](https://cursor.com)