### PR TITLE
[blog] Refer to the Home Assistant App in the 2026.9 release post

### DIFF
--- a/src/content/docs/blog/2026/09/16/esphome-2026-9.mdx
+++ b/src/content/docs/blog/2026/09/16/esphome-2026-9.mdx
@@ -116,7 +116,7 @@ build path for those users.
 ## Build System Parallelization
 
 The install phase of a PlatformIO build was serial from top to bottom, which showed up most sharply on
-Raspberry Pi class hardware and inside the Home Assistant add-on. This release parallelizes it end to end.
+Raspberry Pi class hardware and inside the Home Assistant App. This release parallelizes it end to end.
 [@bdraco](https://github.com/bdraco) added a shared batch download runner with one combined progress bar
 ([#18662](https://github.com/esphome/esphome/pull/18662)), a prefetch subprocess that resolves and downloads
 PlatformIO packages in parallel into PlatformIO's own cache


### PR DESCRIPTION
## Description

The Build System Parallelization section of the 2026.9.0 release post said "Home Assistant add-on". Changed to "Home Assistant App".

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

Note: this is a wording fix, but the 2026.9.0 release post only exists on `next`, so `next` is the correct base.