### PR TITLE
[spi] Document nRF52 (Zephyr) support

### DIFF
--- a/src/content/docs/components/spi.mdx
+++ b/src/content/docs/components/spi.mdx
@@ -109,6 +109,11 @@ ESP8266 has a more limited selection of pins that can be used; check the datashe
 
 Quad and octal modes requires a hardware interface, so `software` and `any` are not permitted values.
 
+nRF52 boards have a single user-accessible hardware controller (`spi`/`spi2`, backed by Zephyr's SPIM2 peripheral),
+selected the same way as on other platforms with `interface: any`, `hardware` or `spi2`. Only one hardware SPI bus
+is supported per device; a second `spi:` instance must set `interface: software` explicitly, or configuration
+fails with an error.
+
 ## Generic SPI device component
 
 <span id="spi_device"></span>
@@ -174,6 +179,7 @@ be achieved by division from the SPI clock source. Clock source frequencies are:
 | ESP32    | 80MHz        |
 | ESP8266  | 40MHz        |
 | RP2040   | 62.5MHz      |
+| nRF52    | 8MHz         |
 
 The requested rate must be able to be generated from the clock source with integer division, with a 5% error allowed.
 


### PR DESCRIPTION
## Description

Documents the nRF52 (Zephyr) hardware SPI backend added in esphome/esphome#18214: interface selection (single
user-accessible hardware bus, `spi`/`spi2` backed by Zephyr's SPIM2 peripheral) and its 8MHz clock source in the
data rates table.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#18214

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.
  (not applicable -- spi.mdx already exists, this only adds a platform note to it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ke2M7VaZwEamwZ5gd6iff