### PR TITLE
Document hold_during_sleep option for ESP32

### DIFF
--- a/src/content/docs/guides/configuration-types.mdx
+++ b/src/content/docs/guides/configuration-types.mdx
@@ -107,6 +107,11 @@ Advanced options:
   i.e. the maximum amount of current can additionally be set. Defaults to `20mA`.
   Options are `5mA`, `10mA`, `20mA`, `40mA`.
 
+- **hold_during_sleep** (*Optional*, boolean): Hold pin during deepsleep on ESP32. Set this to `true` to hold
+  the output level or pullup/pulldown mode during deepsleep. Hold should be used only for GPIO pins and not
+  for pins that are used for peripherals like `i2c`, `uart` or `rmt`. If the pin is also used elsewhere and `allow_other_uses`
+  is set, make sure to use hold on all or none. Defaults to `false`.
+
 - **ignore_strapping_warning** (*Optional*, boolean): Certain pins on ESP32s are designated *strapping pins* and are read
   by the chip on reset to configure initial operation, e.g. to enable bootstrap mode.
   Using such pins for I/O should be avoided and ESPHome will warn if I/O is configured on a strapping pin.

--- a/src/content/docs/guides/configuration-types.mdx
+++ b/src/content/docs/guides/configuration-types.mdx
@@ -110,7 +110,8 @@ Advanced options:
 - **hold_during_sleep** (*Optional*, boolean): Hold pin during deepsleep on ESP32. Set this to `true` to hold
   the output level or pullup/pulldown mode during deepsleep. Hold should be used only for GPIO pins and not
   for pins that are used for peripherals like `i2c`, `uart` or `rmt`. If the pin is also used elsewhere and `allow_other_uses`
-  is set, make sure to use hold on all or none. Defaults to `false`.
+  is set, make sure to use hold on all or none. **Attention:** If a held pin is completely removed from the configuration and
+  the device is OTA updated a hardware reset is needed to clear the held state. Defaults to `false`.
 
 - **ignore_strapping_warning** (*Optional*, boolean): Certain pins on ESP32s are designated *strapping pins* and are read
   by the chip on reset to configure initial operation, e.g. to enable bootstrap mode.


### PR DESCRIPTION
Added documentation for hold_during_sleep option in ESP32 configuration.

<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#18964

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

