### PR TITLE
Update ld6002b.mdx

### DIFF
--- a/src/content/docs/components/sensor/ld6002b.mdx
+++ b/src/content/docs/components/sensor/ld6002b.mdx
@@ -60,7 +60,7 @@ ld6002b:
 
 - GPIO IO voltage is 3.3 V.
 - The TX2 pin can output a simple presence signal (high when presence is detected).
-- Boot requires BOOT1 held low before startup (BOOT pins are pulled up internally).
+- Boot requires BOOT1 held low before startup (BOOT pins are pulled up internally). You need a resistor (like 10k Ohm) between GND on ESP and P19 on the sensor!
 
 ## Specifications
 
@@ -482,6 +482,9 @@ uart:
   tx_pin: GPIOXX
   rx_pin: GPIOXX
   baud_rate: 115200
+  data_bits: 8
+  parity: NONE
+  stop_bits: 1
 
 ld6002b:
   id: ld6002b_radar
@@ -538,6 +541,9 @@ uart:
   tx_pin: GPIOXX
   rx_pin: GPIOXX
   baud_rate: 115200
+  data_bits: 8
+  parity: NONE
+  stop_bits: 1
 
 ld6002b:
   id: ld6002b_radar


### PR DESCRIPTION
Updated the Power and Hardware Requirement for better understanding and added the Uart Properties to the example like in the start mentioned

<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
