### PR TITLE
Document selecting an I/O expander pin provider by I2C address

### DIFF
--- a/src/content/docs/components/max6956.mdx
+++ b/src/content/docs/components/max6956.mdx
@@ -54,6 +54,17 @@ max6956:
 - **brightness_mode** (*Optional*): Define if the current to be sink will be confgured globaly or per pin configured as led driver.
   Defaults to `global`
 
+### Pin configuration variables
+
+- **max6956** (**Required**, [ID](/guides/configuration-types#id)): The id of the `max6956` component of the pin.
+  Instead of an id, an `address:` can be given to select the hub by its I²C address; see
+  [Selecting an I2C expander by address](/guides/configuration-types#selecting-an-i2c-expander-by-address).
+- **number** (**Required**, int): The pin number.
+- **inverted** (*Optional*, boolean): If all read and written values
+  should be treated as inverted. Defaults to `false`.
+- **mode** (*Optional*, string or mapping): A pin mode to set for the pin. `input`, `pullup` and
+  `output` are supported; see [Pin Schema](/guides/configuration-types#pin-schema).
+
 ## Binary Sensor Example
 
 `max6956` pins can be use as binary sensor. Individual pullup are supported.

--- a/src/content/docs/components/mcp230xx.mdx
+++ b/src/content/docs/components/mcp230xx.mdx
@@ -69,6 +69,8 @@ binary_sensor:
 ### Pin configuration variables
 
 - **mcp23xxx** (**Required**, [ID](/guides/configuration-types#id)): The id of the MCP23008 component.
+  Instead of an id, an `address:` can be given to select the hub by its I²C address; see
+  [Selecting an I2C expander by address](/guides/configuration-types#selecting-an-i2c-expander-by-address).
 - **interrupt** (*Optional*): Set this pin to trigger the INT pin on the component. Can be one of `CHANGE`, `RISING`, `FALLING`.
 - **number** (**Required**, int): The pin number.
 - **inverted** (*Optional*, boolean): If all read and written values
@@ -131,7 +133,9 @@ binary_sensor:
 
 ### Pin configuration variables
 
-- **mcp23xxx** (**Required**, [ID](/guides/configuration-types#id)): The id of the MCP23016 component.
+- **mcp23016** (**Required**, [ID](/guides/configuration-types#id)): The id of the MCP23016 component.
+  Instead of an id, an `address:` can be given to select the hub by its I²C address; see
+  [Selecting an I2C expander by address](/guides/configuration-types#selecting-an-i2c-expander-by-address).
 - All other options from [Pin Schema](/guides/configuration-types#pin-schema)
 
 <span id="mcp23017-label"></span>
@@ -201,6 +205,8 @@ binary_sensor:
 ### Pin configuration variables
 
 - **mcp23xxx** (**Required**, [ID](/guides/configuration-types#id)): The id of the MCP23017 component.
+  Instead of an id, an `address:` can be given to select the hub by its I²C address; see
+  [Selecting an I2C expander by address](/guides/configuration-types#selecting-an-i2c-expander-by-address).
 - **interrupt** (*Optional*): Set this pin to trigger the port INT pin on the component. Can be one of `CHANGE`, `RISING`, `FALLING`.
 - All other options from [Pin Schema](/guides/configuration-types#pin-schema)
 

--- a/src/content/docs/components/pca6416a.mdx
+++ b/src/content/docs/components/pca6416a.mdx
@@ -85,6 +85,8 @@ switch:
 ## Pin configuration variables
 
 - **pca6416a** (**Required**, [ID](/guides/configuration-types#id)): The id of the `pca6416a` component of the pin.
+  Instead of an id, an `address:` can be given to select the hub by its I²C address; see
+  [Selecting an I2C expander by address](/guides/configuration-types#selecting-an-i2c-expander-by-address).
 - **number** (**Required**, int): The pin number.
 - **inverted** (*Optional*, boolean): If all read and written values
   should be treated as inverted. Defaults to `false`.

--- a/src/content/docs/components/pca9554.mdx
+++ b/src/content/docs/components/pca9554.mdx
@@ -90,6 +90,8 @@ switch:
 ## Pin configuration variables
 
 - **pca9554** (**Required**, [ID](/guides/configuration-types#id)): The id of the `pca9554` component of the pin.
+  Instead of an id, an `address:` can be given to select the hub by its I²C address; see
+  [Selecting an I2C expander by address](/guides/configuration-types#selecting-an-i2c-expander-by-address).
 - **number** (**Required**, int): The pin number.
 - **inverted** (*Optional*, boolean): If all read and written values
   should be treated as inverted. Defaults to `false`.

--- a/src/content/docs/components/pcf8574.mdx
+++ b/src/content/docs/components/pcf8574.mdx
@@ -68,6 +68,8 @@ switch:
 ## Pin configuration variables
 
 - **pcf8574** (**Required**, [ID](/guides/configuration-types#id)): The id of the PCF8574 component of the pin.
+  Instead of an id, an `address:` can be given to select the hub by its I²C address; see
+  [Selecting an I2C expander by address](/guides/configuration-types#selecting-an-i2c-expander-by-address).
 - **number** (**Required**, int): The pin number.
 - **inverted** (*Optional*, boolean): If all read and written values
   should be treated as inverted. Defaults to `false`.

--- a/src/content/docs/components/pi4ioe5v6408.mdx
+++ b/src/content/docs/components/pi4ioe5v6408.mdx
@@ -54,6 +54,8 @@ binary_sensor:
 ## Pin configuration variables
 
 - **pi4ioe5v6408** (**Required**, [ID](/guides/configuration-types#id)): The id of the `pi4ioe5v6408` component of the pin.
+  Instead of an id, an `address:` can be given to select the hub by its I²C address; see
+  [Selecting an I2C expander by address](/guides/configuration-types#selecting-an-i2c-expander-by-address).
 - **number** (**Required**, int): The pin number. Valid range is 0-7.
 - **inverted** (*Optional*, boolean): If all read and written values should be treated as inverted.
   Defaults to `false`.

--- a/src/content/docs/components/sx1509.mdx
+++ b/src/content/docs/components/sx1509.mdx
@@ -177,6 +177,8 @@ light:
 ```
 
 - **sx1509** (**Required**, [ID](/guides/configuration-types#id)): The id of the SX1509 component of the pin.
+  Instead of an id, an `address:` can be given to select the hub by its I²C address; see
+  [Selecting an I2C expander by address](/guides/configuration-types#selecting-an-i2c-expander-by-address).
 - **number** (**Required**, int): The pin number.
 - **inverted** (*Optional*, boolean): If all read and written values
   should be treated as inverted. Defaults to `false`.

--- a/src/content/docs/components/tca9555.mdx
+++ b/src/content/docs/components/tca9555.mdx
@@ -47,6 +47,8 @@ switch:
 ## Pin configuration variables
 
 - **TCA9555** (**Required**, [ID](/guides/configuration-types#id)): The id of the TCA9555 component of the pin.
+  Instead of an id, an `address:` can be given to select the hub by its I²C address; see
+  [Selecting an I2C expander by address](/guides/configuration-types#selecting-an-i2c-expander-by-address).
 - **number** (**Required**, int): The pin number.
 - **inverted** (*Optional*, boolean): If all read and written values
   should be treated as inverted. Defaults to `false`.

--- a/src/content/docs/components/xl9535.mdx
+++ b/src/content/docs/components/xl9535.mdx
@@ -43,6 +43,8 @@ switch:
 ## Pin configuration variables
 
 - **xl9535** (**Required**, [ID](/guides/configuration-types#id)): The id of the `xl9535` component of the pin.
+  Instead of an id, an `address:` can be given to select the hub by its I²C address; see
+  [Selecting an I2C expander by address](/guides/configuration-types#selecting-an-i2c-expander-by-address).
 - **number** (**Required**, int): The pin number. Valid numbers are 0-7 and 10-17.
 - **inverted** (*Optional*, boolean): If all read and written values
   should be treated as inverted. Defaults to `false`.

--- a/src/content/docs/guides/configuration-types.mdx
+++ b/src/content/docs/guides/configuration-types.mdx
@@ -124,6 +124,33 @@ Advanced options:
   If you are *absolutely* certain that your specific board design allows a normally-reserved pin to be used,
   you can suppress the error by setting this option to `true`. Defaults to `false`.
 
+### Selecting an I2C expander by address
+
+Pins provided by an I²C I/O expander (`xl9535`, `pca9554`, `pca6416a`, `tca9555`, `mcp23xxx`,
+`mcp23016`, `sx1509`, `pcf8574`, `pi4ioe5v6408`, `max6956`) are referenced in the pin schema by the
+expander's own domain name, set to the id of the hub instance:
+
+```yaml
+pin:
+  xl9535: xl9535_hub
+  number: 4
+```
+
+If a configuration has more than one hub instance of the same expander type — for example, a board
+with two `xl9535` expanders at different I²C addresses — the id can be omitted and the hub selected
+instead by its I²C address, matched against the hub's own `address:`:
+
+```yaml
+pin:
+  xl9535:
+    address: 0x21
+  number: 4
+```
+
+This fails with a clear error if no hub of that type has a matching address, or if more than one
+does (for example, two hubs with the same address on different I²C buses — those still need
+explicit ids).
+
 ## Time
 
 In lots of places in ESPHome you need to define time periods.


### PR DESCRIPTION

<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
