### PR TITLE
[ota] Document how to enable encryption on an existing device

### DIFF
--- a/src/content/docs/blog/2026/09/16/esphome-2026-9.mdx
+++ b/src/content/docs/blog/2026/09/16/esphome-2026-9.mdx
@@ -180,8 +180,9 @@ without adding per-connection RAM ([#18526](https://github.com/esphome/esphome/p
 uses. Until now the firmware image travelled over the network in plaintext, so a passive listener on the LAN
 could capture the WiFi credentials and API encryption key embedded in the image; the SHA256 password only
 authenticated the client, it did not make the transfer confidential. A device with an `api` encryption key
-now offers OTA encryption with that key and the CLI uses it whenever the device offers, so enabling it on an
-installed device is an ordinary update ([#18979](https://github.com/esphome/esphome/pull/18979)). An
+now offers OTA encryption with that key and the CLI uses it whenever the device offers, so once a device runs
+this release, enabling encryption is an ordinary update; the update that brings older firmware to this release
+still travels in plaintext ([#18979](https://github.com/esphome/esphome/pull/18979)). An
 `encryption:` block on the OTA platform is what makes the device require it: both the device and the CLI then
 fail closed so an attacker cannot strip encryption and force a plaintext upload. A bare `encryption:` inherits
 the `api` encryption key, and a password and encryption are mutually exclusive because the key already

--- a/src/content/docs/blog/2026/09/16/esphome-2026-9.mdx
+++ b/src/content/docs/blog/2026/09/16/esphome-2026-9.mdx
@@ -179,10 +179,13 @@ without adding per-connection RAM ([#18526](https://github.com/esphome/esphome/p
 ([#18489](https://github.com/esphome/esphome/pull/18489)), using the same protocol the native API already
 uses. Until now the firmware image travelled over the network in plaintext, so a passive listener on the LAN
 could capture the WiFi credentials and API encryption key embedded in the image; the SHA256 password only
-authenticated the client, it did not make the transfer confidential. With an `encryption:` block on the OTA
-platform the whole session is encrypted, and both the device and the CLI fail closed so an attacker cannot
-strip encryption and force a plaintext upload. A bare `encryption:` inherits the `api` encryption key, and a
-password and encryption are mutually exclusive because the key already authenticates the uploader. This work
+authenticated the client, it did not make the transfer confidential. A device with an `api` encryption key
+now offers OTA encryption with that key and the CLI uses it whenever the device offers, so enabling it on an
+installed device is an ordinary update ([#18979](https://github.com/esphome/esphome/pull/18979)). An
+`encryption:` block on the OTA platform is what makes the device require it: both the device and the CLI then
+fail closed so an attacker cannot strip encryption and force a plaintext upload. A bare `encryption:` inherits
+the `api` encryption key, and a password and encryption are mutually exclusive because the key already
+authenticates the uploader. This work
 sits on top of a new shared `noise` component ([#18490](https://github.com/esphome/esphome/pull/18490)) that
 lifts the noise-c dependency, HWRNG binding, error strings, PSK context, encryption key validation and the
 handshake responder out of the api component so both api and ota can share them; there is no user

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -135,7 +135,9 @@ exists while the fallback AP is active).
 A device built with an [API encryption key](/components/api) on ESPHome 2026.9.0 or newer already offers OTA
 encryption, even without an `encryption:` block under `ota:`. Such a device accepts both plaintext and encrypted
 uploads; a plaintext upload still has to pass the OTA password if one is set, while an encrypted upload is
-authenticated by the key. Adding the block is what makes the device require encryption. To turn it on:
+authenticated by the key. Because the key already authenticates uploads, a config with both an API key and an OTA
+`password:` validates with a warning suggesting you replace the password with the `encryption:` block. Adding the
+block is what makes the device require encryption. To turn it on:
 
 1. Make sure the device runs ESPHome 2026.9.0 or newer with an API encryption key. If it does not, install that first
    without the `encryption:` block under `ota:`. This one install goes over plaintext OTA (or USB).

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -132,25 +132,21 @@ exists while the fallback AP is active).
 
 ### Enabling encryption on an existing device
 
-A device built with an [API encryption key](/components/api) on ESPHome 2026.9.0 or newer already offers OTA
-encryption, even without an `encryption:` block under `ota:`. Such a device accepts both plaintext and encrypted
-uploads; a plaintext upload still has to pass the OTA password if one is set, while an encrypted upload is
-authenticated by the key. Because the key already authenticates uploads, an OTA `password:` next to an API key only
-serves older clients without encryption support and wastes significant flash and RAM (about 3.5 KB and 60 bytes on an
-ESP8266, plus the password on the heap); such a config validates with a warning suggesting you replace the password with
-the `encryption:` block. Adding the block is what makes the device require encryption. To turn it on:
+A device built on ESPHome 2026.9.0 or newer with an [API encryption key](/components/api) already offers OTA
+encryption without an `encryption:` block under `ota:`: it accepts plaintext uploads (guarded by the OTA password, if
+set) and encrypted uploads authenticated by the key. The block is what makes it require encryption.
 
-1. Make sure the device runs ESPHome 2026.9.0 or newer with an API encryption key. If it does not, install that first
-   without the `encryption:` block under `ota:`. This one install goes over plaintext OTA (or USB).
-2. Add `encryption:` to the `ota:` block, remove any `password:` line, and install again. This install is already
-   encrypted, and so is every install after it.
+1. If the device runs older firmware or has no API key, install once without the block; that install goes over
+   plaintext OTA (or USB).
+2. Add `encryption:` to the `ota:` block, remove any `password:`, and install again. This install and every later one
+   are encrypted.
 
-If you add the block while the device still runs older firmware, the upload stops with
-`the device did not offer encryption; refusing to send the image in plaintext`. Remove the block, keep the API key,
-install once, then restore the block and install again.
+Adding the block while the device still runs older firmware stops with `the device did not offer encryption;
+refusing to send the image in plaintext`: remove the block, install once, then restore it.
 
-An API `encryption:` block without a `key:` provisions the key at runtime, so it is not known when the firmware is
-built and such a device does not offer OTA encryption. Set an explicit key to use OTA encryption.
+An OTA `password:` next to an API key only serves older clients without encryption support and costs about 3.5 KB of
+flash and 60 bytes of RAM on an ESP8266, so validation warns and suggests the `encryption:` block instead. An API
+`encryption:` block without a `key:` is provisioned at runtime and does not offer OTA encryption; set an explicit key.
 
 To troubleshoot a failing encrypted handshake, raise the log level of the shared `noise` component:
 

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -136,9 +136,9 @@ A device built with an [API encryption key](/components/api) on ESPHome 2026.9.0
 encryption, even without an `encryption:` block under `ota:`. Such a device accepts both plaintext and encrypted
 uploads; a plaintext upload still has to pass the OTA password if one is set, while an encrypted upload is
 authenticated by the key. Because the key already authenticates uploads, an OTA `password:` next to an API key only
-serves older clients without encryption support and wastes flash and RAM; such a config validates with a warning
-suggesting you replace the password with the `encryption:` block. Adding the block is what makes the device require
-encryption. To turn it on:
+serves older clients without encryption support and wastes significant flash and RAM (about 3.5 KB and 60 bytes on an
+ESP8266, plus the password on the heap); such a config validates with a warning suggesting you replace the password with
+the `encryption:` block. Adding the block is what makes the device require encryption. To turn it on:
 
 1. Make sure the device runs ESPHome 2026.9.0 or newer with an API encryption key. If it does not, install that first
    without the `encryption:` block under `ota:`. This one install goes over plaintext OTA (or USB).

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -121,8 +121,8 @@ a key with the on demand generator in the [API component documentation](/compone
 
 Encryption cannot be combined with a password; the key already authenticates the uploader, so remove the `password:`
 line when you add `encryption:`. Combining it with the [web server OTA platform](/components/ota/web_server) is allowed
-but warned about: that endpoint accepts the same firmware image over plaintext HTTP (with `captive_portal:` alone it only
-exists while the fallback AP is active).
+but warned about: that endpoint accepts the same firmware image over plaintext HTTP. With `captive_portal:` alone the
+endpoint only exists while the fallback AP is active and is the intended recovery path, so there is no warning.
 
 > [!IMPORTANT]
 > Once a device runs firmware with `encryption:` enabled it refuses plaintext OTA updates, and the CLI refuses to send

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -28,7 +28,7 @@ ota:
 
 - **encryption** (*Optional*): Encrypt the OTA update with the same Noise protocol the [native API](/components/api) uses. See [Encryption](#encryption) below. Cannot be combined with **password**.
 
-  - **key** (*Optional*, string): The base64 encryption key. When omitted, the [API encryption key](/components/api#configuration-variables) is used, so a single key protects the device. When set, it must match the API encryption key.
+  - **key** (*Optional*, string): The base64 encryption key. When omitted, the [API encryption key](/components/api#configuration-variables) is used, so a single key protects the device. When set, it must match a static API encryption key.
 
 - **password** (*Optional*, string): The password to use for updates. Cannot be combined with **encryption**.
 - **allow_partition_access** (*Optional*, boolean): Only on `esp32`. Allow updating more partition types. Used for updating the partition table and the bootloader. Defaults to `false`.
@@ -120,28 +120,16 @@ You may set an explicit `key:` instead, but it must match the API encryption key
 a key with the on demand generator in the [API component documentation](/components/api#configuration-variables).
 
 Encryption cannot be combined with a password; the key already authenticates the uploader, so remove the `password:`
-line when you add `encryption:`. Combining it with the [web server OTA platform](/components/ota/web_server) is allowed
-but warned about, since that endpoint accepts the same firmware image over plaintext HTTP; the copy `captive_portal:`
-loads on its own is the recovery path and does not warn.
+line when you add `encryption:`. Adding the [web server OTA platform](/components/ota/web_server) next to it is allowed
+but warns during validation, since that endpoint accepts the same firmware image over plaintext HTTP. The captive
+portal's update page (`captive_portal:` without that platform) exists only while the fallback AP is active and is the
+intended recovery path, so it does not warn.
 
 > [!IMPORTANT]
 > Once a device runs firmware with `encryption:` enabled it refuses plaintext OTA updates, and the CLI refuses to send
-> a plaintext image when `encryption:` is configured. This is intentional; a downgrade to plaintext would be an unauthenticated
-> upload. If a device that requires encryption becomes unreachable, recover it with the
-> [web server OTA platform](/components/ota/web_server) or a serial flash.
-
-### Enabling encryption on an existing device
-
-A device on ESPHome 2026.9.0 or newer with an [API encryption key](/components/api) already offers OTA encryption, and
-`esphome run` uses that key whenever the device offers; the `encryption:` block is what makes the device require it.
-Add the block, remove any `password:`, and install. If the device still runs firmware that cannot encrypt, the install
-stops with `the device did not offer encryption; refusing to send the image in plaintext`: install once without the
-block first (until ESPHome 2027.3.0 that upload falls back to plaintext with a warning), then restore it.
-
-An OTA `password:` next to an API key only serves older clients and costs about 3.5 KB of flash on an ESP8266, so
-validation warns. A key provisioned at runtime by Home Assistant (an API `encryption:` block without a `key:`) makes
-the device offer too, but the CLI cannot use a key it does not have, so those uploads stay plaintext and the block
-needs an explicit key.
+> a plaintext image when `encryption:` is configured. This is intentional; a downgrade to plaintext would be an
+> unauthenticated upload. If the key is lost, recover the device with a serial flash, or through the
+> [web server OTA platform](/components/ota/web_server) if the config has it.
 
 To troubleshoot a failing encrypted handshake, raise the log level of the shared `noise` component:
 
@@ -150,6 +138,22 @@ logger:
   logs:
     noise: VERY_VERBOSE
 ```
+
+### Enabling encryption on an existing device
+
+A device on ESPHome 2026.9.0 or newer with an [API encryption key](/components/api) already offers OTA encryption, and
+`esphome run` uses that key whenever the device offers; the `encryption:` block is what makes the device require it.
+Add the block, remove any `password:`, and install. If the device still runs firmware that cannot encrypt, the install
+stops with `the device did not offer encryption; refusing to send the image in plaintext`: install once without the
+block first (until ESPHome 2027.3.0 that upload falls back to plaintext with a warning), then restore it. From
+2027.3.0 the CLI no longer falls back, so update firmware older than 2026.9.0 before then, or by serial flash or the
+web server OTA platform.
+
+An OTA `password:` next to an API key only serves older clients and costs about 3.5 KB of flash on an ESP8266, so
+validation warns. A key provisioned at runtime by Home Assistant (an API `encryption:` block without a `key:`) makes
+the device offer too, but the CLI cannot use a key it does not have, so those uploads stay plaintext. To require
+encryption on such a device give the OTA `encryption:` block its own `key:`; that is the one case where the OTA key
+is separate from the API key.
 
 ## Updating the partition table on ESP32
 

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -127,9 +127,27 @@ exists while the fallback AP is active).
 > [!IMPORTANT]
 > Once a device runs firmware with `encryption:` enabled it refuses plaintext OTA updates, and the CLI refuses to send
 > a plaintext image when a key is configured. This is intentional; a downgrade to plaintext would be an unauthenticated
-> upload. Enabling it is a two-step migration: first upload firmware that has the `encryption:` block over your current
-> (plaintext) OTA, then all later uploads are encrypted. If a device that already requires encryption becomes
-> unreachable, recover it with a serial flash.
+> upload. If a device that requires encryption becomes unreachable, recover it with the
+> [web server OTA platform](/components/ota/web_server) or a serial flash.
+
+### Enabling encryption on an existing device
+
+A device built with an [API encryption key](/components/api) on ESPHome 2026.9.0 or newer already offers OTA
+encryption, even without an `encryption:` block under `ota:`. Such a device accepts both plaintext and encrypted
+uploads; a plaintext upload still has to pass the OTA password if one is set, while an encrypted upload is
+authenticated by the key. Adding the block is what makes the device require encryption. To turn it on:
+
+1. Make sure the device runs ESPHome 2026.9.0 or newer with an API encryption key. If it does not, install that first
+   without the `encryption:` block under `ota:`. This one install goes over plaintext OTA (or USB).
+2. Add `encryption:` to the `ota:` block, remove any `password:` line, and install again. This install is already
+   encrypted, and so is every install after it.
+
+If you add the block while the device still runs older firmware, the upload stops with
+`the device did not offer encryption; refusing to send the image in plaintext`. Remove the block, keep the API key,
+install once, then restore the block and install again.
+
+An API `encryption:` block without a `key:` provisions the key at runtime, so it is not known when the firmware is
+built and such a device does not offer OTA encryption. Set an explicit key to use OTA encryption.
 
 To troubleshoot a failing encrypted handshake, raise the log level of the shared `noise` component:
 

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -135,9 +135,10 @@ exists while the fallback AP is active).
 A device built with an [API encryption key](/components/api) on ESPHome 2026.9.0 or newer already offers OTA
 encryption, even without an `encryption:` block under `ota:`. Such a device accepts both plaintext and encrypted
 uploads; a plaintext upload still has to pass the OTA password if one is set, while an encrypted upload is
-authenticated by the key. Because the key already authenticates uploads, a config with both an API key and an OTA
-`password:` validates with a warning suggesting you replace the password with the `encryption:` block. Adding the
-block is what makes the device require encryption. To turn it on:
+authenticated by the key. Because the key already authenticates uploads, an OTA `password:` next to an API key only
+serves older clients without encryption support and wastes flash and RAM; such a config validates with a warning
+suggesting you replace the password with the `encryption:` block. Adding the block is what makes the device require
+encryption. To turn it on:
 
 1. Make sure the device runs ESPHome 2026.9.0 or newer with an API encryption key. If it does not, install that first
    without the `encryption:` block under `ota:`. This one install goes over plaintext OTA (or USB).

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -134,19 +134,19 @@ endpoint only exists while the fallback AP is active and is the intended recover
 
 A device built on ESPHome 2026.9.0 or newer with an [API encryption key](/components/api) already offers OTA
 encryption without an `encryption:` block under `ota:`: it accepts plaintext uploads (guarded by the OTA password, if
-set) and encrypted uploads authenticated by the key. The block is what makes it require encryption.
+set) and encrypted uploads authenticated by the key. With a key in the YAML, `esphome run` uses it whenever the device
+offers, so those uploads are already encrypted. The block is what makes the device require encryption.
 
-1. If the device runs older firmware or has no API key, install once without the block; that install goes over
-   plaintext OTA (or USB).
-2. Add `encryption:` to the `ota:` block, remove any `password:`, and install again. This install and every later one
-   are encrypted.
-
-Adding the block while the device still runs older firmware stops with `the device did not offer encryption;
-refusing to send the image in plaintext`: remove the block, install once, then restore it.
+Add `encryption:` to the `ota:` block, remove any `password:`, and install. If the device still runs firmware that
+cannot encrypt, install once without the block first: until ESPHome 2027.3.0 that install falls back to plaintext
+with a warning, and after that release it stops with `the device did not offer encryption; refusing to send the image
+in plaintext`, so install once without the block and then restore it.
 
 An OTA `password:` next to an API key only serves older clients without encryption support and costs about 3.5 KB of
 flash and 60 bytes of RAM on an ESP8266, so validation warns and suggests the `encryption:` block instead. An API
-`encryption:` block without a `key:` is provisioned at runtime and does not offer OTA encryption; set an explicit key.
+`encryption:` block without a `key:` is provisioned at runtime by Home Assistant; the device offers OTA encryption
+with that key once provisioned, but the CLI does not know it, so `esphome run` stays plaintext and the block cannot
+be used without an explicit key.
 
 To troubleshoot a failing encrypted handshake, raise the log level of the shared `noise` component:
 

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -120,10 +120,9 @@ You may set an explicit `key:` instead, but it must match the API encryption key
 a key with the on demand generator in the [API component documentation](/components/api#configuration-variables).
 
 Encryption cannot be combined with a password; the key already authenticates the uploader, so remove the `password:`
-line when you add `encryption:`. Combining it with the [web server OTA platform](/components/ota/web_server) is allowed,
-but validation warns because that endpoint accepts the same firmware image over plaintext HTTP. The copy of that
-endpoint that `captive_portal:` loads on its own does not trigger the warning: it only exists while the fallback AP is
-active and is the intended recovery path.
+line when you add `encryption:`. Combining it with the [web server OTA platform](/components/ota/web_server) is allowed
+but warned about, since that endpoint accepts the same firmware image over plaintext HTTP; the copy `captive_portal:`
+loads on its own is the recovery path and does not warn.
 
 > [!IMPORTANT]
 > Once a device runs firmware with `encryption:` enabled it refuses plaintext OTA updates, and the CLI refuses to send
@@ -133,22 +132,16 @@ active and is the intended recovery path.
 
 ### Enabling encryption on an existing device
 
-A device built on ESPHome 2026.9.0 or newer with an [API encryption key](/components/api) already offers OTA
-encryption without an `encryption:` block under `ota:`: it accepts plaintext uploads (guarded by the OTA password, if
-set) and encrypted uploads authenticated by the key. With a key in the YAML, `esphome run` uses it whenever the device
-offers, so those uploads are already encrypted. The block is what makes the device require encryption.
+A device on ESPHome 2026.9.0 or newer with an [API encryption key](/components/api) already offers OTA encryption, and
+`esphome run` uses that key whenever the device offers; the `encryption:` block is what makes the device require it.
+Add the block, remove any `password:`, and install. If the device still runs firmware that cannot encrypt, the install
+stops with `the device did not offer encryption; refusing to send the image in plaintext`: install once without the
+block first (until ESPHome 2027.3.0 that upload falls back to plaintext with a warning), then restore it.
 
-Add `encryption:` to the `ota:` block, remove any `password:`, and install. With the block the CLI never sends
-plaintext, so a device still running firmware that cannot encrypt stops the install with
-`the device did not offer encryption; refusing to send the image in plaintext`. For such a device install once without
-the block first: until ESPHome 2027.3.0 that install falls back to plaintext with a warning and lands a firmware that
-offers encryption; then restore the block and install again.
-
-An OTA `password:` next to an API key only serves older clients without encryption support and costs about 3.5 KB of
-flash and 60 bytes of RAM on an ESP8266, so validation warns and suggests the `encryption:` block instead. An API
-`encryption:` block without a `key:` is provisioned at runtime by Home Assistant; the device offers OTA encryption
-with that key once provisioned, but the CLI does not know it, so `esphome run` stays plaintext and the block cannot
-be used without an explicit key.
+An OTA `password:` next to an API key only serves older clients and costs about 3.5 KB of flash on an ESP8266, so
+validation warns. A key provisioned at runtime by Home Assistant (an API `encryption:` block without a `key:`) makes
+the device offer too, but the CLI cannot use a key it does not have, so those uploads stay plaintext and the block
+needs an explicit key.
 
 To troubleshoot a failing encrypted handshake, raise the log level of the shared `noise` component:
 

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -126,7 +126,7 @@ endpoint only exists while the fallback AP is active and is the intended recover
 
 > [!IMPORTANT]
 > Once a device runs firmware with `encryption:` enabled it refuses plaintext OTA updates, and the CLI refuses to send
-> a plaintext image when a key is configured. This is intentional; a downgrade to plaintext would be an unauthenticated
+> a plaintext image when `encryption:` is configured. This is intentional; a downgrade to plaintext would be an unauthenticated
 > upload. If a device that requires encryption becomes unreachable, recover it with the
 > [web server OTA platform](/components/ota/web_server) or a serial flash.
 
@@ -137,10 +137,11 @@ encryption without an `encryption:` block under `ota:`: it accepts plaintext upl
 set) and encrypted uploads authenticated by the key. With a key in the YAML, `esphome run` uses it whenever the device
 offers, so those uploads are already encrypted. The block is what makes the device require encryption.
 
-Add `encryption:` to the `ota:` block, remove any `password:`, and install. If the device still runs firmware that
-cannot encrypt, install once without the block first: until ESPHome 2027.3.0 that install falls back to plaintext
-with a warning, and after that release it stops with `the device did not offer encryption; refusing to send the image
-in plaintext`, so install once without the block and then restore it.
+Add `encryption:` to the `ota:` block, remove any `password:`, and install. With the block the CLI never sends
+plaintext, so a device still running firmware that cannot encrypt stops the install with `the device did not offer
+encryption; refusing to send the image in plaintext`. For such a device install once without the block first: until
+ESPHome 2027.3.0 that install falls back to plaintext with a warning and lands a firmware that offers encryption; then
+restore the block and install again.
 
 An OTA `password:` next to an API key only serves older clients without encryption support and costs about 3.5 KB of
 flash and 60 bytes of RAM on an ESP8266, so validation warns and suggests the `encryption:` block instead. An API

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -120,9 +120,10 @@ You may set an explicit `key:` instead, but it must match the API encryption key
 a key with the on demand generator in the [API component documentation](/components/api#configuration-variables).
 
 Encryption cannot be combined with a password; the key already authenticates the uploader, so remove the `password:`
-line when you add `encryption:`. Combining it with the [web server OTA platform](/components/ota/web_server) is allowed
-but warned about: that endpoint accepts the same firmware image over plaintext HTTP. With `captive_portal:` alone the
-endpoint only exists while the fallback AP is active and is the intended recovery path, so there is no warning.
+line when you add `encryption:`. Combining it with the [web server OTA platform](/components/ota/web_server) is allowed,
+but validation warns because that endpoint accepts the same firmware image over plaintext HTTP. The copy of that
+endpoint that `captive_portal:` loads on its own does not trigger the warning: it only exists while the fallback AP is
+active and is the intended recovery path.
 
 > [!IMPORTANT]
 > Once a device runs firmware with `encryption:` enabled it refuses plaintext OTA updates, and the CLI refuses to send
@@ -138,10 +139,10 @@ set) and encrypted uploads authenticated by the key. With a key in the YAML, `es
 offers, so those uploads are already encrypted. The block is what makes the device require encryption.
 
 Add `encryption:` to the `ota:` block, remove any `password:`, and install. With the block the CLI never sends
-plaintext, so a device still running firmware that cannot encrypt stops the install with `the device did not offer
-encryption; refusing to send the image in plaintext`. For such a device install once without the block first: until
-ESPHome 2027.3.0 that install falls back to plaintext with a warning and lands a firmware that offers encryption; then
-restore the block and install again.
+plaintext, so a device still running firmware that cannot encrypt stops the install with
+`the device did not offer encryption; refusing to send the image in plaintext`. For such a device install once without
+the block first: until ESPHome 2027.3.0 that install falls back to plaintext with a warning and lands a firmware that
+offers encryption; then restore the block and install again.
 
 An OTA `password:` next to an API key only serves older clients without encryption support and costs about 3.5 KB of
 flash and 60 bytes of RAM on an ESP8266, so validation warns and suggests the `encryption:` block instead. An API

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -146,12 +146,12 @@ mqtt:
 ota:
   - platform: esphome
     encryption:
-      key: !secret device_name__ota_key
+      key: !secret device_name__ota_esphome_key
 ```
 
 > [!WARNING]
 > A device flashed by serial can carry `encryption:` from the start. A device updated over the air gets it once it
-> runs ESPHome 2026.9.0 or newer with `api: encryption:`, and keeps it from then on. Older firmware cannot offer
+> runs ESPHome 2026.9.0 or newer with an API encryption key, and keeps it from then on. Older firmware cannot offer
 > encryption, and with the block in the config the CLI refuses to send
 > plaintext, so an install against it stops with
 > `the device did not offer encryption; refusing to send the image in plaintext`. See
@@ -198,8 +198,9 @@ be updated before then; after that, update it by serial flash or through the
 An OTA `password:` next to an API key only serves older clients and costs about 3.5 KB of flash on an ESP8266, so
 validation warns. A key provisioned at runtime by Home Assistant (an API `encryption:` block without a `key:`) makes
 the device offer too, but the CLI cannot use a key it does not have, so those uploads stay plaintext until either
-`api: encryption:` gets a `key:` in the yaml or the OTA `encryption:` block gets its own, which gives that device two
-keys: the provisioned API key and the OTA key in the config.
+`api: encryption:` carries that provisioned key in the yaml (the Device Builder writes it there when Home Assistant
+hands it over; a freshly generated key would lock Home Assistant out after the next install) or the OTA `encryption:`
+block gets its own `key:`, which gives that device two keys: the provisioned API key and the OTA key in the config.
 
 ## Updating the partition table on ESP32
 

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -121,11 +121,11 @@ and has no `api:` block, or one whose API key is provisioned at runtime by Home 
 demand generator in the [API component documentation](/components/api#configuration-variables).
 
 > [!WARNING]
-> Do not add `encryption:` under `ota:` until the device already runs ESPHome 2026.9.0 or newer with
-> `api: encryption:`. A device on older firmware cannot offer encryption, and with the block in the config the CLI
-> refuses to send plaintext, so the install stops with
-> `the device did not offer encryption; refusing to send the image in plaintext`. Install once without the block
-> first, then add it; a device that is already unreachable this way needs a serial flash.
+> Add `encryption:` under `ota:` once the device runs ESPHome 2026.9.0 or newer with `api: encryption:`, and keep it
+> from then on. Older firmware cannot offer encryption, and with the block in the config the CLI refuses to send
+> plaintext, so an install against it stops with
+> `the device did not offer encryption; refusing to send the image in plaintext`. If that happens, remove the block,
+> install once, and add it back; or flash the device by serial.
 
 Encryption cannot be combined with a password; the key already authenticates the uploader, so remove the `password:`
 line when you add `encryption:`. Adding the [web server OTA platform](/components/ota/web_server) next to it is allowed

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -152,7 +152,7 @@ ota:
 > encryption, and with the block in the config the CLI refuses to send
 > plaintext, so an install against it stops with
 > `the device did not offer encryption; refusing to send the image in plaintext`. See
-> [Enabling encryption on an existing device](#enabling-encryption-on-an-existing-device) for the way around it.
+> [Enabling Encryption on an Existing Device](#enabling-encryption-on-an-existing-device) for the way around it.
 
 Encryption cannot be combined with a password; the key already authenticates the uploader, so remove the `password:`
 line when you add `encryption:`. Adding the [web server OTA platform](/components/ota/web_server/) next to it is allowed

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -31,7 +31,9 @@ ota:
     encryption:
 ```
 
-Without an API encryption key, a password authenticates the uploader but does not keep the image confidential:
+The secret names on this page follow the `<hostname>__<base>` shape the Device Builder writes to `secrets.yaml`, see
+[Using secrets.yaml](/guides/security_best_practices/#using-secretsyaml). Without an API encryption key, a password
+authenticates the uploader but does not keep the image confidential:
 
 ```yaml
 # Example configuration entry, password only (no API encryption key)
@@ -186,8 +188,8 @@ any `password:`, and install; the encrypted handshake authenticates that upload,
 If the device still runs older firmware, install once without the block first, keeping any existing `password:` and
 with `api: encryption: key:` set: until ESPHome 2027.3.0 that upload falls back to plaintext with a warning and lands
 a firmware that offers, then add the block and drop the password. From 2027.3.0 the CLI no longer falls back to
-plaintext, so a device still on firmware older than 2026.9.0 must be updated before then; after that, update it by
-serial flash or through the
+plaintext when it has a key to use, so a device with an API encryption key still on firmware older than 2026.9.0 must
+be updated before then; after that, update it by serial flash or through the
 [web server OTA platform](/components/ota/web_server/).
 
 An OTA `password:` next to an API key only serves older clients and costs about 3.5 KB of flash on an ESP8266, so

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -28,7 +28,7 @@ ota:
 
 - **encryption** (*Optional*): Encrypt the OTA update with the same Noise protocol the [native API](/components/api) uses. See [Encryption](#encryption) below. Cannot be combined with **password**.
 
-  - **key** (*Optional*, string): The base64 encryption key. When omitted, the [API encryption key](/components/api#configuration-variables) is used, so a single key protects the device. When set, it must match a static API encryption key.
+  - **key** (*Optional*, string): The base64 encryption key. Omit it so the [API encryption key](/components/api#configuration-variables) is used and one key protects the device; only set it when there is no static API encryption key, for example a device that uses MQTT without `api:`.
 
 - **password** (*Optional*, string): The password to use for updates. Cannot be combined with **encryption**.
 - **allow_partition_access** (*Optional*, boolean): Only on `esp32`. Allow updating more partition types. Used for updating the partition table and the bootloader. Defaults to `false`.
@@ -103,8 +103,8 @@ network in plaintext. The image contains your Wi-Fi credentials and your API enc
 the traffic on your network can read them. Encrypting the update keeps the image confidential and, because it uses the
 Noise `NNpsk0` pattern with a pre-shared key, also authenticates the uploader; no password is needed.
 
-To enable it, add an `encryption:` block to the OTA platform. With no `key:`, the device reuses the
-[API encryption key](/components/api), so a single key protects the device:
+The recommended setup is an API encryption key plus a bare `encryption:` block under the OTA platform. The OTA uses
+the API key, so there is one key per device and nothing else to manage:
 
 ```yaml
 api:
@@ -116,8 +116,15 @@ ota:
     encryption:
 ```
 
-You may set an explicit `key:` instead, but it must match the API encryption key; there is one key per device. Generate
-a key with the on demand generator in the [API component documentation](/components/api#configuration-variables).
+Only give the OTA block its own `key:` when there is no static API key to use, for example a device that talks MQTT
+and has no `api:` block, or one whose API key is provisioned at runtime by Home Assistant. Generate a key with the on
+demand generator in the [API component documentation](/components/api#configuration-variables).
+
+> [!WARNING]
+> Do not add `encryption:` under `ota:` until the device already runs ESPHome 2026.9.0 or newer with `api: encryption:`.
+> A device on older firmware cannot offer encryption, and with the block in the config the CLI refuses to send plaintext,
+> so the install stops with `the device did not offer encryption; refusing to send the image in plaintext` and only a
+> serial flash gets the device going again. Install once without the block first, then add it.
 
 Encryption cannot be combined with a password; the key already authenticates the uploader, so remove the `password:`
 line when you add `encryption:`. Adding the [web server OTA platform](/components/ota/web_server) next to it is allowed
@@ -141,19 +148,17 @@ logger:
 
 ### Enabling encryption on an existing device
 
-A device on ESPHome 2026.9.0 or newer with an [API encryption key](/components/api) already offers OTA encryption, and
-`esphome run` uses that key whenever the device offers; the `encryption:` block is what makes the device require it.
-Add the block, remove any `password:`, and install. If the device still runs firmware that cannot encrypt, the install
-stops with `the device did not offer encryption; refusing to send the image in plaintext`: install once without the
-block first (until ESPHome 2027.3.0 that upload falls back to plaintext with a warning), then restore it. From
-2027.3.0 the CLI no longer falls back, so update firmware older than 2026.9.0 before then, or by serial flash or the
-web server OTA platform.
+A device on ESPHome 2026.9.0 or newer with an API encryption key already offers OTA encryption, and `esphome run` uses
+that key whenever the device offers; the `encryption:` block is what makes the device require it. Add the block, remove
+any `password:`, and install. If the device still runs older firmware, install once without the block first: until
+ESPHome 2027.3.0 that upload falls back to plaintext with a warning and lands a firmware that offers, then add the
+block. From 2027.3.0 the CLI no longer falls back, so update firmware older than 2026.9.0 before then, or by serial
+flash or the web server OTA platform.
 
 An OTA `password:` next to an API key only serves older clients and costs about 3.5 KB of flash on an ESP8266, so
 validation warns. A key provisioned at runtime by Home Assistant (an API `encryption:` block without a `key:`) makes
-the device offer too, but the CLI cannot use a key it does not have, so those uploads stay plaintext. To require
-encryption on such a device give the OTA `encryption:` block its own `key:`; that is the one case where the OTA key
-is separate from the API key.
+the device offer too, but the CLI cannot use a key it does not have, so those uploads stay plaintext unless the OTA
+block gets its own `key:`.
 
 ## Updating the partition table on ESP32
 

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -168,7 +168,8 @@ intended recovery path for a device that cannot join Wi-Fi, so it does not warn.
 > a plaintext image when `encryption:` is configured. This is intentional; a downgrade to plaintext would be an
 > unauthenticated upload. If the key is lost, recover the device with a serial flash, or through the
 > [web server OTA platform](/components/ota/web_server/) if the config has it. Changing the key is not an OTA
-> operation either: the device only accepts the key it is running, so a new key goes in the same two ways.
+> operation yet either: the device only accepts the key it is running and the CLI presents the key in the config,
+> so a new key goes in the same two ways until the tooling can compile with the new key and upload with the old.
 
 To troubleshoot a failing encrypted handshake, build with the logger at `VERY_VERBOSE` so the shared `noise`
 component's messages are compiled in; a `logs:` entry alone cannot raise a level above `level:`. `initial_level`

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -147,14 +147,15 @@ ota:
 ```
 
 > [!WARNING]
-> Add `encryption:` under `ota:` once the device runs ESPHome 2026.9.0 or newer with `api: encryption:`, and keep it
-> from then on. Older firmware cannot offer encryption, and with the block in the config the CLI refuses to send
+> A device flashed by serial can carry `encryption:` from the start. A device updated over the air gets it once it
+> runs ESPHome 2026.9.0 or newer with `api: encryption:`, and keeps it from then on. Older firmware cannot offer
+> encryption, and with the block in the config the CLI refuses to send
 > plaintext, so an install against it stops with
 > `the device did not offer encryption; refusing to send the image in plaintext`. See
 > [Enabling encryption on an existing device](#enabling-encryption-on-an-existing-device) for the way around it.
 
 Encryption cannot be combined with a password; the key already authenticates the uploader, so remove the `password:`
-line when you add `encryption:`. Adding the [web server OTA platform](/components/ota/web_server) next to it is allowed
+line when you add `encryption:`. Adding the [web server OTA platform](/components/ota/web_server/) next to it is allowed
 but warns during validation, since that endpoint accepts the same firmware image over plaintext HTTP. The captive
 portal's update page (`captive_portal:` without that platform) exists only while the fallback AP is active and is the
 intended recovery path for a device that cannot join Wi-Fi, so it does not warn.
@@ -177,15 +178,16 @@ logger:
     noise: VERY_VERBOSE
 ```
 
-### Enabling encryption on an existing device
+### Enabling Encryption on an Existing Device
 
 A device on ESPHome 2026.9.0 or newer with an API encryption key already offers OTA encryption, and `esphome run` uses
 that key whenever the device offers; the `encryption:` block is what makes the device require it. Add the block, remove
 any `password:`, and install; the encrypted handshake authenticates that upload, so the password is not needed for it.
 If the device still runs older firmware, install once without the block first, keeping any existing `password:` and
 with `api: encryption: key:` set: until ESPHome 2027.3.0 that upload falls back to plaintext with a warning and lands
-a firmware that offers, then add the block and drop the password. From 2027.3.0 the CLI no longer falls back to plaintext, so a device still on firmware older than 2026.9.0
-must be updated before then; after that, update it by serial flash or through the
+a firmware that offers, then add the block and drop the password. From 2027.3.0 the CLI no longer falls back to
+plaintext, so a device still on firmware older than 2026.9.0 must be updated before then; after that, update it by
+serial flash or through the
 [web server OTA platform](/components/ota/web_server/).
 
 An OTA `password:` next to an API key only serves older clients and costs about 3.5 KB of flash on an ESP8266, so

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -21,7 +21,7 @@ expected. This is automatically enabled by this component, but it may be disable
 # Example configuration entry, encrypted with the API key (recommended)
 api:
   encryption:
-    key: !secret api_encryption_key
+    key: !secret device_name__encryption_key
 
 ota:
   - platform: esphome
@@ -32,7 +32,7 @@ ota:
 # Example configuration entry, password only (no API encryption key)
 ota:
   - platform: esphome
-    password: !secret ota_password
+    password: !secret device_name__ota_password
 ```
 
 ## Configuration variables
@@ -120,7 +120,7 @@ the API key, so there is one key per device and nothing else to manage:
 ```yaml
 api:
   encryption:
-    key: !secret device_name_key
+    key: !secret device_name__encryption_key
 
 ota:
   - platform: esphome
@@ -138,7 +138,7 @@ mqtt:
 ota:
   - platform: esphome
     encryption:
-      key: !secret device_name_ota_key
+      key: !secret device_name__ota_key
 ```
 
 > [!WARNING]

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -158,8 +158,8 @@ flash or the web server OTA platform.
 
 An OTA `password:` next to an API key only serves older clients and costs about 3.5 KB of flash on an ESP8266, so
 validation warns. A key provisioned at runtime by Home Assistant (an API `encryption:` block without a `key:`) makes
-the device offer too, but the CLI cannot use a key it does not have, so those uploads stay plaintext unless the OTA
-block gets its own `key:`.
+the device offer too, but the CLI cannot use a key it does not have, so those uploads stay plaintext until either
+`api: encryption:` gets a `key:` in the yaml or the OTA `encryption:` block gets its own.
 
 ## Updating the partition table on ESP32
 

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -116,10 +116,11 @@ If OTA is already enabled without a password, simply add a `password:` line to t
 
 ## Encryption
 
-By default the OTA update authenticates the uploader with a password, but the firmware image itself travels over the
-network in plaintext. The image contains your Wi-Fi credentials and your API encryption key, so anyone who can capture
-the traffic on your network can read them. Encrypting the update keeps the image confidential and, because it uses the
-Noise `NNpsk0` pattern with a pre-shared key, also authenticates the uploader; no password is needed.
+Without encryption the OTA update travels over the network in plaintext, and unless a `password:` is set anyone who
+can reach the device can upload to it. The image contains your Wi-Fi credentials and your API encryption key, so anyone
+who can capture the traffic on your network can read them. Encrypting the update keeps the image confidential and,
+because it uses the Noise `NNpsk0` pattern with a pre-shared key, also authenticates the uploader; no password is
+needed.
 
 The recommended setup is an API encryption key plus a bare `encryption:` block under the OTA platform. The OTA uses
 the API key, so there is one key per device and nothing else to manage:

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -97,7 +97,9 @@ replaced with the new password in the `ota:` section.
 
 ### Adding a Password
 
-If OTA is already enabled without a password, simply add a `password:` line to the existing `ota:` config block.
+If OTA is already enabled without a password, simply add a `password:` line to the existing `ota:` config block. If
+the device has an API encryption key, use [Encryption](#encryption) instead; a password next to an API key only serves
+older uploaders and warns at validation.
 
 ### Removing a Password
 

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -129,7 +129,17 @@ ota:
 
 Only give the OTA block its own `key:` when there is no static API key to use, for example a device that talks MQTT
 and has no `api:` block, or one whose API key is provisioned at runtime by Home Assistant. Generate a key with the on
-demand generator in the [API component documentation](/components/api#configuration-variables).
+demand generator in the [API component documentation](/components/api#configuration-variables):
+
+```yaml
+mqtt:
+  broker: !secret mqtt_broker
+
+ota:
+  - platform: esphome
+    encryption:
+      key: !secret device_name_ota_key
+```
 
 > [!WARNING]
 > Add `encryption:` under `ota:` once the device runs ESPHome 2026.9.0 or newer with `api: encryption:`, and keep it

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -46,7 +46,7 @@ ota:
 
 - **encryption** (*Optional*): Encrypt the OTA update with the same Noise protocol the [native API](/components/api) uses. See [Encryption](#encryption) below. Cannot be combined with **password**.
 
-  - **key** (*Optional*, string): The base64 encryption key. Omit it so the [API encryption key](/components/api#configuration-variables) is used and one key protects the device; only set it when there is no static API encryption key, for example a device that uses MQTT without `api:`.
+  - **key** (*Optional*, string): The base64 encryption key. Omit it so the [API encryption key](/components/api#configuration-variables) is used and one key protects the device; only set it when there is no static API encryption key, for example a device that uses MQTT without `api:`. Next to a static API key it must be the same key, a different one is rejected at validation.
 
 - **password** (*Optional*, string): The password to use for updates. Not recommended for new devices, use **encryption** instead. Cannot be combined with **encryption**.
 - **allow_partition_access** (*Optional*, boolean): Only on `esp32`. Allow updating more partition types. Used for updating the partition table and the bootloader. Defaults to `false`.
@@ -206,6 +206,11 @@ too, but the CLI cannot use a key it does not have, so those uploads stay plaint
   Assistant hands it over; do not generate a fresh one, that locks Home Assistant out after the next install.
 - Give the OTA `encryption:` block its own `key:`, which leaves the device with two keys: the provisioned API key and
   the OTA key in the config.
+
+A device without a static API key cannot get its own OTA `key:` over the air: its running firmware either offers no
+encryption at all (an MQTT device) or offers with the provisioned API key rather than the OTA key the CLI would
+present, and with the block in the config the CLI does not send plaintext. Put the block in by serial flash or through
+the [web server OTA platform](/components/ota/web_server/); after that, installs are encrypted with the OTA key.
 
 ## Updating the partition table on ESP32
 

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -124,8 +124,8 @@ demand generator in the [API component documentation](/components/api#configurat
 > Add `encryption:` under `ota:` once the device runs ESPHome 2026.9.0 or newer with `api: encryption:`, and keep it
 > from then on. Older firmware cannot offer encryption, and with the block in the config the CLI refuses to send
 > plaintext, so an install against it stops with
-> `the device did not offer encryption; refusing to send the image in plaintext`. If that happens, remove the block,
-> install once, and add it back; or flash the device by serial.
+> `the device did not offer encryption; refusing to send the image in plaintext`. See
+> [Enabling encryption on an existing device](#enabling-encryption-on-an-existing-device) for the way around it.
 
 Encryption cannot be combined with a password; the key already authenticates the uploader, so remove the `password:`
 line when you add `encryption:`. Adding the [web server OTA platform](/components/ota/web_server) next to it is allowed
@@ -153,13 +153,15 @@ A device on ESPHome 2026.9.0 or newer with an API encryption key already offers 
 that key whenever the device offers; the `encryption:` block is what makes the device require it. Add the block, remove
 any `password:`, and install. If the device still runs older firmware, install once without the block first: until
 ESPHome 2027.3.0 that upload falls back to plaintext with a warning and lands a firmware that offers, then add the
-block. From 2027.3.0 the CLI no longer falls back, so update firmware older than 2026.9.0 before then, or by serial
-flash or the web server OTA platform.
+block. From 2027.3.0 the CLI no longer falls back to plaintext, so a device still on firmware older than 2026.9.0
+must be updated before then; after that, update it by serial flash or through the
+[web server OTA platform](/components/ota/web_server).
 
 An OTA `password:` next to an API key only serves older clients and costs about 3.5 KB of flash on an ESP8266, so
 validation warns. A key provisioned at runtime by Home Assistant (an API `encryption:` block without a `key:`) makes
 the device offer too, but the CLI cannot use a key it does not have, so those uploads stay plaintext until either
-`api: encryption:` gets a `key:` in the yaml or the OTA `encryption:` block gets its own.
+`api: encryption:` gets a `key:` in the yaml or the OTA `encryption:` block gets its own, which gives that device two
+keys: the provisioned API key and the OTA key in the config.
 
 ## Updating the partition table on ESP32
 

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -41,7 +41,7 @@ ota:
 
   - **key** (*Optional*, string): The base64 encryption key. Omit it so the [API encryption key](/components/api#configuration-variables) is used and one key protects the device; only set it when there is no static API encryption key, for example a device that uses MQTT without `api:`.
 
-- **password** (*Optional*, string): The password to use for updates. Cannot be combined with **encryption**.
+- **password** (*Optional*, string): The password to use for updates. Not recommended for new devices, use **encryption** instead. Cannot be combined with **encryption**.
 - **allow_partition_access** (*Optional*, boolean): Only on `esp32`. Allow updating more partition types. Used for updating the partition table and the bootloader. Defaults to `false`.
 
 > [!IMPORTANT]

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -139,12 +139,13 @@ intended recovery path, so it does not warn.
 > unauthenticated upload. If the key is lost, recover the device with a serial flash, or through the
 > [web server OTA platform](/components/ota/web_server) if the config has it.
 
-To troubleshoot a failing encrypted handshake, raise the log level of the shared `noise` component:
+To troubleshoot a failing encrypted handshake, build with the logger at `VERY_VERBOSE`; the messages come from the
+shared `noise` component, and the per component `logs:` map can only lower a level below `level:`, so a `noise:`
+entry there does nothing on its own:
 
 ```yaml
 logger:
-  logs:
-    noise: VERY_VERBOSE
+  level: VERY_VERBOSE
 ```
 
 ### Enabling encryption on an existing device

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -18,7 +18,18 @@ expected. This is automatically enabled by this component, but it may be disable
 [Safe Mode](/components/safe_mode/) for details.
 
 ```yaml
-# Example configuration entry
+# Example configuration entry, encrypted with the API key (recommended)
+api:
+  encryption:
+    key: !secret api_encryption_key
+
+ota:
+  - platform: esphome
+    encryption:
+```
+
+```yaml
+# Example configuration entry, password only (no API encryption key)
 ota:
   - platform: esphome
     password: !secret ota_password

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -124,8 +124,8 @@ demand generator in the [API component documentation](/components/api#configurat
 > Do not add `encryption:` under `ota:` until the device already runs ESPHome 2026.9.0 or newer with
 > `api: encryption:`. A device on older firmware cannot offer encryption, and with the block in the config the CLI
 > refuses to send plaintext, so the install stops with
-> `the device did not offer encryption; refusing to send the image in plaintext` and only a serial flash gets the
-> device going again. Install once without the block first, then add it.
+> `the device did not offer encryption; refusing to send the image in plaintext`. Install once without the block
+> first, then add it; a device that is already unreachable this way needs a serial flash.
 
 Encryption cannot be combined with a password; the key already authenticates the uploader, so remove the `password:`
 line when you add `encryption:`. Adding the [web server OTA platform](/components/ota/web_server) next to it is allowed

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -169,8 +169,8 @@ intended recovery path for a device that cannot join Wi-Fi, so it does not warn.
 > unauthenticated upload. If the key is lost, recover the device with a serial flash, or through the
 > [web server OTA platform](/components/ota/web_server/) if the config has it. Changing the key is not an OTA
 > operation yet either: the device only accepts the key it is running and the CLI presents the key in the config,
-> so a new key goes in the same two ways until the tooling can compile with the new key and upload with the old
-> ([esphome/backlog#161](https://github.com/esphome/backlog/issues/161)).
+> so a new key goes in the same two ways until the tooling can compile with the new key and upload with the old; see
+> the [plan to improve key rotation](https://github.com/esphome/backlog/issues/161).
 
 To troubleshoot a failing encrypted handshake, build with the logger at `VERY_VERBOSE` so the shared `noise`
 component's messages are compiled in; a `logs:` entry alone cannot raise a level above `level:`. `initial_level`

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -121,10 +121,11 @@ and has no `api:` block, or one whose API key is provisioned at runtime by Home 
 demand generator in the [API component documentation](/components/api#configuration-variables).
 
 > [!WARNING]
-> Do not add `encryption:` under `ota:` until the device already runs ESPHome 2026.9.0 or newer with `api: encryption:`.
-> A device on older firmware cannot offer encryption, and with the block in the config the CLI refuses to send plaintext,
-> so the install stops with `the device did not offer encryption; refusing to send the image in plaintext` and only a
-> serial flash gets the device going again. Install once without the block first, then add it.
+> Do not add `encryption:` under `ota:` until the device already runs ESPHome 2026.9.0 or newer with
+> `api: encryption:`. A device on older firmware cannot offer encryption, and with the block in the config the CLI
+> refuses to send plaintext, so the install stops with
+> `the device did not offer encryption; refusing to send the image in plaintext` and only a serial flash gets the
+> device going again. Install once without the block first, then add it.
 
 Encryption cannot be combined with a password; the key already authenticates the uploader, so remove the `password:`
 line when you add `encryption:`. Adding the [web server OTA platform](/components/ota/web_server) next to it is allowed

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -196,11 +196,15 @@ be updated before then; after that, update it by serial flash or through the
 [web server OTA platform](/components/ota/web_server/).
 
 An OTA `password:` next to an API key only serves older clients and costs about 3.5 KB of flash on an ESP8266, so
-validation warns. A key provisioned at runtime by Home Assistant (an API `encryption:` block without a `key:`) makes
-the device offer too, but the CLI cannot use a key it does not have, so those uploads stay plaintext until either
-`api: encryption:` carries that provisioned key in the yaml (the Device Builder writes it there when Home Assistant
-hands it over; a freshly generated key would lock Home Assistant out after the next install) or the OTA `encryption:`
-block gets its own `key:`, which gives that device two keys: the provisioned API key and the OTA key in the config.
+validation warns.
+
+A key provisioned at runtime by Home Assistant (an API `encryption:` block without a `key:`) makes the device offer
+too, but the CLI cannot use a key it does not have, so those uploads stay plaintext until one of these is done:
+
+- Put the key Home Assistant provisioned into `api: encryption: key:`. The Device Builder writes it there when Home
+  Assistant hands it over; do not generate a fresh one, that locks Home Assistant out after the next install.
+- Give the OTA `encryption:` block its own `key:`, which leaves the device with two keys: the provisioned API key and
+  the OTA key in the config.
 
 ## Updating the partition table on ESP32
 

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -169,8 +169,8 @@ intended recovery path for a device that cannot join Wi-Fi, so it does not warn.
 > unauthenticated upload. If the key is lost, recover the device with a serial flash, or through the
 > [web server OTA platform](/components/ota/web_server/) if the config has it. Changing the key is not an OTA
 > operation yet either: the device only accepts the key it is running and the CLI presents the key in the config,
-> so a new key goes in the same two ways until the tooling can compile with the new key and upload with the old; see
-> the [plan to improve key rotation](https://github.com/esphome/backlog/issues/161).
+> so a new key goes in the same two ways. A
+> [key rotation system is planned for the future](https://github.com/esphome/backlog/issues/161).
 
 To troubleshoot a failing encrypted handshake, build with the logger at `VERY_VERBOSE` so the shared `noise`
 component's messages are compiled in; a `logs:` entry alone cannot raise a level above `level:`. `initial_level`

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -167,7 +167,8 @@ intended recovery path for a device that cannot join Wi-Fi, so it does not warn.
 > Once a device runs firmware with `encryption:` enabled it refuses plaintext OTA updates, and the CLI refuses to send
 > a plaintext image when `encryption:` is configured. This is intentional; a downgrade to plaintext would be an
 > unauthenticated upload. If the key is lost, recover the device with a serial flash, or through the
-> [web server OTA platform](/components/ota/web_server/) if the config has it.
+> [web server OTA platform](/components/ota/web_server/) if the config has it. Changing the key is not an OTA
+> operation either: the device only accepts the key it is running, so a new key goes in the same two ways.
 
 To troubleshoot a failing encrypted handshake, build with the logger at `VERY_VERBOSE` so the shared `noise`
 component's messages are compiled in; a `logs:` entry alone cannot raise a level above `level:`. `initial_level`

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -17,6 +17,9 @@ In addition to OTA updates, ESPHome also supports a "safe mode" to help with rec
 expected. This is automatically enabled by this component, but it may be disabled if desired. See
 [Safe Mode](/components/safe_mode/) for details.
 
+The recommended form reuses the [native API](/components/api/) encryption key, so one key protects the device; on a
+device that is already installed, read [Encryption](#encryption) before adding the block.
+
 ```yaml
 # Example configuration entry, encrypted with the API key (recommended)
 api:
@@ -27,6 +30,8 @@ ota:
   - platform: esphome
     encryption:
 ```
+
+Without an API encryption key, a password authenticates the uploader but does not keep the image confidential:
 
 ```yaml
 # Example configuration entry, password only (no API encryption key)
@@ -152,32 +157,36 @@ Encryption cannot be combined with a password; the key already authenticates the
 line when you add `encryption:`. Adding the [web server OTA platform](/components/ota/web_server) next to it is allowed
 but warns during validation, since that endpoint accepts the same firmware image over plaintext HTTP. The captive
 portal's update page (`captive_portal:` without that platform) exists only while the fallback AP is active and is the
-intended recovery path, so it does not warn.
+intended recovery path for a device that cannot join Wi-Fi, so it does not warn.
 
 > [!IMPORTANT]
 > Once a device runs firmware with `encryption:` enabled it refuses plaintext OTA updates, and the CLI refuses to send
 > a plaintext image when `encryption:` is configured. This is intentional; a downgrade to plaintext would be an
 > unauthenticated upload. If the key is lost, recover the device with a serial flash, or through the
-> [web server OTA platform](/components/ota/web_server) if the config has it.
+> [web server OTA platform](/components/ota/web_server/) if the config has it.
 
-To troubleshoot a failing encrypted handshake, build with the logger at `VERY_VERBOSE`; the messages come from the
-shared `noise` component, and the per component `logs:` map can only lower a level below `level:`, so a `noise:`
-entry there does nothing on its own:
+To troubleshoot a failing encrypted handshake, build with the logger at `VERY_VERBOSE` so the shared `noise`
+component's messages are compiled in; a `logs:` entry alone cannot raise a level above `level:`. `initial_level`
+keeps every other component at its usual volume:
 
 ```yaml
 logger:
   level: VERY_VERBOSE
+  initial_level: DEBUG
+  logs:
+    noise: VERY_VERBOSE
 ```
 
 ### Enabling encryption on an existing device
 
 A device on ESPHome 2026.9.0 or newer with an API encryption key already offers OTA encryption, and `esphome run` uses
 that key whenever the device offers; the `encryption:` block is what makes the device require it. Add the block, remove
-any `password:`, and install. If the device still runs older firmware, install once without the block first: until
-ESPHome 2027.3.0 that upload falls back to plaintext with a warning and lands a firmware that offers, then add the
-block. From 2027.3.0 the CLI no longer falls back to plaintext, so a device still on firmware older than 2026.9.0
+any `password:`, and install; the encrypted handshake authenticates that upload, so the password is not needed for it.
+If the device still runs older firmware, install once without the block first, keeping any existing `password:` and
+with `api: encryption: key:` set: until ESPHome 2027.3.0 that upload falls back to plaintext with a warning and lands
+a firmware that offers, then add the block and drop the password. From 2027.3.0 the CLI no longer falls back to plaintext, so a device still on firmware older than 2026.9.0
 must be updated before then; after that, update it by serial flash or through the
-[web server OTA platform](/components/ota/web_server).
+[web server OTA platform](/components/ota/web_server/).
 
 An OTA `password:` next to an API key only serves older clients and costs about 3.5 KB of flash on an ESP8266, so
 validation warns. A key provisioned at runtime by Home Assistant (an API `encryption:` block without a `key:`) makes

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -169,7 +169,8 @@ intended recovery path for a device that cannot join Wi-Fi, so it does not warn.
 > unauthenticated upload. If the key is lost, recover the device with a serial flash, or through the
 > [web server OTA platform](/components/ota/web_server/) if the config has it. Changing the key is not an OTA
 > operation yet either: the device only accepts the key it is running and the CLI presents the key in the config,
-> so a new key goes in the same two ways until the tooling can compile with the new key and upload with the old.
+> so a new key goes in the same two ways until the tooling can compile with the new key and upload with the old
+> ([esphome/backlog#161](https://github.com/esphome/backlog/issues/161)).
 
 To troubleshoot a failing encrypted handshake, build with the logger at `VERY_VERBOSE` so the shared `noise`
 component's messages are compiled in; a `logs:` entry alone cannot raise a level above `level:`. `initial_level`

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -32,7 +32,7 @@ ota:
 ```
 
 The secret names on this page follow the `<hostname>__<base>` shape the Device Builder writes to `secrets.yaml`, see
-[Using secrets.yaml](/guides/security_best_practices/#using-secretsyaml). Without an API encryption key, a password
+[Using secrets.yaml](/guides/security_best_practices/#using-secrets-yaml). Without an API encryption key, a password
 authenticates the uploader but does not keep the image confidential:
 
 ```yaml

--- a/src/content/docs/guides/security_best_practices.mdx
+++ b/src/content/docs/guides/security_best_practices.mdx
@@ -100,7 +100,7 @@ ota:
 - Prefer encryption over a password; a password only authenticates the uploader, it does not keep the image confidential
 - Reuse the API encryption key so there is a single unique key per device
 - Never reuse keys across devices
-- Enable encryption before the device leaves a trusted network; a device on 2026.9.0 or newer with an API key already offers it, so the upload that adds the block is encrypted, while older firmware takes one last plaintext upload
+- Enable encryption before the device leaves a trusted network; on 2026.9.0 or newer with an API key the upload that adds the block is already encrypted, older firmware takes one last plaintext upload
 
 **Without OTA encryption:** Anyone on your local network can:
 

--- a/src/content/docs/guides/security_best_practices.mdx
+++ b/src/content/docs/guides/security_best_practices.mdx
@@ -100,7 +100,7 @@ ota:
 - Prefer encryption over a password; a password only authenticates the uploader, it does not keep the image confidential
 - Reuse the API encryption key so there is a single unique key per device
 - Never reuse keys across devices
-- Enable encryption before the device leaves a trusted network; the first upload that adds it still goes over plaintext OTA
+- Enable encryption before the device leaves a trusted network; a device on 2026.9.0 or newer with an API key already offers it, so the upload that adds the block is encrypted, while older firmware takes one last plaintext upload
 
 **Without OTA encryption:** Anyone on your local network can:
 

--- a/src/content/docs/guides/security_best_practices.mdx
+++ b/src/content/docs/guides/security_best_practices.mdx
@@ -278,7 +278,7 @@ If you have extreme security requirements, you can physically disable USB/serial
 
 ### Using secrets.yaml
 
-Use `secrets.yaml` to avoid storing sensitive information in your configuration files, especially if you share your configs in a public Git repository. The per device names below follow the `<hostname>__<base>` shape the Device Builder uses when it stores a secret for a device, so the examples match what it writes to `secrets.yaml`:
+Use `secrets.yaml` to avoid storing sensitive information in your configuration files, especially if you share your configs in a public Git repository. The per device names below follow the `<hostname>__<base>` shape the Device Builder uses when it stores a secret for a device, with hyphens in the hostname written as underscores, so the examples match what it writes to `secrets.yaml`:
 
 ```yaml
 # Example: device1.yaml

--- a/src/content/docs/guides/security_best_practices.mdx
+++ b/src/content/docs/guides/security_best_practices.mdx
@@ -88,7 +88,7 @@ reuses the API key, so no extra secret is needed:
 ```yaml
 api:
   encryption:
-    key: !secret device_name_key
+    key: !secret device_name__encryption_key
 
 ota:
   - platform: esphome
@@ -114,7 +114,7 @@ If you cannot use encryption, at least set an OTA password:
 ```yaml
 ota:
   - platform: esphome
-    password: !secret device_name_ota_password
+    password: !secret device_name__ota_password
 ```
 
 Use a strong, unique password, store it in `secrets.yaml`, never share it across devices, and rotate it after a
@@ -448,7 +448,7 @@ mqtt:
 ota:
   - platform: esphome
     encryption:
-      key: !secret device_name_ota_key
+      key: !secret device_name__ota_key
 
 ```
 

--- a/src/content/docs/guides/security_best_practices.mdx
+++ b/src/content/docs/guides/security_best_practices.mdx
@@ -288,21 +288,19 @@ api:
 
 ota:
   - platform: esphome
-    password: !secret device1_ota_password
+    encryption:
 
 ```
 
 **secrets.yaml:**
 
 ```yaml
-# Each device should have unique keys and passwords
+# Each device should have unique keys and passwords; the API key also encrypts OTA
 device1_api_key: "uKh1234567890abcdefghijklmnopqrstuvwxyz="
-device1_ota_password: "strong-unique-password-device1"
 device1_web_username: "device1_admin"
 device1_web_password: "strong-unique-web-password-device1"
 
 device2_api_key: "aBc9876543210xyzqrstuvwxyzabcdefghijkl="
-device2_ota_password: "strong-unique-password-device2"
 device2_web_username: "device2_admin"
 device2_web_password: "strong-unique-web-password-device2"
 
@@ -312,7 +310,7 @@ wifi_password: "your-wifi-password"
 
 ```
 
-**Important:** Even when using `secrets.yaml`, **each device must have unique API encryption keys, OTA passwords, and web server credentials**. Never reuse these across devices. Only WiFi credentials can be shared.
+**Important:** Even when using `secrets.yaml`, **each device must have unique API encryption keys (which also secure OTA), OTA passwords where still used, and web server credentials**. Never reuse these across devices. Only WiFi credentials can be shared.
 
 ### Version Control
 
@@ -504,10 +502,10 @@ api:
   encryption:
     key: !secret secure_device_api_key
 
-# OTA with password (REQUIRED)
+# OTA encrypted with the API key (REQUIRED)
 ota:
   - platform: esphome
-    password: !secret secure_device_ota_password
+    encryption:
 
 # Disable web server if not needed
 # web_server:
@@ -552,10 +550,10 @@ api:
   # Optional: Restrict to specific Home Assistant instance
   # reboot_timeout: 15min
 
-# OTA with password
+# OTA encrypted with the API key
 ota:
   - platform: esphome
-    password: !secret production_device_ota_password
+    encryption:
   # Optional: Require safe_mode for troubleshooting
   # safe_mode: true
 
@@ -594,8 +592,8 @@ Depending on your jurisdiction and use case, you may need to comply with:
 1. **Investigate** other devices on the same network
 1. **Rotate credentials**:
 
-   - API encryption keys
-   - OTA passwords
+   - API encryption keys (a device that requires OTA encryption only accepts its current key, so a new key goes in with the serial flash below)
+   - OTA passwords, where still used
    - Web server credentials
    - WiFi passwords (if device had access)
 

--- a/src/content/docs/guides/security_best_practices.mdx
+++ b/src/content/docs/guides/security_best_practices.mdx
@@ -35,7 +35,7 @@ api:
 **Best practices:**
 
 - Generate a unique encryption key for each device - see the [API component documentation](/components/api#configuration-variables) for an on-demand key generator
-- Store keys in `secrets.yaml` (never commit this file to version control)
+- Store keys in `secrets.yaml` (never commit this file to version control); the `device_name__encryption_key` name follows the `<hostname>__<base>` shape the Device Builder writes, see [Using secrets.yaml](#using-secretsyaml)
 - Never reuse encryption keys across devices
 - If a device is compromised, regenerate its key immediately
 
@@ -278,7 +278,7 @@ If you have extreme security requirements, you can physically disable USB/serial
 
 ### Using secrets.yaml
 
-Use `secrets.yaml` to avoid storing sensitive information in your configuration files, especially if you share your configs in a public Git repository: The per device names below follow the `<hostname>__<base>` shape the Device Builder uses when it stores a secret for a device, so the examples match what it writes to `secrets.yaml`:
+Use `secrets.yaml` to avoid storing sensitive information in your configuration files, especially if you share your configs in a public Git repository. The per device names below follow the `<hostname>__<base>` shape the Device Builder uses when it stores a secret for a device, so the examples match what it writes to `secrets.yaml`:
 
 ```yaml
 # Example: device1.yaml

--- a/src/content/docs/guides/security_best_practices.mdx
+++ b/src/content/docs/guides/security_best_practices.mdx
@@ -28,7 +28,7 @@ The [native API](/components/api) is the primary communication method between ES
 ```yaml
 api:
   encryption:
-    key: !secret device_name_api_key
+    key: !secret device_name__encryption_key
 
 ```
 
@@ -54,8 +54,8 @@ If you enable the [web server](/components/web_server) for device monitoring and
 web_server:
   port: 80
   auth:
-    username: !secret device_name_web_username
-    password: !secret device_name_web_password
+    username: !secret device_name__web_server_username
+    password: !secret device_name__web_password
 
 ```
 
@@ -190,7 +190,7 @@ wifi:
   # Optional: Fallback AP with password (only if needed)
   ap:
     ssid: "Fallback-AP"
-    password: !secret fallback_password
+    password: !secret device_name__ap_password
 
 ```
 
@@ -284,7 +284,7 @@ Use `secrets.yaml` to avoid storing sensitive information in your configuration 
 # Example: device1.yaml
 api:
   encryption:
-    key: !secret device1_api_key
+    key: !secret device1__encryption_key
 
 ota:
   - platform: esphome
@@ -296,13 +296,13 @@ ota:
 
 ```yaml
 # Each device should have unique keys and passwords; the API key also encrypts OTA
-device1_api_key: "uKh1234567890abcdefghijklmnopqrstuvwxyz="
-device1_web_username: "device1_admin"
-device1_web_password: "strong-unique-web-password-device1"
+device1__encryption_key: "uKh1234567890abcdefghijklmnopqrstuvwxyz="
+device1__web_server_username: "device1_admin"
+device1__web_password: "strong-unique-web-password-device1"
 
-device2_api_key: "aBc9876543210xyzqrstuvwxyzabcdefghijkl="
-device2_web_username: "device2_admin"
-device2_web_password: "strong-unique-web-password-device2"
+device2__encryption_key: "aBc9876543210xyzqrstuvwxyzabcdefghijkl="
+device2__web_server_username: "device2_admin"
+device2__web_password: "strong-unique-web-password-device2"
 
 # WiFi credentials can be shared across devices
 wifi_ssid: "YourNetworkName"
@@ -416,7 +416,7 @@ wifi:
   # ... your normal wifi config ...
   ap:
     ssid: "Device-Fallback"
-    password: !secret device_name_fallback_password  # ALWAYS SET THIS
+    password: !secret device_name__ap_password  # ALWAYS SET THIS
 
 ```
 
@@ -439,8 +439,8 @@ If using [MQTT](/components/mqtt) instead of the native API:
 ```yaml
 mqtt:
   broker: !secret mqtt_broker
-  username: !secret mqtt_username
-  password: !secret mqtt_password
+  username: !secret device_name__mqtt_username
+  password: !secret device_name__mqtt_password
   # For ESP32 with esp-idf: Use TLS with certificate authority
   # certificate_authority: ca_cert.pem
 
@@ -501,12 +501,12 @@ wifi:
   # Fallback hotspot with password
   ap:
     ssid: "Secure-Device-Fallback"
-    password: !secret secure_device_fallback_password
+    password: !secret secure_device__ap_password
 
 # API with encryption (REQUIRED)
 api:
   encryption:
-    key: !secret secure_device_api_key
+    key: !secret secure_device__encryption_key
 
 # OTA encrypted with the API key (REQUIRED)
 ota:
@@ -517,8 +517,8 @@ ota:
 # web_server:
 #   port: 80
 #   auth:
-#     username: !secret secure_device_web_username
-#     password: !secret secure_device_web_password
+#     username: !secret secure_device__web_server_username
+#     password: !secret secure_device__web_password
 
 logger:
   level: INFO
@@ -552,7 +552,7 @@ wifi:
 # API with encryption
 api:
   encryption:
-    key: !secret production_device_api_key
+    key: !secret production_device__encryption_key
   # Optional: Restrict to specific Home Assistant instance
   # reboot_timeout: 15min
 

--- a/src/content/docs/guides/security_best_practices.mdx
+++ b/src/content/docs/guides/security_best_practices.mdx
@@ -100,7 +100,7 @@ ota:
 - Prefer encryption over a password; a password only authenticates the uploader, it does not keep the image confidential
 - Reuse the API encryption key so there is a single unique key per device
 - Never reuse keys across devices
-- Enable encryption before the device leaves a trusted network; on 2026.9.0 or newer with an API key the upload that adds the block is already encrypted, older firmware takes one last plaintext upload
+- Enable encryption before the device leaves a trusted network. On 2026.9.0 or newer with an API key the upload that adds the block is already encrypted; on older firmware install once without the block first, see [Enabling encryption on an existing device](/components/ota/esphome/#enabling-encryption-on-an-existing-device)
 
 **Without OTA encryption:** Anyone on your local network can:
 

--- a/src/content/docs/guides/security_best_practices.mdx
+++ b/src/content/docs/guides/security_best_practices.mdx
@@ -62,7 +62,7 @@ web_server:
 **Best practices:**
 
 - Use strong, unique passwords
-- Store credentials in `secrets.yaml`
+- Store the password in `secrets.yaml`
 - Consider disabling the web server entirely if you don't need it
 - If you only need logs, use Home Assistant or the native API instead
 

--- a/src/content/docs/guides/security_best_practices.mdx
+++ b/src/content/docs/guides/security_best_practices.mdx
@@ -448,7 +448,7 @@ mqtt:
 ota:
   - platform: esphome
     encryption:
-      key: !secret device_name__ota_key
+      key: !secret device_name__ota_esphome_key
 
 ```
 

--- a/src/content/docs/guides/security_best_practices.mdx
+++ b/src/content/docs/guides/security_best_practices.mdx
@@ -35,7 +35,7 @@ api:
 **Best practices:**
 
 - Generate a unique encryption key for each device - see the [API component documentation](/components/api#configuration-variables) for an on-demand key generator
-- Store keys in `secrets.yaml` (never commit this file to version control); the `device_name__encryption_key` name follows the `<hostname>__<base>` shape the Device Builder writes, see [Using secrets.yaml](#using-secretsyaml)
+- Store keys in `secrets.yaml` (never commit this file to version control); the `device_name__encryption_key` name follows the `<hostname>__<base>` shape the Device Builder writes, see [Using secrets.yaml](#using-secrets-yaml)
 - Never reuse encryption keys across devices
 - If a device is compromised, regenerate its key immediately
 

--- a/src/content/docs/guides/security_best_practices.mdx
+++ b/src/content/docs/guides/security_best_practices.mdx
@@ -444,6 +444,12 @@ mqtt:
   # For ESP32 with esp-idf: Use TLS with certificate authority
   # certificate_authority: ca_cert.pem
 
+# Without api: encryption there is no API key to reuse, so give OTA its own
+ota:
+  - platform: esphome
+    encryption:
+      key: !secret device_name_ota_key
+
 ```
 
 **Best practices:**

--- a/src/content/docs/guides/security_best_practices.mdx
+++ b/src/content/docs/guides/security_best_practices.mdx
@@ -100,7 +100,7 @@ ota:
 - Prefer encryption over a password; a password only authenticates the uploader, it does not keep the image confidential
 - Reuse the API encryption key so there is a single unique key per device
 - Never reuse keys across devices
-- Enable encryption before the device leaves a trusted network. On 2026.9.0 or newer with an API key the upload that adds the block is already encrypted; on older firmware install once without the block first, see [Enabling encryption on an existing device](/components/ota/esphome/#enabling-encryption-on-an-existing-device)
+- Enable encryption before the device leaves a trusted network. On 2026.9.0 or newer with an API key the upload that adds the block is already encrypted; on older firmware install once without the block first, see [Enabling Encryption on an Existing Device](/components/ota/esphome/#enabling-encryption-on-an-existing-device)
 
 **Without OTA encryption:** Anyone on your local network can:
 

--- a/src/content/docs/guides/security_best_practices.mdx
+++ b/src/content/docs/guides/security_best_practices.mdx
@@ -278,7 +278,7 @@ If you have extreme security requirements, you can physically disable USB/serial
 
 ### Using secrets.yaml
 
-Use `secrets.yaml` to avoid storing sensitive information in your configuration files, especially if you share your configs in a public Git repository:
+Use `secrets.yaml` to avoid storing sensitive information in your configuration files, especially if you share your configs in a public Git repository: The per device names below follow the `<hostname>__<base>` shape the Device Builder uses when it stores a secret for a device, so the examples match what it writes to `secrets.yaml`:
 
 ```yaml
 # Example: device1.yaml

--- a/src/content/docs/guides/security_best_practices.mdx
+++ b/src/content/docs/guides/security_best_practices.mdx
@@ -442,14 +442,15 @@ mqtt:
   # For ESP32 with esp-idf: Use TLS with certificate authority
   # certificate_authority: ca_cert.pem
 
-# Without api: encryption there is no API key to reuse, so give OTA its own.
-# A deployed device cannot receive this block over the air, see the OTA docs.
+# Without api: encryption there is no API key to reuse, so give OTA its own
 ota:
   - platform: esphome
     encryption:
       key: !secret device_name__ota_esphome_key
 
 ```
+
+A device already in the field cannot receive that OTA block over the air; see [Enabling Encryption on an Existing Device](/components/ota/esphome/#enabling-encryption-on-an-existing-device).
 
 **Best practices:**
 

--- a/src/content/docs/guides/security_best_practices.mdx
+++ b/src/content/docs/guides/security_best_practices.mdx
@@ -442,7 +442,8 @@ mqtt:
   # For ESP32 with esp-idf: Use TLS with certificate authority
   # certificate_authority: ca_cert.pem
 
-# Without api: encryption there is no API key to reuse, so give OTA its own
+# Without api: encryption there is no API key to reuse, so give OTA its own.
+# A deployed device cannot receive this block over the air, see the OTA docs.
 ota:
   - platform: esphome
     encryption:

--- a/src/content/docs/guides/security_best_practices.mdx
+++ b/src/content/docs/guides/security_best_practices.mdx
@@ -543,7 +543,7 @@ wifi:
 
   # Use static IP to reduce mDNS dependency
   manual_ip:
-    static_ip: !secret production_device_ip
+    static_ip: !secret production_device__ip
     gateway: !secret gateway_ip
     subnet: 255.255.255.0
 

--- a/src/content/docs/guides/security_best_practices.mdx
+++ b/src/content/docs/guides/security_best_practices.mdx
@@ -54,7 +54,7 @@ If you enable the [web server](/components/web_server) for device monitoring and
 web_server:
   port: 80
   auth:
-    username: !secret device_name__web_server_username
+    username: device-name-admin
     password: !secret device_name__web_password
 
 ```
@@ -278,7 +278,7 @@ If you have extreme security requirements, you can physically disable USB/serial
 
 ### Using secrets.yaml
 
-Use `secrets.yaml` to avoid storing sensitive information in your configuration files, especially if you share your configs in a public Git repository. The per device names below follow the `<hostname>__<base>` shape the Device Builder uses when it stores a secret for a device, with hyphens in the hostname written as underscores, so the examples match what it writes to `secrets.yaml`:
+Use `secrets.yaml` to avoid storing sensitive information in your configuration files, especially if you share your configs in a public Git repository. The per device names below follow the `<hostname>__<base>` shape the Device Builder uses when it stores a secret for a device, with hyphens in the hostname written as underscores, so the examples match what it writes to `secrets.yaml`; the web server username is not a secret, so it stays in the config:
 
 ```yaml
 # Example: device1.yaml
@@ -297,11 +297,9 @@ ota:
 ```yaml
 # Each device should have unique keys and passwords; the API key also encrypts OTA
 device1__encryption_key: "uKh1234567890abcdefghijklmnopqrstuvwxyz="
-device1__web_server_username: "device1_admin"
 device1__web_password: "strong-unique-web-password-device1"
 
 device2__encryption_key: "aBc9876543210xyzqrstuvwxyzabcdefghijkl="
-device2__web_server_username: "device2_admin"
 device2__web_password: "strong-unique-web-password-device2"
 
 # WiFi credentials can be shared across devices
@@ -517,7 +515,7 @@ ota:
 # web_server:
 #   port: 80
 #   auth:
-#     username: !secret secure_device__web_server_username
+#     username: secure-device-admin
 #     password: !secret secure_device__web_password
 
 logger:


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Documents how to enable OTA encryption on an existing device: a device on 2026.9.0 or newer with an API key already offers it, so adding the `ota: encryption:` block and installing once is enough, while older firmware takes one plaintext install first. Also covers the "did not offer encryption" error, the runtime provisioned key case, the warning for an OTA password next to an API key, and recovery options.

The page now leads with the recommended shape (an API key plus a bare `ota: encryption:`), marks `password:` as not recommended for new devices, and shows the own key form for MQTT devices. The security best practices guide is updated to match: its examples use encrypted OTA, and every per device secret in it is renamed to the `<hostname>__<base>` shape the Device Builder writes to secrets.yaml (`device1__encryption_key`, `device1__web_password`, `device_name__ap_password`, and so on), which touches examples beyond the OTA sections. The 2026.9 release post's encrypted OTA paragraph gains two sentences on the offer, since that is the behaviour the page rests on.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#18979

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>


