### PR TITLE
Update wts01.mdx

### DIFF
--- a/src/content/docs/components/sensor/wts01.mdx
+++ b/src/content/docs/components/sensor/wts01.mdx
@@ -35,12 +35,68 @@ sensor:
 
 - All options from [Sensor](/components/sensor).
 
+## Complete example setup
+
 > [!NOTE]
 > The WTS01 sensor is used in Sonoff TH Origin (THR316, THR320) and TH Elite (THR316D, THR320D) devices and connects to the main device using a RJ9 4C4P connector.
 > This sensor provides temperature readings with 0.1°C resolution.
+
+### WTS01 sensor RJ9 pinout
+
+RJ9 pins, when the connector is viewed from the contacts side, cables exiting at the bottom, and pin 1 is farthest left.
+
+| Pin | Function               |
+| --- | ---------------------- |
+| 1   | Sensor 3.3V Power      |
+| 2   | Sensor Bus Data Out    |
+| 3   | Not Connected          |
+| 4   | Sensor Ground          |
+
+The following example assumes that you connect the following:
+- `Pin 1` of RJ9 connector (power) to `GPIO25`
+- `Pin 2` of RJ9 connector (data) to `GPIO27`
+- `Pin 4` of RJ9 connector (ground) to `GND`
+
+### Example configuration
+
+The ``throttle`` filter is completely optional, but recommended to not spam
+the receiving home assistant instance with updates.
+
+```yaml
+esphome:  
+  on_boot:
+    - priority: 90
+      then:
+      # Make sure the sensor power is on at startup
+      - switch.turn_on: WTS01_sensor_power
+
+uart:
+  - id: uart_bus
+    rx_pin: GPIO27  # for data of WTS01 (pin 2)
+    baud_rate: 9600
+
+switch:
+  # This is needed to power the external sensor.
+  # It receives 3v3 from this pin, which is pulled up on boot.
+  - platform: gpio
+    pin: GPIO25  # for power to WTS01 (pin 1)
+    id: WTS01_sensor_power
+    restore_mode: ALWAYS_ON
+
+sensor:
+  - platform: wts01
+    name: WTS01 Temperature Sensor
+    id: sensor_wts01
+    uart_id: uart_bus
+    device_class: temperature
+    unit_of_measurement: °C
+    filters:
+      - throttle_average: 15s
+```
 
 ## See Also
 
 - [Sensor Filters](/components/sensor/#sensor-filters)
 - [UART Bus](/components/uart/)
+- [Sonoff THR316](https://devices.esphome.io/devices/sonoff-thr316/)
 - <APIRef text="wts01.h" path="wts01/wts01.h" />

--- a/src/content/docs/components/sensor/wts01.mdx
+++ b/src/content/docs/components/sensor/wts01.mdx
@@ -53,8 +53,8 @@ RJ9 pins, when the connector is viewed from the contacts side, cables exiting at
 | 4   | Sensor Ground          |
 
 The following example assumes that you connect the following:
-- `Pin 1` of RJ9 connector (power) to `GPIO25`
-- `Pin 2` of RJ9 connector (data) to `GPIO27`
+- `Pin 1` of RJ9 connector (power) to `GPIO27`
+- `Pin 2` of RJ9 connector (data) to `GPIO25`
 - `Pin 4` of RJ9 connector (ground) to `GND`
 
 ### Example configuration
@@ -72,14 +72,14 @@ esphome:
 
 uart:
   - id: uart_bus
-    rx_pin: GPIO27  # for data of WTS01 (pin 2)
+    rx_pin: GPIO25  # for data of WTS01 (pin 2)
     baud_rate: 9600
 
 switch:
   # This is needed to power the external sensor.
   # It receives 3v3 from this pin, which is pulled up on boot.
   - platform: gpio
-    pin: GPIO25  # for power to WTS01 (pin 1)
+    pin: GPIO27  # for power to WTS01 (pin 1)
     id: WTS01_sensor_power
     restore_mode: ALWAYS_ON
 


### PR DESCRIPTION
Include missing information for a complete working setup, especially with regard to RJ9 pinout connections to GPIO pins.

When trying to assemble the WTS01 temperature sensor with an ESP32 board, the documentation was lacking information about how to connect the RJ9 connector of the sensor to the board's GPIO pins.

The RJ9 pinout (power, data, ground) was luckily available here:
https://devices.esphome.io/devices/sonoff-thr316/

And this post provided other essential information about how to actually get the sensor running:
https://community.home-assistant.io/t/support-for-sonoff-wts01temperature-sensor-aka-ds18b20/745652/4

With all this information merged in one place, I hope the setup is now more straightforward.

<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

