### PR TITLE
[mitsubishi_cn105] Update remote temperature cookbook example to reflect top-level hub

### DIFF
--- a/src/content/docs/cookbook/mitsubishi_cn105_remote_temp.mdx
+++ b/src/content/docs/cookbook/mitsubishi_cn105_remote_temp.mdx
@@ -7,7 +7,7 @@ Mitsubishi heatpumps equipped with the `CN105` internal connector support readin
 The advantage of this feature is that a remote sensor can be placed more optimally in the room to get information about the
 real temperature.
 
-The [Mitsubishi CN105 Climate](/components/climate/mitsubishi_cn105/) component supports this feature by providing [actions and lambdas](/automations/) to update the hardware
+The [Mitsubishi CN105](/components/climate/mitsubishi_cn105/) component supports this feature by providing [actions and lambdas](/automations/) to update the hardware
 with values from any temperature sensor available in ESPHome.
 
 The following is a possible configuration to implement this. Some heatpumps require frequent temperature updates to prevent from
@@ -16,10 +16,9 @@ failing sensors - that's when one would still want to continue operation, based 
 possibility to choose at run time between which temperature source to use with the heatpump.
 
 ```yaml
-climate:
-  - platform: mitsubishi_cn105
-    id: ac
-    ...
+mitsubishi_cn105:
+  id: hp
+  ...
 
 sensor:
   - platform: ...
@@ -39,12 +38,12 @@ sensor:
                 options: "External"
             - lambda: return (!isnan(x));
           then:
-            - climate.mitsubishi_cn105.set_remote_temperature:
-                id: ac
+            - mitsubishi_cn105.set_remote_temperature:
+                id: hp
                 temperature: !lambda 'return x;'
           else:
-            - climate.mitsubishi_cn105.clear_remote_temperature:
-                id: ac
+            - mitsubishi_cn105.clear_remote_temperature:
+                id: hp
 
 select:
   - platform: template
@@ -63,16 +62,16 @@ select:
               id: sel_temp
               options: "Internal"
           then:
-            - climate.mitsubishi_cn105.clear_remote_temperature:
-                id: ac
+            - mitsubishi_cn105.clear_remote_temperature:
+                id: hp
       - if:
           condition:
             select.is:
               id: sel_temp
               options: "External"
           then:
-            - climate.mitsubishi_cn105.set_remote_temperature:
-                id: ac
+            - mitsubishi_cn105.set_remote_temperature:
+                id: hp
                 temperature: !lambda 'return id(my_temp).state;'
 ```
 

--- a/src/content/docs/cookbook/mitsubishi_cn105_remote_temp.mdx
+++ b/src/content/docs/cookbook/mitsubishi_cn105_remote_temp.mdx
@@ -17,7 +17,7 @@ possibility to choose at run time between which temperature source to use with t
 
 ```yaml
 mitsubishi_cn105:
-  id: hp
+  id: ac
   ...
 
 sensor:
@@ -39,11 +39,11 @@ sensor:
             - lambda: return (!isnan(x));
           then:
             - mitsubishi_cn105.set_remote_temperature:
-                id: hp
+                id: ac
                 temperature: !lambda 'return x;'
           else:
             - mitsubishi_cn105.clear_remote_temperature:
-                id: hp
+                id: ac
 
 select:
   - platform: template
@@ -63,7 +63,7 @@ select:
               options: "Internal"
           then:
             - mitsubishi_cn105.clear_remote_temperature:
-                id: hp
+                id: ac
       - if:
           condition:
             select.is:
@@ -71,7 +71,7 @@ select:
               options: "External"
           then:
             - mitsubishi_cn105.set_remote_temperature:
-                id: hp
+                id: ac
                 temperature: !lambda 'return id(my_temp).state;'
 ```
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Updates the CN105 remote temperature cookbook to use the top-level hub and hub-owned actions instead of the deprecated climate-owned configuration.

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.
