### PR TITLE
[blog] Hide previous/next post links on blog posts

### DIFF
--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -639,6 +639,13 @@ article.preview {
   margin-bottom: 0;
 }
 
+/* starlight-blog renders previous/next post link cards at the end of every blog
+   post. They add no value here, and the plugin offers no option to disable them,
+   so hide them. The surrounding post footer still shows the post tags. */
+.post-footer .pagination {
+  display: none;
+}
+
 .metadata.not-content .dates:before {
   display: none;
 }


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

The previous/next post link cards at the bottom of every blog post are removed. `starlight-blog` renders them from its own `MarkdownContent` override and exposes no config option to turn them off, and this repo deliberately avoids overriding `MarkdownContent` (importing `starlight-blog/libs/page` trips a rolldown exports-field error, see the note in `src/components/Footer.astro`), so they are hidden with CSS instead. The post tags above them are unaffected, and the blog index / tag / author listing pages keep their own post-list paging since that markup lives outside `.post-footer`.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.