### PR TITLE
Document user-defined action metadata

### DIFF
--- a/src/content/docs/components/api.mdx
+++ b/src/content/docs/components/api.mdx
@@ -514,6 +514,34 @@ Each of these also exist in array form:
 - bool[]: An array of boolean values. C++ type: `std::vector<bool>`
 - ... - Same for other types.
 
+### Action Metadata
+
+Variables can also be declared in a mapping form to attach metadata. Clients
+such as Home Assistant use it to describe the action and its fields in the UI:
+
+```yaml
+# Example configuration entry
+api:
+  actions:
+    - action: play_buzzer
+      description: Play a melody on the buzzer
+      variables:
+        song_str:
+          type: string
+          description: Melody in RTTTL format
+          example: "two_short:d=4,o=5,b=100:16e6,16e6"
+      then:
+        - rtttl.play:
+            rtttl: !lambda "return song_str;"
+```
+
+- **type** (**Required**, string): The variable type, one of the types listed above.
+- **description** (*Optional*, string): Description of the variable.
+- **example** (*Optional*, string): Example value for the variable.
+
+An action itself also accepts **description** (*Optional*, string), as shown above.
+Both forms can be mixed freely; the `name: type` shorthand remains valid.
+
 ### Action Responses
 
 User-defined actions can send responses back to the calling client (such as Home Assistant). This enables

--- a/src/content/docs/components/api.mdx
+++ b/src/content/docs/components/api.mdx
@@ -516,8 +516,8 @@ Each of these also exist in array form:
 
 ### Action Metadata
 
-Variables can also be declared in a mapping form to attach metadata. Clients
-such as Home Assistant use it to describe the action and its fields in the UI:
+Actions and their variables can carry metadata. Clients such as Home Assistant
+use it to describe the action and its fields in the UI:
 
 ```yaml
 # Example configuration entry
@@ -535,12 +535,17 @@ api:
             rtttl: !lambda "return song_str;"
 ```
 
-- **type** (**Required**, string): The variable type, one of the types listed above.
-- **description** (*Optional*, string): Description of the variable.
-- **example** (*Optional*, string): Example value for the variable.
+#### Configuration variables
 
-An action itself also accepts **description** (*Optional*, string), as shown above.
-Both forms can be mixed freely; the `name: type` shorthand remains valid.
+- **description** (*Optional*, string): Description of the action.
+- **variables** (*Optional*, mapping): Each variable may be given as `name: type` or as a mapping:
+  - **type** (**Required**, string): The variable type, one of the types listed above.
+  - **description** (*Optional*, string): Description of the variable.
+  - **example** (*Optional*, string): Example value for the variable. Always a string, so
+    quote values for numeric variables, e.g. `example: "420"`.
+
+The `name: type` shorthand and the mapping form can be mixed within the same
+`variables:` block.
 
 ### Action Responses
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Documents the new user-defined action metadata: the `description` option on an action and the mapping form for `variables` with `type`/`description`/`example`.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#18881

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.
