### PR TITLE
[ci] Allow bypassing fork default branch PR closure with a label

### DIFF
--- a/.github/workflows/close-pr-from-fork-default-branch.yml
+++ b/.github/workflows/close-pr-from-fork-default-branch.yml
@@ -13,9 +13,13 @@ jobs:
   close:
     name: Close PR opened from fork's current/next branch
     runs-on: ubuntu-latest
+    # Maintainers can apply the `allow-fork-default-branch` label to exempt a PR from this check, e.g. for
+    # legacy PRs opened before this rule existed. Labels can only be set by users with write access, so
+    # contributors can't exempt themselves.
     if: >-
       github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
       && (github.event.pull_request.head.ref == 'current' || github.event.pull_request.head.ref == 'next')
+      && !contains(github.event.pull_request.labels.*.name, 'allow-fork-default-branch')
     steps:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

The `Close PR From Fork Default Branch` workflow runs on `opened` and `reopened`, so a legacy PR opened from a fork's `current`/`next` branch before this rule existed gets commented on and closed again every time a maintainer reopens it. This adds an `allow-fork-default-branch` label that exempts a PR from the check, letting maintainers keep working on those older PRs. Labels can only be applied by users with triage/write access, so contributors can't exempt their own PRs. The label is not mentioned in the bot's closing comment.

Note the `allow-fork-default-branch` label needs to be created in the repository's label settings before it can be used.

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.