### PR TITLE
[ufm01] Document diagnostics, clear action, and stale NaN behavior

### DIFF
--- a/src/content/docs/components/ufm01.mdx
+++ b/src/content/docs/components/ufm01.mdx
@@ -10,9 +10,12 @@ The `ufm01` component allows you to integrate the UFM-01 flow meter
 ([datasheet](https://www.sciosense.com/wp-content/uploads/2025/06/UFM-01-Datasheet-1.pdf),
 [manufacturer page](https://www.sciosense.com/ufm-01-ultrasonic-flow-sensing-module/))
 into your ESPHome device. This component reads accumulated flow (volume), current flow rate, and water temperature
-from the UFM-01 device via UART. It also provides several diagnostic binary sensors to monitor the device's status.
+from the UFM-01 device via UART. It also provides diagnostic binary sensors, optional device ID and software version
+text sensors, and an action to clear the accumulated flow stored on the meter.
 
 The UFM-01 flow meter communicates using a specific UART protocol at 2400 baud with even parity and 1 stop bit.
+One-Wire is not supported; use the [manufacturer Arduino library](https://github.com/sciosense/ufm01-arduino)
+if you need that bus.
 
 <Figure
   src="/images/ufm01.png"
@@ -89,8 +92,9 @@ sensor:
 
   - All options from [Sensor](/components/sensor).
 
-When `empty_tube` is active, `flow` and `temperature` are published as unknown (`NaN`). `accumulated_flow` continues
-to update.
+When `empty_tube` is active, or when the meter stops sending valid readings long enough for the component to treat
+the stream as stale, `flow` and `temperature` are published as unknown (`NaN`). `accumulated_flow` continues to
+update while frames are still valid.
 
 ## Binary Sensor
 
@@ -131,6 +135,53 @@ binary_sensor:
 
   - All options from [Binary Sensor](/components/binary_sensor#config-binary_sensor).
 
+## Text Sensor
+
+The `ufm01` text sensors report the meter identity and firmware version.
+
+```yaml
+text_sensor:
+  - platform: ufm01
+    ufm01_id: ufm01_component
+    device_id:
+      name: "UFM01 Device ID"
+    software_version:
+      name: "UFM01 Software Version"
+```
+
+### Configuration variables
+
+- **platform**: `ufm01`
+- **ufm01_id** (*Optional*, [ID](/guides/configuration-types#id)): The ID of the `ufm01` component this text sensor
+  belongs to.
+- **device_id** (*Optional*): The 10-digit device ID from the meter.
+
+  - All options from [Text Sensor](/components/text_sensor#config-text_sensor).
+
+- **software_version** (*Optional*): The software version reported by the meter.
+
+  - All options from [Text Sensor](/components/text_sensor#config-text_sensor).
+
+## Actions
+
+### `ufm01.clear_accumulated_flow` Action
+
+Clears the accumulated flow stored on the UFM-01. The action waits for the UART to be idle, sends the command, and
+continues the automation after the meter acknowledges it (or after a timeout).
+
+```yaml
+on_...:
+  - ufm01.clear_accumulated_flow: ufm01_component
+
+  # Equivalent long form
+  - ufm01.clear_accumulated_flow:
+      id: ufm01_component
+```
+
+#### Configuration variables
+
+- **id** (**Required**, [ID](/guides/configuration-types#id)): The ID of the UFM-01 component.
+
 ## Full Example Configuration
 
 ```yaml
@@ -167,6 +218,20 @@ binary_sensor:
       name: "UFM01 Empty Tube"
     flow_rate_out_of_range:
       name: "UFM01 Flow Rate Out of Range"
+
+text_sensor:
+  - platform: ufm01
+    ufm01_id: ufm01_component
+    device_id:
+      name: "UFM01 Device ID"
+    software_version:
+      name: "UFM01 Software Version"
+
+button:
+  - platform: template
+    name: "Clear UFM01 accumulated flow"
+    on_press:
+      - ufm01.clear_accumulated_flow: ufm01_component
 ```
 
 ## See Also
@@ -174,4 +239,6 @@ binary_sensor:
 - [UART](/components/uart/)
 - [Sensor](/components/sensor/)
 - [Binary Sensor](/components/binary_sensor/)
+- [Text Sensor](/components/text_sensor/)
+- [Automation](/automations/)
 - <APIRef text="ufm01.h" path="ufm01/ufm01.h" />

--- a/src/content/docs/components/ufm01.mdx
+++ b/src/content/docs/components/ufm01.mdx
@@ -10,7 +10,7 @@ The `ufm01` component allows you to integrate the UFM-01 flow meter
 ([datasheet](https://www.sciosense.com/wp-content/uploads/2025/06/UFM-01-Datasheet-1.pdf),
 [manufacturer page](https://www.sciosense.com/ufm-01-ultrasonic-flow-sensing-module/))
 into your ESPHome device. This component reads accumulated flow (volume), current flow rate, and water temperature
-from the UFM-01 device via UART. It also provides diagnostic binary sensors, optional device ID and software version
+from the UFM-01 device via UART. It also provides diagnostic binary sensors, optional meter ID and software version
 text sensors, and an action to clear the accumulated flow stored on the meter.
 
 The UFM-01 flow meter communicates using a specific UART protocol at 2400 baud with even parity and 1 stop bit.
@@ -143,8 +143,8 @@ The `ufm01` text sensors report the meter identity and firmware version.
 text_sensor:
   - platform: ufm01
     ufm01_id: ufm01_component
-    device_id:
-      name: "UFM01 Device ID"
+    meter_id:
+      name: "UFM01 Meter ID"
     software_version:
       name: "UFM01 Software Version"
 ```
@@ -154,7 +154,7 @@ text_sensor:
 - **platform**: `ufm01`
 - **ufm01_id** (*Optional*, [ID](/guides/configuration-types#id)): The ID of the `ufm01` component this text sensor
   belongs to.
-- **device_id** (*Optional*): The 10-digit device ID from the meter.
+- **meter_id** (*Optional*): The 10-digit meter ID from the device.
 
   - All options from [Text Sensor](/components/text_sensor#config-text_sensor).
 
@@ -167,7 +167,8 @@ text_sensor:
 ### `ufm01.clear_accumulated_flow` Action
 
 Clears the accumulated flow stored on the UFM-01. The action waits for the UART to be idle, sends the command, and
-continues the automation after the meter acknowledges it (or after a timeout).
+continues the automation after the meter acknowledges it (or after a timeout). If a clear is already in progress,
+additional triggers are ignored and do not advance the automation chain.
 
 ```yaml
 on_...:
@@ -222,8 +223,8 @@ binary_sensor:
 text_sensor:
   - platform: ufm01
     ufm01_id: ufm01_component
-    device_id:
-      name: "UFM01 Device ID"
+    meter_id:
+      name: "UFM01 Meter ID"
     software_version:
       name: "UFM01 Software Version"
 


### PR DESCRIPTION
## Description

Document UFM-01 features and behavior added in esphome/esphome#18899:

- Optional `meter_id` and `software_version` text sensors
- `ufm01.clear_accumulated_flow` automation action
- `flow` and `temperature` publish as unknown (`NaN`) when the active UART stream goes stale
- UART is the supported bus (One-Wire is not supported)

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- https://github.com/esphome/esphome/pull/18899

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.


Made with [Cursor](https://cursor.com)