### PR TITLE
Document that saved Wi-Fi credentials expire when the config also defines a network

### DIFF
--- a/src/content/docs/components/wifi.mdx
+++ b/src/content/docs/components/wifi.mdx
@@ -214,6 +214,15 @@ Some components such as [Captive Portal](/components/captive_portal/), [Improv S
 as long as no credentials are set in the config file, and firmware is uploaded without erasing
 the flash (via OTA), the device will keep the saved credentials.
 
+Saved credentials take precedence over any `ssid` and `password` in the configuration: the device loads them at
+boot and connects with them instead.
+
+Leaving `ssid` and `password` in the configuration as a fallback does not work as expected. When the configuration
+defines a network, the saved credentials are stored under a key derived from the configuration and the ESPHome
+version, so they are discarded by any configuration change or version upgrade, and the device silently reverts to
+the credentials in the configuration. When the configuration defines no network, they are stored under a fixed key
+and survive updates. Omit `ssid` and `password` entirely when provisioning with Captive Portal or Improv.
+
 <span id="wifi-manual_ip"></span>
 
 ## Manual IPs


### PR DESCRIPTION
## What

Expands the **User Entered Credentials** section of the WiFi docs with two facts that are currently implied but not stated:

1. Saved credentials **take precedence** over `ssid`/`password` in the configuration.
2. Keeping `ssid`/`password` as a "fallback" alongside Improv or Captive Portal **silently expires the provisioned credentials** on the next build.

## Why

The existing text gives the rule — "as long as no credentials are set in the config file" — but not the consequence, so it reads as a best-practice suggestion rather than a requirement. The natural conclusion is that leaving credentials in the config is a harmless safety net. It isn't.

From `WiFiComponent::start()` in `esphome/components/wifi/wifi_component.cpp`:

```cpp
uint32_t hash = this->has_sta() ? App.get_config_version_hash() : 88491487UL;
this->pref_ = global_preferences->make_preference<wifi::SavedWifiSettings>(hash, true);

SavedWifiSettings save{};
if (this->pref_.load(&save)) {
  ESP_LOGD(TAG, "Loaded settings: %s", save.ssid);
  WiFiAP sta{};
  sta.set_ssid(save.ssid);
  sta.set_password(save.password);
  this->set_sta(sta);
}
```

`set_sta()` replaces the STA list, which is fact (1).

The ternary is fact (2). With a network configured the preference key is `App.get_config_version_hash()`, which is

```cpp
uint32_t Application::get_config_version_hash() { return fnv1a_hash_extend(ESPHOME_CONFIG_HASH, ESPHOME_VERSION); }
```

— so it changes on **any config edit and on any ESPHome version upgrade**. The saved credentials are then unreadable and the device falls back to the config file's. With no network configured the key is the constant `88491487`, and the credentials persist.

The failure mode is quiet and delayed: provisioning works, the device runs for weeks, and then an unrelated config tweak or a routine ESPHome upgrade sends it back to stale credentials.

## Notes

- Documentation only; no behaviour change.
- Written as prose rather than an admonition to match the surrounding section, which uses no admonition components.
- Lines wrapped at 120 characters per `CONTRIBUTING.md`.

Found while provisioning an ESP32 with `improv_serial`, on ESPHome 2026.6.5.