### PR TITLE
[changelog] Add Device Builder section to 2026.9.0

### DIFF
--- a/src/content/docs/blog/2026/09/16/esphome-2026-9.mdx
+++ b/src/content/docs/blog/2026/09/16/esphome-2026-9.mdx
@@ -66,7 +66,9 @@ Improv provisioning to Ethernet-only boards, teaches WiFi provisioning to shut d
 when the window closes, and rewrites IR transmission on Beken and Realtek chips to run from a hardware timer
 interrupt instead of a busy-wait. The multi-release modbus overhaul continues with a heap-free write path, a
 consolidated range-join option, and continuous polling. Six new components (ds1603l, d01, sfa40, mk2pvrouter,
-snapshot, noise) and roughly a dozen feature additions to existing components round out the release.
+snapshot, noise) and roughly a dozen feature additions to existing components round out the release. The bundled
+Device Builder masks credentials in the YAML diff view, boots ESP32-C6 boards after a browser flash, and lets paired
+build servers recover from an address change on their own.
 {/* RELEASE_OVERVIEW_END */}
 
 ## Upgrade Checklist
@@ -172,6 +174,96 @@ is 104 bytes smaller per open encrypted connection ([#18420](https://github.com/
 the camera image reader is created lazily instead of per connection
 ([#18421](https://github.com/esphome/esphome/pull/18421)), and API message-type storage widened to `uint16_t`
 without adding per-connection RAM ([#18526](https://github.com/esphome/esphome/pull/18526)).
+
+## ESPHome Device Builder
+
+This section covers everything that changed in the bundled
+[ESPHome Device Builder](https://github.com/esphome/device-builder) since the 2026.8.0 release notes. Device Builder
+updates also ship in ESPHome patch releases for as long as the changes remain safe to include, so some of what
+follows already reached you during the 2026.8.x cycle; the rest is new with this release.
+
+**Secrets Stay Hidden**
+
+The YAML diff view used to render credentials in plain text, so a password the editor masks as bullets became visible
+the moment you flipped the diff toggle. The diff now masks the same sensitive values the editor does, and both the
+editor diff and the config migration preview gained a reveal toggle
+([frontend#1664](https://github.com/esphome/device-builder-frontend/pull/1664),
+[frontend#1665](https://github.com/esphome/device-builder-frontend/pull/1665)). The Device Builder also stopped
+corrupting `secrets.yaml` itself: a Wi-Fi password containing `#` made every Wi-Fi write append a second
+`wifi_password:` line, and the resulting parse failure came back as an internal error asking you to file a bug. The
+writer now understands quoted values, heals an already duplicated file on the next write, and reports a broken
+`secrets.yaml` as your file to fix ([#2624](https://github.com/esphome/device-builder/pull/2624)). The create-device
+error offers an **Open secrets** action that takes you to the Secrets page, where duplicate keys are flagged in place
+([frontend#1673](https://github.com/esphome/device-builder-frontend/pull/1673)), and the structured secrets editor
+recognises quoted keys ([frontend#1674](https://github.com/esphome/device-builder-frontend/pull/1674)).
+
+**ESPHome Web and First Use**
+
+Flashing an ESP32-C6, H2 or P4 from the browser left the chip sitting in the ROM bootloader instead of booting the new
+firmware, so Improv never answered and the Wi-Fi dialog waited forever. The USB-Serial/JTAG reset after flashing now
+boots the firmware, and the Improv dialog reopens the port that appears once the chip has actually started
+([frontend#1679](https://github.com/esphome/device-builder-frontend/pull/1679)). The **Prepare for first use** dialog
+gained an **Erase the device first** option, so a board that previously ran other firmware does not come up already
+provisioned with stale Wi-Fi credentials
+([frontend#1680](https://github.com/esphome/device-builder-frontend/pull/1680)).
+
+**Remote Builds**
+
+When a paired build server moves to a new IP on another subnet with no mDNS in between, the Device Builder used to dial
+the stale endpoint forever and the only way out was editing the endpoint by hand. The build server now remembers
+where the last session came from and, after five minutes of silence, dials back to announce its new address, so the
+pairing heals itself ([#2650](https://github.com/esphome/device-builder/pull/2650)). The install dialog's "Building
+on" line only shows the receiver's ESPHome version when the receiver really builds with it, rather than the version it
+had installed before provisioning ours ([#2628](https://github.com/esphome/device-builder/pull/2628),
+[frontend#1676](https://github.com/esphome/device-builder-frontend/pull/1676)), and
+[@bharvey88](https://github.com/bharvey88) rewrote the pairing walkthrough to match the current Settings screens,
+with recordings of each step ([#2623](https://github.com/esphome/device-builder/pull/2623)).
+
+**Device Cards and Table**
+
+[@Daniel085](https://github.com/Daniel085) brought the device comment back to the tile card, where the legacy
+dashboard used to show it ([frontend#1671](https://github.com/esphome/device-builder-frontend/pull/1671)); it is now
+set as a metadata row with a leading icon so it does not read as a second filename
+([frontend#1682](https://github.com/esphome/device-builder-frontend/pull/1682)). The card layout had a pass of its
+own: the divider hugs the action row instead of floating mid card on short cards, label chips line up across a row,
+and the `+N` overflow chip no longer wraps
+([frontend#1683](https://github.com/esphome/device-builder-frontend/pull/1683)). In the table view the device count
+now reflects the search box as well as the facet filters
+([frontend#1677](https://github.com/esphome/device-builder-frontend/pull/1677)), and toasts lift above the Install and
+Save buttons on the editor and Secrets pages instead of covering them
+([frontend#1681](https://github.com/esphome/device-builder-frontend/pull/1681)).
+
+**Editor Fixes**
+
+ESPHome ignores top-level keys that start with a dot, the documented way to park YAML anchors, but the editor's
+section parser did not, so the anchor list rendered as bogus unnamed cards and editing the section above it through
+the structured form silently deleted the anchor key. Dot-prefixed keys are now block boundaries everywhere the file is
+scanned, on both the frontend and backend side
+([frontend#1689](https://github.com/esphome/device-builder-frontend/pull/1689),
+[#2652](https://github.com/esphome/device-builder/pull/2652)). The add-component form no longer demands `cs_pin`,
+`dc_pin` and `dimensions` for a display model that predefines them, since required fields for model-driven displays
+such as `epaper_spi` are now resolved per model ([#2648](https://github.com/esphome/device-builder/pull/2648)), and
+the `variables`, `data` and `data_template` maps on the Home Assistant actions keep their map editor with the 2026.9
+schema ([#2655](https://github.com/esphome/device-builder/pull/2655)). The log viewer explains ESP32 "TCP buffer
+full" warnings with a popover linking to the new
+[`tcp_send_buffer`](/components/network/#configuration-variables) option
+([frontend#1672](https://github.com/esphome/device-builder-frontend/pull/1672)), and a component whose config example
+appears on more than one docs page, like `xiaomi_lywsd03mmc`, gets its docs link back
+([#2609](https://github.com/esphome/device-builder/pull/2609)).
+
+**Under the Hood**
+
+Out-of-band edit detection moved from a hand-maintained list of keys to a versioned fingerprint of the whole file, so
+a future change to the algorithm can never again trigger a fleet-wide regeneration and build-directory wipe on the
+first scan after an upgrade ([#2617](https://github.com/esphome/device-builder/pull/2617)). A third-party device
+advertising an mDNS service name with control characters no longer floods the log with tracebacks
+([#2621](https://github.com/esphome/device-builder/pull/2621)), the plain Docker container reaps orphaned `git` and
+compile processes instead of leaving them defunct when running as PID 1
+([#2636](https://github.com/esphome/device-builder/pull/2636)), and version history ignores the fake executable bit
+Samba puts on files edited from Windows, so every diff no longer carries a mode change
+([#2646](https://github.com/esphome/device-builder/pull/2646)).
+[@rwrozelle](https://github.com/rwrozelle) kept nRF52 boards resolving in the catalog ahead of the move to Hardware
+Model v2 board names ([#2618](https://github.com/esphome/device-builder/pull/2618)).
 
 ## Encrypted OTA Updates
 

--- a/src/content/docs/blog/2026/09/16/esphome-2026-9.mdx
+++ b/src/content/docs/blog/2026/09/16/esphome-2026-9.mdx
@@ -177,93 +177,42 @@ without adding per-connection RAM ([#18526](https://github.com/esphome/esphome/p
 
 ## ESPHome Device Builder
 
-This section covers everything that changed in the bundled
-[ESPHome Device Builder](https://github.com/esphome/device-builder) since the 2026.8.0 release notes. Device Builder
-updates also ship in ESPHome patch releases for as long as the changes remain safe to include, so some of what
-follows already reached you during the 2026.8.x cycle; the rest is new with this release.
+This is a smaller cycle for the bundled [ESPHome Device Builder](https://github.com/esphome/device-builder), and
+most of it already reached you through the 2026.8.x patch releases; this section covers everything since the 2026.8.0
+release notes.
 
-**Secrets Stay Hidden**
+The YAML diff view used to render credentials in plain text the moment you flipped the diff toggle. It now masks the
+same sensitive values the editor does, with a reveal toggle
+([frontend#1664](https://github.com/esphome/device-builder-frontend/pull/1664)). A Wi-Fi password containing `#`
+made every Wi-Fi write append a second `wifi_password:` line to `secrets.yaml`; the writer now handles quoted values,
+heals an already duplicated file, and reports a broken `secrets.yaml` as your file to fix rather than an internal
+error ([#2624](https://github.com/esphome/device-builder/pull/2624),
+[frontend#1673](https://github.com/esphome/device-builder-frontend/pull/1673)).
 
-The YAML diff view used to render credentials in plain text, so a password the editor masks as bullets became visible
-the moment you flipped the diff toggle. The diff now masks the same sensitive values the editor does, and both the
-editor diff and the config migration preview gained a reveal toggle
-([frontend#1664](https://github.com/esphome/device-builder-frontend/pull/1664),
-[frontend#1665](https://github.com/esphome/device-builder-frontend/pull/1665)). The Device Builder also stopped
-corrupting `secrets.yaml` itself: a Wi-Fi password containing `#` made every Wi-Fi write append a second
-`wifi_password:` line, and the resulting parse failure came back as an internal error asking you to file a bug. The
-writer now understands quoted values, heals an already duplicated file on the next write, and reports a broken
-`secrets.yaml` as your file to fix ([#2624](https://github.com/esphome/device-builder/pull/2624)). The create-device
-error offers an **Open secrets** action that takes you to the Secrets page, where duplicate keys are flagged in place
-([frontend#1673](https://github.com/esphome/device-builder-frontend/pull/1673)), and the structured secrets editor
-recognises quoted keys ([frontend#1674](https://github.com/esphome/device-builder-frontend/pull/1674)).
-
-**ESPHome Web and First Use**
-
-Flashing an ESP32-C6, H2 or P4 from the browser left the chip sitting in the ROM bootloader instead of booting the new
-firmware, so Improv never answered and the Wi-Fi dialog waited forever. The USB-Serial/JTAG reset after flashing now
-boots the firmware, and the Improv dialog reopens the port that appears once the chip has actually started
-([frontend#1679](https://github.com/esphome/device-builder-frontend/pull/1679)). The **Prepare for first use** dialog
-gained an **Erase the device first** option, so a board that previously ran other firmware does not come up already
-provisioned with stale Wi-Fi credentials
+On ESPHome Web, flashing an ESP32-C6, H2 or P4 left the chip in the ROM bootloader instead of booting the new
+firmware, so Improv never answered. The reset after flashing now boots the firmware
+([frontend#1679](https://github.com/esphome/device-builder-frontend/pull/1679)), and **Prepare for first use** gained
+an **Erase the device first** option so a board that ran other firmware does not come up with stale Wi-Fi credentials
 ([frontend#1680](https://github.com/esphome/device-builder-frontend/pull/1680)).
 
-**Remote Builds**
+A paired build server that moves to a new IP on another subnet used to be reachable again only by editing the
+endpoint by hand. After five minutes of silence it now dials back to announce its new address, so the pairing heals
+itself ([#2650](https://github.com/esphome/device-builder/pull/2650)).
 
-When a paired build server moves to a new IP on another subnet with no mDNS in between, the Device Builder used to dial
-the stale endpoint forever and the only way out was editing the endpoint by hand. The build server now remembers
-where the last session came from and, after five minutes of silence, dials back to announce its new address, so the
-pairing heals itself ([#2650](https://github.com/esphome/device-builder/pull/2650)). The install dialog's "Building
-on" line only shows the receiver's ESPHome version when the receiver really builds with it, rather than the version it
-had installed before provisioning ours ([#2628](https://github.com/esphome/device-builder/pull/2628),
-[frontend#1676](https://github.com/esphome/device-builder-frontend/pull/1676)), and
-[@bharvey88](https://github.com/bharvey88) rewrote the pairing walkthrough to match the current Settings screens,
-with recordings of each step ([#2623](https://github.com/esphome/device-builder/pull/2623)).
-
-**Device Cards and Table**
-
-[@Daniel085](https://github.com/Daniel085) brought the device comment back to the tile card, where the legacy
-dashboard used to show it ([frontend#1671](https://github.com/esphome/device-builder-frontend/pull/1671)); it is now
-set as a metadata row with a leading icon so it does not read as a second filename
-([frontend#1682](https://github.com/esphome/device-builder-frontend/pull/1682)). The card layout had a pass of its
-own: the divider hugs the action row instead of floating mid card on short cards, label chips line up across a row,
-and the `+N` overflow chip no longer wraps
-([frontend#1683](https://github.com/esphome/device-builder-frontend/pull/1683)). In the table view the device count
-now reflects the search box as well as the facet filters
-([frontend#1677](https://github.com/esphome/device-builder-frontend/pull/1677)), and toasts lift above the Install and
-Save buttons on the editor and Secrets pages instead of covering them
-([frontend#1681](https://github.com/esphome/device-builder-frontend/pull/1681)).
-
-**Editor Fixes**
-
-ESPHome ignores top-level keys that start with a dot, the documented way to park YAML anchors, but the editor's
-section parser did not, so the anchor list rendered as bogus unnamed cards and editing the section above it through
-the structured form silently deleted the anchor key. Dot-prefixed keys are now block boundaries everywhere the file is
-scanned, on both the frontend and backend side
+In the editor, dot-prefixed top-level keys, the documented way to park YAML anchors, no longer render as bogus cards
+or get deleted when you edit the section above them through the structured form
 ([frontend#1689](https://github.com/esphome/device-builder-frontend/pull/1689),
-[#2652](https://github.com/esphome/device-builder/pull/2652)). The add-component form no longer demands `cs_pin`,
-`dc_pin` and `dimensions` for a display model that predefines them, since required fields for model-driven displays
-such as `epaper_spi` are now resolved per model ([#2648](https://github.com/esphome/device-builder/pull/2648)), and
-the `variables`, `data` and `data_template` maps on the Home Assistant actions keep their map editor with the 2026.9
-schema ([#2655](https://github.com/esphome/device-builder/pull/2655)). The log viewer explains ESP32 "TCP buffer
-full" warnings with a popover linking to the new
-[`tcp_send_buffer`](/components/network/#configuration-variables) option
-([frontend#1672](https://github.com/esphome/device-builder-frontend/pull/1672)), and a component whose config example
-appears on more than one docs page, like `xiaomi_lywsd03mmc`, gets its docs link back
-([#2609](https://github.com/esphome/device-builder/pull/2609)).
+[#2652](https://github.com/esphome/device-builder/pull/2652)), and the add-component form stops demanding pins and
+dimensions that the selected display model already predefines
+([#2648](https://github.com/esphome/device-builder/pull/2648)). [@Daniel085](https://github.com/Daniel085) brought
+the device comment back to the tile card
+([frontend#1671](https://github.com/esphome/device-builder-frontend/pull/1671)).
 
-**Under the Hood**
-
-Out-of-band edit detection moved from a hand-maintained list of keys to a versioned fingerprint of the whole file, so
-a future change to the algorithm can never again trigger a fleet-wide regeneration and build-directory wipe on the
-first scan after an upgrade ([#2617](https://github.com/esphome/device-builder/pull/2617)). A third-party device
-advertising an mDNS service name with control characters no longer floods the log with tracebacks
-([#2621](https://github.com/esphome/device-builder/pull/2621)), the plain Docker container reaps orphaned `git` and
-compile processes instead of leaving them defunct when running as PID 1
+Under the hood, out-of-band edit detection uses a versioned whole-file fingerprint, so a future algorithm change can
+never again trigger a fleet-wide regeneration on upgrade ([#2617](https://github.com/esphome/device-builder/pull/2617)),
+the Docker container reaps orphaned processes when running as PID 1
 ([#2636](https://github.com/esphome/device-builder/pull/2636)), and version history ignores the fake executable bit
-Samba puts on files edited from Windows, so every diff no longer carries a mode change
-([#2646](https://github.com/esphome/device-builder/pull/2646)).
-[@rwrozelle](https://github.com/rwrozelle) kept nRF52 boards resolving in the catalog ahead of the move to Hardware
-Model v2 board names ([#2618](https://github.com/esphome/device-builder/pull/2618)).
+Samba puts on files edited from Windows ([#2646](https://github.com/esphome/device-builder/pull/2646)).
 
 ## Encrypted OTA Updates
 

--- a/src/content/docs/blog/2026/09/16/esphome-2026-9.mdx
+++ b/src/content/docs/blog/2026/09/16/esphome-2026-9.mdx
@@ -183,8 +183,8 @@ release notes.
 
 The YAML diff view used to render credentials in plain text the moment you flipped the diff toggle. It now masks the
 same sensitive values the editor does, with a reveal toggle
-([frontend#1664](https://github.com/esphome/device-builder-frontend/pull/1664)). A Wi-Fi password containing `#`
-made every Wi-Fi write append a second `wifi_password:` line to `secrets.yaml`; the writer now handles quoted values,
+([frontend#1664](https://github.com/esphome/device-builder-frontend/pull/1664)). A WiFi password containing `#`
+made every WiFi write append a second `wifi_password:` line to `secrets.yaml`; the writer now handles quoted values,
 heals an already duplicated file, and reports a broken `secrets.yaml` as your file to fix rather than an internal
 error ([#2624](https://github.com/esphome/device-builder/pull/2624),
 [frontend#1673](https://github.com/esphome/device-builder-frontend/pull/1673)).
@@ -192,7 +192,7 @@ error ([#2624](https://github.com/esphome/device-builder/pull/2624),
 On ESPHome Web, flashing an ESP32-C6, H2 or P4 left the chip in the ROM bootloader instead of booting the new
 firmware, so Improv never answered. The reset after flashing now boots the firmware
 ([frontend#1679](https://github.com/esphome/device-builder-frontend/pull/1679)), and **Prepare for first use** gained
-an **Erase the device first** option so a board that ran other firmware does not come up with stale Wi-Fi credentials
+an **Erase the device first** option so a board that ran other firmware does not come up with stale WiFi credentials
 ([frontend#1680](https://github.com/esphome/device-builder-frontend/pull/1680)).
 
 A paired build server that moves to a new IP on another subnet used to be reachable again only by editing the


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Adds a Device Builder section to the 2026.9.0 release notes. 2026.8.0 shipped with device-builder 1.12.0, the current
beta ships 1.13.1 and dev is on 1.14.0; the releases in between went out through the 2026.8.1 and 2026.8.2 patch
releases and were never written up, so this covers everything from 1.12.1 through 1.14.0. No version numbers in the
copy, since more Device Builder releases may ship before 2026.9.0 goes final.

A smaller cycle than last time, so the section is kept short: the masked YAML diff view and the secrets.yaml fix,
the ESP32-C6 browser flash fix and erase option, build server connect back, the dot-prefixed anchor key fix, and a
few reliability items. Catalog syncs, dependency bumps, refactors and CI are left out. Also adds one Device Builder
sentence to the release overview.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
