### PR TITLE
[modbus] Document rx_timeout tuning for high baud rates

### DIFF
--- a/src/content/docs/components/modbus.mdx
+++ b/src/content/docs/components/modbus.mdx
@@ -87,6 +87,42 @@ increase it.
 Reducing `send_wait_time` generally does not impact performance at all, unless you have devices that are physically
 offline. When all devices are responding, `send_wait_time` does nothing.
 
+### Reducing CPU Load at High Baud Rates
+
+Modbus RTU requires a silent gap between frames. Above 19200 baud the specification fixes that gap at 1.75 ms, which
+is far longer than the frames themselves, so at high baud rates the bus spends most of its time waiting. The component
+waits out the remainder of that gap before it transmits, and the last part of the wait is spent busy-waiting so the
+gap is met precisely.
+
+On ESP32, increasing [`rx_timeout`](/components/uart/#configuration-variables) on the
+[UART Component](/components/uart/) moves more of that waiting into the UART hardware. A larger value means the UART
+waits longer after the last byte before it declares a frame complete and hands it over, so the component is notified
+later and has less of the gap left to wait out itself. Throughput is unaffected, because the gap is measured from the
+last byte on the wire rather than from the moment the frame was handed over.
+
+`rx_timeout` is counted in bytes, not in time: one unit is however long a byte takes to send at your baud rate, which
+is roughly ten bit times. At 115200 baud a byte is about 87 us, so the default of `2` is about 174 us and the 1.75 ms
+gap is about twenty.
+
+On a bus running at 115200 baud, raising `rx_timeout` from the default of `2` to `15` can reduce the time the
+`modbus` component spends in each loop from around 1.67 ms to 0.43 ms, without affecting throughput. The CPU freed
+this way is available to WiFi and the rest of your configuration.
+
+The saving is per transaction, so it only adds up if you are already pushing throughput: `turnaround_time` reduced
+to `0` and devices polled as fast as they will answer. With the default `turnaround_time` the bus is idle most of the
+time and there is little to reclaim.
+
+There is a limit: if the value is so large that the frame is handed over too late for the component to process it and
+transmit within the remaining gap, throughput starts to fall. Staying under about three quarters of the gap leaves
+enough room, which is around `15` at 115200 baud. At 19200 baud and below the gap scales with the baud rate rather
+than being fixed, so it is only 3.5 bytes wide and the default of `2` already covers more than half of it: there is
+little left to reclaim and no room to raise it.
+
+> [!WARNING]
+> A large `rx_timeout` also means the UART waits longer before deciding that a frame has ended, so anything arriving
+> in that window is handed over as a single block. That makes it harder to recover cleanly from line noise, and
+> setting it too large may lead to problems parsing frames; reduce it again if you see them.
+
 ## Hardware setup
 
 You need an RS485 transceiver module:


### PR DESCRIPTION
Adds a subsection to *Performance vs Stability* on the `modbus` page covering `rx_timeout` as a throughput/CPU tuning knob.

Above 19200 baud the Modbus RTU interframe gap is fixed at 1.75 ms, far longer than the frames themselves, so the bus spends most of its time waiting and the component busy-waits the last part of that gap to meet it precisely.
Raising the UART's `rx_timeout` moves more of the wait into the UART hardware: the frame is handed over later, so less of the gap remains for the component to wait out.
Throughput is unaffected, because the gap is measured from the last byte on the wire rather than from when the frame was handed over.

Measured on a client polling three servers at 115200 baud: raising `rx_timeout` from 2 to 15 took the time the `modbus` component spent in each loop from 1.67 ms to 0.43 ms, with bus utilisation unchanged at ~96%.

The section also documents the ceiling (too large and the frame arrives too late to transmit within the gap, costing throughput) and warns that a long timeout means the UART waits longer before deciding a frame has ended, so a device that does not leave a proper gap can have two frames handed over as one and fail the checksum.

Companion to esphome/esphome#18898, though the two are independent: this documents an existing option and needs no code change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with functional changes (if applicable):** esphome/esphome#18898
