### PR TITLE
[remote_transmitter] non_blocking is BK7238-only on Beken

### DIFF
--- a/src/content/docs/components/remote_transmitter.mdx
+++ b/src/content/docs/components/remote_transmitter.mdx
@@ -38,8 +38,8 @@ remote_transmitter:
   transmitters are connected to a single device.
 - **non_blocking** (*Optional*, boolean): If enabled, transmissions return immediately and complete in the
   background; the `on_complete` automation triggers once the transmission finishes. Only available on ESP32
-  variants with RMT hardware, where it defaults to `true`, and on RTL8720C, BK7231N and BK7238, where it
-  defaults to `false`.
+  variants with RMT hardware, where it defaults to `true`, and on RTL8720C and BK7238, where it defaults
+  to `false`.
 
 ### ESP32 RMT configuration variables
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Corrects the `non_blocking:` platform list: on Beken the option is BK7238 only.

BK7231N shares the PWM block but LibreTiny builds that family against an older SDK that does not expose the driver API the implementation uses, so it stays on the bit-bang path. The linked code PR fixes the resulting build failure and narrows the config gate to match.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#18958

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.
