### PR TITLE
[blog] Add tagline and description for 2026.9.0 release post

### DIFF
--- a/src/content/docs/blog/2026/09/16/esphome-2026-9.mdx
+++ b/src/content/docs/blog/2026/09/16/esphome-2026-9.mdx
@@ -1,14 +1,14 @@
 ---
-title: "ESPHome 2026.9.0: {TAGLINE}"
-description: "{DESCRIPTION}"
+title: "ESPHome 2026.9.0: Faster builds and encrypted OTA"
+description: "ESPHome 2026.9.0 parallelizes PlatformIO installs, lays the groundwork for a native ESP8266 toolchain, adds Noise-encrypted OTA updates, and frees ESP8266 RAM."
 date: 2026-09-16
 authors:
   - jesse
 tags:
   - Releases
-excerpt: "{DESCRIPTION}"
+excerpt: "ESPHome 2026.9.0 parallelizes PlatformIO installs, lays the groundwork for a native ESP8266 toolchain, adds Noise-encrypted OTA updates, and frees ESP8266 RAM."
 cover:
-  alt: "ESPHome 2026.9.0: {TAGLINE}"
+  alt: "ESPHome 2026.9.0: Faster builds and encrypted OTA"
   image: "https://assets.openhomefoundation.org/opengraph?url=https://esphome.io/blog/2026/09/16/esphome-2026-9"
 head:
   - tag: meta
@@ -26,7 +26,7 @@ head:
   - tag: meta
     attrs:
       property: "og:image:title2"
-      content: "{TAGLINE}"
+      content: "Faster builds and encrypted OTA"
   - tag: meta
     attrs:
       property: "og:image:author"


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Fills in the `{TAGLINE}` and `{DESCRIPTION}` placeholders in the 2026.9.0 release blog post frontmatter (title, description, excerpt, cover alt, and the `og:image:title2` meta tag). Content is drawn from the release overview: build system parallelization, the ESP8266 native toolchain groundwork, Noise-encrypted OTA, and the ESP8266 RAM sweep.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.