### PR TITLE
[light] Document RESTORE_DEFAULT_INITIAL_STATE

### DIFF
--- a/src/content/docs/components/light/index.mdx
+++ b/src/content/docs/components/light/index.mdx
@@ -308,7 +308,7 @@ on_...:
 **Configuration variables:**
 
 - **id** (**Required**, [ID](/guides/configuration-types#id)): The ID of the light.
-- **state** (*Optional*, [boolean](/guides/configuration-types/#boolean), [templatable](/automations/templates)): Change the ON/OFF state for the light.
+- **state** (*Optional*, [boolean](/guides/configuration-types#boolean), [templatable](/automations/templates)): Change the ON/OFF state for the light.
 - All other options from [light state](#light-state).
 
 ### `light.dim_relative` Action

--- a/src/content/docs/components/light/index.mdx
+++ b/src/content/docs/components/light/index.mdx
@@ -50,13 +50,14 @@ light:
 - **initial_state** (*Optional*): The initial state the light should be set to on bootup. This state will be applied
   when the state is **not** restored based on `restore_mode` (below).
 
-  - **state** (*Optional*, boolean, [templatable](/automations/templates)): The ON/OFF state for the light.
+  - **state** (*Optional*, [boolean](/guides/configuration-types/#boolean), [templatable](/automations/templates)): The ON/OFF state for the light.
   - All other options from [light state](#light-state).
 
 - **restore_mode** (*Optional*): Control how the light attempts to restore state on bootup.
 
   - `RESTORE_DEFAULT_OFF` - Attempt to restore state and default to OFF if not possible to restore.
   - `RESTORE_DEFAULT_ON` - Attempt to restore state and default to ON.
+  - `RESTORE_DEFAULT_INITIAL_STATE` - Attempt to restore state and default to the configured initial state.
   - `RESTORE_INVERTED_DEFAULT_OFF` - Attempt to restore state inverted from the previous state and default to OFF.
   - `RESTORE_INVERTED_DEFAULT_ON` - Attempt to restore state inverted from the previous state and default to ON.
   - `RESTORE_AND_OFF` - Attempt to restore state but initialize the light as OFF.
@@ -307,7 +308,7 @@ on_...:
 **Configuration variables:**
 
 - **id** (**Required**, [ID](/guides/configuration-types#id)): The ID of the light.
-- **state** (*Optional*, [templatable](/automations/templates), boolean): Change the ON/OFF state of the light.
+- **state** (*Optional*, [boolean](/guides/configuration-types/#boolean), [templatable](/automations/templates)): Change the ON/OFF state for the light.
 - All other options from [light state](#light-state).
 
 ### `light.dim_relative` Action
@@ -656,7 +657,7 @@ light:
 - **name** (*Optional*, string): The name of the effect. Defaults to `Strobe`.
 - **colors** (*Optional*, list): A list of colors to cycle through. Defaults to a quick cycle between ON and OFF.
 
-  - **state** (*Optional*, boolean): The on/off state to show. Defaults to `true`.
+  - **state** (*Optional*, boolean): The on/off state to show. Defaults to `on`.
   - **color_mode** (*Optional*, string): The color mode of the light. Defaults to the current color mode.
   - **brightness** (*Optional*, percentage): The brightness of the light. Defaults to `100%`.
   - **color_brightness** (*Optional*, percentage): The brightness of the RGB lights, if applicable. Defaults to `100%`.

--- a/src/content/docs/components/light/index.mdx
+++ b/src/content/docs/components/light/index.mdx
@@ -50,7 +50,7 @@ light:
 - **initial_state** (*Optional*): The initial state the light should be set to on bootup. This state will be applied
   when the state is **not** restored based on `restore_mode` (below).
 
-  - **state** (*Optional*, [boolean](/guides/configuration-types/#boolean), [templatable](/automations/templates)): The ON/OFF state for the light.
+  - **state** (*Optional*, [boolean](/guides/configuration-types#boolean), [templatable](/automations/templates)): The ON/OFF state for the light.
   - All other options from [light state](#light-state).
 
 - **restore_mode** (*Optional*): Control how the light attempts to restore state on bootup.

--- a/src/content/docs/guides/configuration-types.mdx
+++ b/src/content/docs/guides/configuration-types.mdx
@@ -124,6 +124,16 @@ Advanced options:
   If you are *absolutely* certain that your specific board design allows a normally-reserved pin to be used,
   you can suppress the error by setting this option to `true`. Defaults to `false`.
 
+## Boolean
+
+Wherever a boolean value is required, you may provide one of several forms that map to `true` and `false`.
+
+- Truthy values are:  `true`, `yes`, `on` and `enable`.
+- Falsy values are: `false`, `no`, `off` and `disable`.
+
+
+
+
 ## Time
 
 In lots of places in ESPHome you need to define time periods.

--- a/src/content/docs/guides/configuration-types.mdx
+++ b/src/content/docs/guides/configuration-types.mdx
@@ -128,10 +128,8 @@ Advanced options:
 
 Wherever a boolean value is required, you may provide one of several forms that map to `true` and `false`.
 
-- Truthy values are:  `true`, `yes`, `on` and `enable`.
+- Truthy values are: `true`, `yes`, `on` and `enable`.
 - Falsy values are: `false`, `no`, `off` and `disable`.
-
-
 
 
 ## Time

--- a/src/content/docs/guides/configuration-types.mdx
+++ b/src/content/docs/guides/configuration-types.mdx
@@ -127,6 +127,7 @@ Advanced options:
 ## Boolean
 
 Wherever a boolean value is required, you may provide one of several forms that map to `true` and `false`.
+All values are case-insensitive.
 
 - Truthy values are: `true`, `yes`, `on` and `enable`.
 - Falsy values are: `false`, `no`, `off` and `disable`.


### PR DESCRIPTION
Also add a configuration type explanation for boolean values.

<!-- markdownlint-disable -->

## Description

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#18978

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
