### PR TITLE
[ota] Enable encryption on an existing device in two numbered paths

### DIFF
--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -198,11 +198,10 @@ apply depends on whether the device uses the native API.
 
 #### Devices With the Native API
 
-Each step ends with an install and a check of the device log; do not start step 2 until the check in step 1 passes.
+Do not start step 2 until the check in step 1 passes.
 
-1. **Install a firmware that offers encryption.** Leave the config as it is, without `encryption:` under the OTA
-   platform, and keep any existing `password:`. If `api:` has no `encryption:` yet, add one with a key now; a device
-   already added to Home Assistant needs that key entered there after this install.
+1. **Install a firmware that offers encryption.** Keep the config as it is: any `password:` stays, and nothing is
+   added under the OTA platform. If `api:` has no `encryption:` yet, add one with a key.
 
    ```yaml
    api:
@@ -214,16 +213,10 @@ Each step ends with an install and a check of the device log; do not start step 
        password: !secret device_name__ota_password
    ```
 
-   Install with ESPHome 2026.9.0 or newer. Validation warns about the password next to the key; that is expected
-   here and goes away in step 2. If the device runs older firmware or had no key, this upload is plaintext and the CLI
-   says so with a warning. Adding a key to a config that had none pulls in the noise library, so on a
-   device with 1 MB of flash check that the build still fits first; if it does not, leave out components the device
-   does not need for this one build and put them back in step 2. When the device has booted, its log must show
-   `Encryption: offered, plaintext accepted`. A device that already runs 2026.9.0 or newer with the key shows this
-   already and can start at step 2.
+   Install with ESPHome 2026.9.0 or newer. Check: after the boot the device log shows
+   `Encryption: offered, plaintext accepted`. A device that already shows this can start at step 2.
 
-2. **Require encryption.** Add `encryption:` under the OTA platform and remove the `password:`; the encrypted
-   handshake authenticates the upload, so the password the running firmware still has is not needed.
+2. **Require encryption.** Add `encryption:` under the OTA platform and remove the `password:`.
 
    ```yaml
    api:
@@ -235,24 +228,28 @@ Each step ends with an install and a check of the device log; do not start step 
        encryption:
    ```
 
-   Install. The CLI reports `Encrypted connection established`, and after the boot the device log shows
-   `Encryption: required`. From now on the device refuses plaintext uploads.
+   Install. Check: the CLI reports `Encrypted connection established` and the device log shows
+   `Encryption: required`.
 
-A key provisioned at runtime by Home Assistant (an API `encryption:` block without a `key:`) has to be in the yaml
-before step 1: the Device Builder writes it there when Home Assistant hands it over. Do not generate a fresh key for
-such a device, that locks Home Assistant out after the next install.
+What to expect on this path:
+
+- A key provisioned by Home Assistant (an API `encryption:` block without a `key:`) must be in the yaml before step 1;
+  the Device Builder writes it there. Never generate a fresh key for such a device, that locks Home Assistant out.
+- If step 1 added a key, Home Assistant asks for it after that install.
+- The step 1 upload is plaintext when the running firmware has no key to offer; the CLI warns. Validation also warns
+  about the password next to the key until step 2 removes it.
+- Adding a key pulls in the noise library. On a device with 1 MB of flash, check the build fits; if not, leave out
+  components the device does not need for that one build and put them back in step 2.
 
 #### Devices Without the Native API
 
-MQTT devices, and anything else without an `api:` block, use an `api:` block once as a stepping stone: only an API key
-can make the running firmware offer encryption, and the OTA key then has to arrive over an encrypted upload. A device
-that has `api:` follows the path above instead. As above, do not start step 2 until the check in step 1 passes.
+MQTT devices, and anything else without an `api:` block, use one as a stepping stone: only an API key makes the running
+firmware offer encryption, and the OTA key then arrives over an encrypted upload. Do not start step 2 until the check
+in step 1 passes.
 
 1. **Install a firmware that offers encryption.** Generate a key with the
    [on demand generator](/components/api#configuration-variables). Add a temporary `api:` block with it and
-   `reboot_timeout: 0s`, since a device with `api:` and no client would otherwise reboot every 15 minutes. Keep any
-   existing `password:`. Home Assistant will discover the device while this build runs; ignore that, it disappears
-   again after step 2.
+   `reboot_timeout: 0s`. Any `password:` stays.
 
    ```yaml
    mqtt:
@@ -269,18 +266,11 @@ that has `api:` follows the path above instead. As above, do not start step 2 un
        password: !secret device_name__ota_password
    ```
 
-   Install with ESPHome 2026.9.0 or newer. Validation warns about the password next to the key; that is expected
-   here and goes away in step 2. The running firmware has no key to offer, so this upload is always plaintext and the
-   CLI says so with a warning. The temporary block adds the API server and the noise library to this one
-   build, so on a device with 1 MB of flash check that the build still fits first. If it does not, leave out
-   components the stepping stone does not need for this one build and put them back in step 2; that can include
-   `mqtt:` (its entities are unavailable until step 2), unless the CLI finds the device through MQTT rather than
-   mDNS, in which case keep it and set `use_address` to the device's IP instead. When the device has booted, its log
-   must show `Encryption: offered, plaintext accepted`.
+   Install with ESPHome 2026.9.0 or newer. Check: after the boot the device log shows
+   `Encryption: offered, plaintext accepted`.
 
-2. **Move the key to the OTA platform and require encryption.** Remove the `api:` block, add `encryption:` under the
-   OTA platform with the same key, and remove the `password:`; the encrypted handshake authenticates the upload, so
-   the password the running firmware still has is not needed.
+2. **Move the key to the OTA platform and require encryption.** Remove the `api:` block, add `encryption:` with the
+   same key under the OTA platform, and remove the `password:`.
 
    ```yaml
    mqtt:
@@ -292,11 +282,22 @@ that has `api:` follows the path above instead. As above, do not start step 2 un
          key: !secret device_name__ota_esphome_key
    ```
 
-   Install. The CLI reports `Encrypted connection established`, and after the boot the device log shows
-   `Encryption: required`. That key is now the device's OTA key.
+   Install. Check: the CLI reports `Encrypted connection established` and the device log shows
+   `Encryption: required`.
+
+What to expect on this path:
+
+- `reboot_timeout: 0s` is needed because a device with `api:` and no client otherwise reboots every 15 minutes.
+- Home Assistant discovers the device while the step 1 build runs; ignore it, it disappears after step 2.
+- The step 1 upload is always plaintext, the running firmware has no key to offer; the CLI warns. Validation also
+  warns about the password next to the key until step 2 removes it.
+- The temporary block adds the API server and the noise library. On a device with 1 MB of flash, check the build
+  fits; if not, leave out components the device does not need for that one build and put them back in step 2. Keep
+  `mqtt:` if the CLI finds the device through MQTT rather than mDNS, or set `use_address` to the device's IP.
 
 #### Notes
 
+- The password can go in step 2 because the encrypted handshake authenticates that upload.
 - Step 1 relies on the CLI falling back to plaintext when the device does not offer encryption. That fallback is
   planned to go away no earlier than ESPHome 2027.3.0, the release notes will announce the release that drops it. Do
   step 1 while it exists for every device whose running firmware has no key to offer: older than 2026.9.0, on

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -198,10 +198,9 @@ apply depends on whether the device uses the native API.
 
 #### Devices With the Native API
 
-Do not start step 2 until the check in step 1 passes.
-
-1. **Install a firmware that offers encryption.** Keep the config as it is: any `password:` stays, and nothing is
-   added under the OTA platform. If `api:` has no `encryption:` yet, add one with a key.
+1. **Install a firmware that offers encryption.** Keep the config as it is; if `api:` has no `encryption:` yet, add
+   one with a key. Install with ESPHome 2026.9.0 or newer, then check the device log for
+   `Encryption: offered, plaintext accepted`. A device that already shows this starts at step 2.
 
    ```yaml
    api:
@@ -213,10 +212,8 @@ Do not start step 2 until the check in step 1 passes.
        password: !secret device_name__ota_password
    ```
 
-   Install with ESPHome 2026.9.0 or newer. Check: after the boot the device log shows
-   `Encryption: offered, plaintext accepted`. A device that already shows this can start at step 2.
-
-2. **Require encryption.** Add `encryption:` under the OTA platform and remove the `password:`.
+2. **Require encryption.** Add `encryption:` under the OTA platform, remove the `password:`, and install. Check the
+   device log for `Encryption: required`.
 
    ```yaml
    api:
@@ -228,28 +225,16 @@ Do not start step 2 until the check in step 1 passes.
        encryption:
    ```
 
-   Install. Check: the CLI reports `Encrypted connection established` and the device log shows
-   `Encryption: required`.
-
-What to expect on this path:
-
-- A key provisioned by Home Assistant (an API `encryption:` block without a `key:`) must be in the yaml before step 1;
-  the Device Builder writes it there. Never generate a fresh key for such a device, that locks Home Assistant out.
-- If step 1 added a key, Home Assistant asks for it after that install.
-- The step 1 upload is plaintext when the running firmware has no key to offer; the CLI warns. Validation also warns
-  about the password next to the key until step 2 removes it.
-- Adding a key pulls in the noise library. On a device with 1 MB of flash, check the build fits; if not, leave out
-  components the device does not need for that one build and put them back in step 2.
+A key provisioned by Home Assistant must already be in the yaml; the Device Builder writes it there. Never generate a
+fresh key for such a device, that locks Home Assistant out.
 
 #### Devices Without the Native API
 
-MQTT devices, and anything else without an `api:` block, use one as a stepping stone: only an API key makes the running
-firmware offer encryption, and the OTA key then arrives over an encrypted upload. Do not start step 2 until the check
-in step 1 passes.
+Without `api:` the running firmware cannot offer encryption, so an `api:` block is used once as a stepping stone.
 
-1. **Install a firmware that offers encryption.** Generate a key with the
-   [on demand generator](/components/api#configuration-variables). Add a temporary `api:` block with it and
-   `reboot_timeout: 0s`. Any `password:` stays.
+1. **Install a firmware that offers encryption.** Add a temporary `api:` block with a generated key and
+   `reboot_timeout: 0s`. Install with ESPHome 2026.9.0 or newer, then check the device log for
+   `Encryption: offered, plaintext accepted`.
 
    ```yaml
    mqtt:
@@ -266,11 +251,8 @@ in step 1 passes.
        password: !secret device_name__ota_password
    ```
 
-   Install with ESPHome 2026.9.0 or newer. Check: after the boot the device log shows
-   `Encryption: offered, plaintext accepted`.
-
-2. **Move the key to the OTA platform and require encryption.** Remove the `api:` block, add `encryption:` with the
-   same key under the OTA platform, and remove the `password:`.
+2. **Move the key to the OTA platform.** Remove the `api:` block, put the same key under `ota: encryption:`, remove
+   the `password:`, and install. Check the device log for `Encryption: required`.
 
    ```yaml
    mqtt:
@@ -282,29 +264,15 @@ in step 1 passes.
          key: !secret device_name__ota_esphome_key
    ```
 
-   Install. Check: the CLI reports `Encrypted connection established` and the device log shows
-   `Encryption: required`.
-
-What to expect on this path:
-
-- `reboot_timeout: 0s` is needed because a device with `api:` and no client otherwise reboots every 15 minutes.
-- Home Assistant discovers the device while the step 1 build runs; ignore it, it disappears after step 2.
-- The step 1 upload is always plaintext, the running firmware has no key to offer; the CLI warns. Validation also
-  warns about the password next to the key until step 2 removes it.
-- The temporary block adds the API server and the noise library. On a device with 1 MB of flash, check the build
-  fits; if not, leave out components the device does not need for that one build and put them back in step 2. Keep
-  `mqtt:` if the CLI finds the device through MQTT rather than mDNS, or set `use_address` to the device's IP.
-
 #### Notes
 
-- The password can go in step 2 because the encrypted handshake authenticates that upload.
-- Step 1 relies on the CLI falling back to plaintext when the device does not offer encryption. That fallback is
-  planned to go away no earlier than ESPHome 2027.3.0, the release notes will announce the release that drops it. Do
-  step 1 while it exists for every device whose running firmware has no key to offer: older than 2026.9.0, on
-  2026.9.0 or newer without an API encryption key, or without the native API at all; after that, the block arrives by
-  serial flash or through the [web server OTA platform](/components/ota/web_server/).
-- An OTA `password:` next to an API key only serves older clients and costs about 3.5 KB of flash on an ESP8266, so
-  validation warns.
+- The step 1 upload is plaintext, the running firmware has no key to offer, and validation warns about the password
+  next to the key; both are expected and end with step 2. That plaintext fallback is planned to go away no earlier
+  than ESPHome 2027.3.0, so do step 1 before then.
+- Step 1 grows the build by the API server and the noise library. On a device with 1 MB of flash, leave out components
+  you do not need for that one build.
+- Home Assistant asks for the key after step 1 if one was added, and discovers the temporary `api:` device on the
+  second path; ignore that, it disappears after step 2.
 
 ## Updating the partition table on ESP32
 

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -214,8 +214,9 @@ Each step ends with an install and a check of the device log; do not start step 
        password: !secret device_name__ota_password
    ```
 
-   Install with ESPHome 2026.9.0 or newer. If the device runs older firmware or had no key, this upload is plaintext
-   and the CLI says so with a warning. Adding a key to a config that had none pulls in the noise library, so on a
+   Install with ESPHome 2026.9.0 or newer. Validation warns about the password next to the key; that is expected
+   here and goes away in step 2. If the device runs older firmware or had no key, this upload is plaintext and the CLI
+   says so with a warning. Adding a key to a config that had none pulls in the noise library, so on a
    device with 1 MB of flash check that the build still fits first; one that no longer fits over the air can only be
    flashed by serial. When the device has booted, its log must show
    `Encryption: offered, plaintext accepted`. A device that already runs 2026.9.0 or newer with the key shows this
@@ -267,8 +268,9 @@ that has `api:` follows the path above instead. As above, do not start step 2 un
        password: !secret device_name__ota_password
    ```
 
-   Install with ESPHome 2026.9.0 or newer. The running firmware has no key to offer, so this upload is always plaintext
-   and the CLI says so with a warning. The temporary block adds the API server and the noise library to this one
+   Install with ESPHome 2026.9.0 or newer. Validation warns about the password next to the key; that is expected
+   here and goes away in step 2. The running firmware has no key to offer, so this upload is always plaintext and the
+   CLI says so with a warning. The temporary block adds the API server and the noise library to this one
    build, so on a device with 1 MB of flash check that the build still fits first; one that no longer fits over the
    air can only be flashed by serial. When the device has booted, its log must show
    `Encryption: offered, plaintext accepted`.

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -198,7 +198,8 @@ the block in place the CLI never sends plaintext. Which steps apply depends on w
 #### Devices With the Native API
 
 1. Build and install with ESPHome 2026.9.0 or newer, with the config as it is and without the block. If `api:` has
-   no `encryption:` yet, add one with a key now. Keep any existing `password:`. If the device still runs older
+   no `encryption:` yet, add one with a key now; a device already added to Home Assistant needs that key entered
+   there after this install. Keep any existing `password:`. If the device still runs older
    firmware or had no key, this install is plaintext, with a warning; the firmware it lands offers OTA encryption
    with the API key. A device that already runs 2026.9.0 or newer with the key can skip to step 2.
 

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -153,9 +153,9 @@ ota:
 
 > [!WARNING]
 > A device flashed by serial can carry `encryption:` from the start. A device updated over the air gets it once it
-> runs firmware that offers encryption, and keeps it from then on. Older firmware cannot offer
-> encryption, and with the block in the config the CLI refuses to send
-> plaintext, so an install against it stops with
+> runs ESPHome 2026.9.0 or newer with an encryption key it can offer, and keeps it from then on. Firmware without
+> such a key cannot offer encryption, and with the block in the config the CLI refuses to send plaintext, so an
+> install against it stops with
 > `the device did not offer encryption; refusing to send the image in plaintext`. See
 > [Enabling Encryption on an Existing Device](#enabling-encryption-on-an-existing-device) for the way around it.
 
@@ -188,14 +188,15 @@ logger:
 
 ### Enabling Encryption on an Existing Device
 
-The block goes into the config only after the device runs firmware that offers encryption, because with the block in
-place the CLI never sends plaintext. Which steps apply depends on whether the device uses the native API.
+Over the air, the block goes into the config only after the device runs firmware that offers encryption, because with
+the block in place the CLI never sends plaintext. Which steps apply depends on whether the device uses the native API.
 
 #### Devices with an API encryption key
 
-1. Install ESPHome 2026.9.0 or newer with the config as it is, without the block. Keep any existing `password:`. If the
-   device still runs older firmware this install is plaintext, with a warning; the firmware it lands offers OTA
-   encryption with the API key.
+1. Build and install with ESPHome 2026.9.0 or newer, with the config as it is and without the block. Keep any
+   existing `password:`. If the device still runs older firmware this install is plaintext, with a warning; the
+   firmware it lands offers OTA encryption with the API key. A device that already runs 2026.9.0 or newer with the
+   key can skip to step 2.
 
    ```yaml
    api:
@@ -229,9 +230,11 @@ such a device, that locks Home Assistant out after the next install.
 MQTT devices, and anything else without an `api:` block, use an `api:` block once as a stepping stone: only an API key
 can make the running firmware offer encryption, and the OTA key then has to arrive over an encrypted upload.
 
-1. Generate a key. Add a temporary `api:` block with it and `reboot_timeout: 0s`, since a device with `api:` and no
-   client would otherwise reboot every 15 minutes. Keep any existing `password:` and install. If the device still runs
-   older firmware this install is plaintext, with a warning; the firmware it lands offers OTA encryption with that key.
+1. Generate a key with the [on demand generator](/components/api#configuration-variables). Add a temporary `api:`
+   block with it and `reboot_timeout: 0s`, since a device with `api:` and no client would otherwise reboot every 15
+   minutes. Keep any existing `password:`, then build and install with ESPHome 2026.9.0 or newer. The running firmware
+   has no key to offer, so this install is always plaintext, with a warning; the firmware it lands offers OTA
+   encryption with that key.
 
    ```yaml
    mqtt:
@@ -264,9 +267,10 @@ can make the running firmware offer encryption, and the OTA key then has to arri
 #### Notes
 
 - Step 1 relies on the CLI falling back to plaintext when the device does not offer encryption. That fallback is
-  planned to go away no earlier than ESPHome 2027.3.0, the release notes will announce the release that drops it, so
-  update devices on firmware older than 2026.9.0 while it exists; after that, update them by serial flash or through
-  the [web server OTA platform](/components/ota/web_server/).
+  planned to go away no earlier than ESPHome 2027.3.0, the release notes will announce the release that drops it. Do
+  step 1 while it exists, both for devices on firmware older than 2026.9.0 and for devices without the native API,
+  whose firmware has no key to offer at any version; after that, the block arrives by serial flash or through the
+  [web server OTA platform](/components/ota/web_server/).
 - An OTA `password:` next to an API key only serves older clients and costs about 3.5 KB of flash on an ESP8266, so
   validation warns.
 

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -192,8 +192,9 @@ logger:
 
 ### Enabling Encryption on an Existing Device
 
-Over the air, the block goes into the config only after the device runs firmware that offers encryption, because with
-the block in place the CLI never sends plaintext. Which steps apply depends on whether the device uses the native API.
+Add `encryption:` under the OTA platform only once the device runs firmware that offers encryption. With that line in
+the config the CLI never sends plaintext, so an over the air install against older firmware is refused. Which steps
+apply depends on whether the device uses the native API.
 
 #### Devices With the Native API
 

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -264,8 +264,9 @@ can make the running firmware offer encryption, and the OTA key then has to arri
 #### Notes
 
 - Step 1 relies on the CLI falling back to plaintext when the device does not offer encryption. That fallback is
-  removed in ESPHome 2027.3.0, so a device still on firmware older than 2026.9.0 must be updated before then; after
-  that, update it by serial flash or through the [web server OTA platform](/components/ota/web_server/).
+  planned to go away no earlier than ESPHome 2027.3.0, the release notes will announce the release that drops it, so
+  update devices on firmware older than 2026.9.0 while it exists; after that, update them by serial flash or through
+  the [web server OTA platform](/components/ota/web_server/).
 - An OTA `password:` next to an API key only serves older clients and costs about 3.5 KB of flash on an ESP8266, so
   validation warns.
 

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -46,7 +46,7 @@ ota:
 
 - **encryption** (*Optional*): Encrypt the OTA update with the same Noise protocol the [native API](/components/api) uses. See [Encryption](#encryption) below. Cannot be combined with **password**.
 
-  - **key** (*Optional*, string): The base64 encryption key. Omit it so the [API encryption key](/components/api#configuration-variables) is used and one key protects the device; only set it when there is no static API encryption key, for example a device that uses MQTT without `api:`. Next to a static API key it must be the same key, a different one is rejected at validation.
+  - **key** (*Optional*, string): The base64 encryption key. Omit it so the [API encryption key](/components/api#configuration-variables) is used and one key protects the device; only set it when there is no `api:` block at all, for example a device that uses MQTT. Next to a static API key it must be the same key, a different one is rejected at validation.
 
 - **password** (*Optional*, string): The password to use for updates. Not recommended for new devices, use **encryption** instead. Cannot be combined with **encryption**.
 - **allow_partition_access** (*Optional*, boolean): Only on `esp32`. Allow updating more partition types. Used for updating the partition table and the bootloader. Defaults to `false`.
@@ -137,11 +137,9 @@ ota:
     encryption:
 ```
 
-Only give the OTA block its own `key:` when there is no `api:` block at all, for example a device that talks MQTT. A
-device whose API key is provisioned at runtime by Home Assistant keeps one key: the provisioned key goes into the
-yaml and the OTA block inherits it, see
-[Enabling Encryption on an Existing Device](#enabling-encryption-on-an-existing-device). Generate a key with the on
-demand generator in the [API component documentation](/components/api#configuration-variables):
+Only give the OTA block its own `key:` when there is no `api:` block at all, for example a device that talks MQTT.
+Generate a key with the on demand generator in the
+[API component documentation](/components/api#configuration-variables):
 
 ```yaml
 mqtt:
@@ -152,6 +150,10 @@ ota:
     encryption:
       key: !secret device_name__ota_esphome_key
 ```
+
+By contrast, a device whose API key is provisioned at runtime by Home Assistant keeps one key: the provisioned key goes
+into the yaml and the OTA block inherits it, see
+[Enabling Encryption on an Existing Device](#enabling-encryption-on-an-existing-device).
 
 > [!WARNING]
 > A device flashed by serial can carry `encryption:` from the start. A device updated over the air gets it once it
@@ -193,12 +195,12 @@ logger:
 Over the air, the block goes into the config only after the device runs firmware that offers encryption, because with
 the block in place the CLI never sends plaintext. Which steps apply depends on whether the device uses the native API.
 
-#### Devices With an API Encryption Key
+#### Devices With the Native API
 
-1. Build and install with ESPHome 2026.9.0 or newer, with the config as it is and without the block. Keep any
-   existing `password:`. If the device still runs older firmware this install is plaintext, with a warning; the
-   firmware it lands offers OTA encryption with the API key. A device that already runs 2026.9.0 or newer with the
-   key can skip to step 2.
+1. Build and install with ESPHome 2026.9.0 or newer, with the config as it is and without the block. If `api:` has
+   no `encryption:` yet, add one with a key now. Keep any existing `password:`. If the device still runs older
+   firmware or had no key, this install is plaintext, with a warning; the firmware it lands offers OTA encryption
+   with the API key. A device that already runs 2026.9.0 or newer with the key can skip to step 2.
 
    ```yaml
    api:
@@ -230,7 +232,8 @@ such a device, that locks Home Assistant out after the next install.
 #### Devices Without the Native API
 
 MQTT devices, and anything else without an `api:` block, use an `api:` block once as a stepping stone: only an API key
-can make the running firmware offer encryption, and the OTA key then has to arrive over an encrypted upload.
+can make the running firmware offer encryption, and the OTA key then has to arrive over an encrypted upload. A device
+that has `api:` follows the path above instead.
 
 1. Generate a key with the [on demand generator](/components/api#configuration-variables). Add a temporary `api:`
    block with it and `reboot_timeout: 0s`, since a device with `api:` and no client would otherwise reboot every 15

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -198,6 +198,9 @@ apply depends on whether the device uses the native API.
 
 #### Devices With the Native API
 
+A key provisioned by Home Assistant must already be in the yaml; the Device Builder writes it there. Never generate a
+fresh key for such a device, that locks Home Assistant out.
+
 1. **Install a firmware that offers encryption.** Keep the config as it is; if `api:` has no `encryption:` yet, add
    one with a key. Install with ESPHome 2026.9.0 or newer, then check the device log for
    `Encryption: offered, plaintext accepted`. A device that already shows this starts at step 2.
@@ -224,9 +227,6 @@ apply depends on whether the device uses the native API.
      - platform: esphome
        encryption:
    ```
-
-A key provisioned by Home Assistant must already be in the yaml; the Device Builder writes it there. Never generate a
-fresh key for such a device, that locks Home Assistant out.
 
 #### Devices Without the Native API
 
@@ -268,7 +268,8 @@ Without `api:` the running firmware cannot offer encryption, so an `api:` block 
 
 - The step 1 upload is plaintext, the running firmware has no key to offer, and validation warns about the password
   next to the key; both are expected and end with step 2. That plaintext fallback is planned to go away no earlier
-  than ESPHome 2027.3.0, so do step 1 before then.
+  than ESPHome 2027.3.0, so do step 1 before then; after that the block arrives by serial flash or through the
+  [web server OTA platform](/components/ota/web_server/).
 - The step 1 build is larger, it includes the API server and the noise library. On a device with 1 MB of flash, leave
   out components you do not need for that one build.
 - Home Assistant asks for the key after step 1 if one was added, and discovers the temporary `api:` device on the

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -215,11 +215,14 @@ Each step ends with an install and a check of the device log; do not start step 
    ```
 
    Install with ESPHome 2026.9.0 or newer. If the device runs older firmware or had no key, this upload is plaintext
-   and the CLI says so with a warning. When the device has booted, its log must show
+   and the CLI says so with a warning. Adding a key to a config that had none pulls in the noise library, so on a
+   device with 1 MB of flash check that the build still fits first; one that no longer fits over the air can only be
+   flashed by serial. When the device has booted, its log must show
    `Encryption: offered, plaintext accepted`. A device that already runs 2026.9.0 or newer with the key shows this
    already and can start at step 2.
 
-2. **Require encryption.** Add `encryption:` under the OTA platform and remove the `password:`.
+2. **Require encryption.** Add `encryption:` under the OTA platform and remove the `password:`; the encrypted
+   handshake authenticates the upload, so the password the running firmware still has is not needed.
 
    ```yaml
    api:
@@ -266,11 +269,13 @@ that has `api:` follows the path above instead. As above, do not start step 2 un
 
    Install with ESPHome 2026.9.0 or newer. The running firmware has no key to offer, so this upload is always plaintext
    and the CLI says so with a warning. The temporary block adds the API server and the noise library to this one
-   build, so on a device with 1 MB of flash check that the build still fits first. When the device has booted, its log
-   must show `Encryption: offered, plaintext accepted`.
+   build, so on a device with 1 MB of flash check that the build still fits first; one that no longer fits over the
+   air can only be flashed by serial. When the device has booted, its log must show
+   `Encryption: offered, plaintext accepted`.
 
 2. **Move the key to the OTA platform and require encryption.** Remove the `api:` block, add `encryption:` under the
-   OTA platform with the same key, and remove the `password:`.
+   OTA platform with the same key, and remove the `password:`; the encrypted handshake authenticates the upload, so
+   the password the running firmware still has is not needed.
 
    ```yaml
    mqtt:

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -198,11 +198,11 @@ apply depends on whether the device uses the native API.
 
 #### Devices With the Native API
 
-1. Build and install with ESPHome 2026.9.0 or newer, with the config as it is and without the block. If `api:` has
-   no `encryption:` yet, add one with a key now; a device already added to Home Assistant needs that key entered
-   there after this install. Keep any existing `password:`. If the device still runs older
-   firmware or had no key, this install is plaintext, with a warning; the firmware it lands offers OTA encryption
-   with the API key. A device that already runs 2026.9.0 or newer with the key can skip to step 2.
+Each step ends with an install and a check of the device log; do not start step 2 until the check in step 1 passes.
+
+1. **Install a firmware that offers encryption.** Leave the config as it is, without `encryption:` under the OTA
+   platform, and keep any existing `password:`. If `api:` has no `encryption:` yet, add one with a key now; a device
+   already added to Home Assistant needs that key entered there after this install.
 
    ```yaml
    api:
@@ -214,8 +214,12 @@ apply depends on whether the device uses the native API.
        password: !secret device_name__ota_password
    ```
 
-2. Add `encryption:` under the OTA platform, remove the `password:`, and install. This install is encrypted with the
-   API key, and from now on the device refuses plaintext uploads.
+   Install with ESPHome 2026.9.0 or newer. If the device runs older firmware or had no key, this upload is plaintext
+   and the CLI says so with a warning. When the device has booted, its log must show
+   `Encryption: offered, plaintext accepted`. A device that already runs 2026.9.0 or newer with the key shows this
+   already and can start at step 2.
+
+2. **Require encryption.** Add `encryption:` under the OTA platform and remove the `password:`.
 
    ```yaml
    api:
@@ -227,6 +231,9 @@ apply depends on whether the device uses the native API.
        encryption:
    ```
 
+   Install. The CLI reports `Encrypted connection established`, and after the boot the device log shows
+   `Encryption: required`. From now on the device refuses plaintext uploads.
+
 A key provisioned at runtime by Home Assistant (an API `encryption:` block without a `key:`) has to be in the yaml
 before step 1: the Device Builder writes it there when Home Assistant hands it over. Do not generate a fresh key for
 such a device, that locks Home Assistant out after the next install.
@@ -235,14 +242,12 @@ such a device, that locks Home Assistant out after the next install.
 
 MQTT devices, and anything else without an `api:` block, use an `api:` block once as a stepping stone: only an API key
 can make the running firmware offer encryption, and the OTA key then has to arrive over an encrypted upload. A device
-that has `api:` follows the path above instead.
+that has `api:` follows the path above instead. As above, do not start step 2 until the check in step 1 passes.
 
-1. Generate a key with the [on demand generator](/components/api#configuration-variables). Add a temporary `api:`
-   block with it and `reboot_timeout: 0s`, since a device with `api:` and no client would otherwise reboot every 15
-   minutes. Keep any existing `password:`, then build and install with ESPHome 2026.9.0 or newer. The running firmware
-   has no key to offer, so this install is always plaintext, with a warning; the firmware it lands offers OTA
-   encryption with that key. The temporary block adds the API server and the noise library to this one build, so on a
-   device with 1 MB of flash check that the build still fits before installing.
+1. **Install a firmware that offers encryption.** Generate a key with the
+   [on demand generator](/components/api#configuration-variables). Add a temporary `api:` block with it and
+   `reboot_timeout: 0s`, since a device with `api:` and no client would otherwise reboot every 15 minutes. Keep any
+   existing `password:`.
 
    ```yaml
    mqtt:
@@ -259,8 +264,13 @@ that has `api:` follows the path above instead.
        password: !secret device_name__ota_password
    ```
 
-2. Remove the `api:` block, give the OTA platform `encryption:` with the same key, remove the `password:`, and
-   install. This install is encrypted with that key, which is now the device's OTA key.
+   Install with ESPHome 2026.9.0 or newer. The running firmware has no key to offer, so this upload is always plaintext
+   and the CLI says so with a warning. The temporary block adds the API server and the noise library to this one
+   build, so on a device with 1 MB of flash check that the build still fits first. When the device has booted, its log
+   must show `Encryption: offered, plaintext accepted`.
+
+2. **Move the key to the OTA platform and require encryption.** Remove the `api:` block, add `encryption:` under the
+   OTA platform with the same key, and remove the `password:`.
 
    ```yaml
    mqtt:
@@ -271,6 +281,9 @@ that has `api:` follows the path above instead.
        encryption:
          key: !secret device_name__ota_esphome_key
    ```
+
+   Install. The CLI reports `Encrypted connection established`, and after the boot the device log shows
+   `Encryption: required`. That key is now the device's OTA key.
 
 #### Notes
 

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -251,7 +251,8 @@ that has `api:` follows the path above instead. As above, do not start step 2 un
 1. **Install a firmware that offers encryption.** Generate a key with the
    [on demand generator](/components/api#configuration-variables). Add a temporary `api:` block with it and
    `reboot_timeout: 0s`, since a device with `api:` and no client would otherwise reboot every 15 minutes. Keep any
-   existing `password:`.
+   existing `password:`. Home Assistant will discover the device while this build runs; ignore that, it disappears
+   again after step 2.
 
    ```yaml
    mqtt:

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -217,8 +217,8 @@ Each step ends with an install and a check of the device log; do not start step 
    Install with ESPHome 2026.9.0 or newer. Validation warns about the password next to the key; that is expected
    here and goes away in step 2. If the device runs older firmware or had no key, this upload is plaintext and the CLI
    says so with a warning. Adding a key to a config that had none pulls in the noise library, so on a
-   device with 1 MB of flash check that the build still fits first; one that no longer fits over the air can only be
-   flashed by serial. When the device has booted, its log must show
+   device with 1 MB of flash check that the build still fits first; if it does not, leave out components the device
+   does not need for this one build and put them back in step 2. When the device has booted, its log must show
    `Encryption: offered, plaintext accepted`. A device that already runs 2026.9.0 or newer with the key shows this
    already and can start at step 2.
 
@@ -272,9 +272,9 @@ that has `api:` follows the path above instead. As above, do not start step 2 un
    Install with ESPHome 2026.9.0 or newer. Validation warns about the password next to the key; that is expected
    here and goes away in step 2. The running firmware has no key to offer, so this upload is always plaintext and the
    CLI says so with a warning. The temporary block adds the API server and the noise library to this one
-   build, so on a device with 1 MB of flash check that the build still fits first; one that no longer fits over the
-   air can only be flashed by serial. When the device has booted, its log must show
-   `Encryption: offered, plaintext accepted`.
+   build, so on a device with 1 MB of flash check that the build still fits first. If it does not, leave out
+   components the stepping stone does not need, `mqtt:` included, for this one build and put them back in step 2.
+   When the device has booted, its log must show `Encryption: offered, plaintext accepted`.
 
 2. **Move the key to the OTA platform and require encryption.** Remove the `api:` block, add `encryption:` under the
    OTA platform with the same key, and remove the `password:`; the encrypted handshake authenticates the upload, so

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -273,8 +273,10 @@ that has `api:` follows the path above instead. As above, do not start step 2 un
    here and goes away in step 2. The running firmware has no key to offer, so this upload is always plaintext and the
    CLI says so with a warning. The temporary block adds the API server and the noise library to this one
    build, so on a device with 1 MB of flash check that the build still fits first. If it does not, leave out
-   components the stepping stone does not need, `mqtt:` included, for this one build and put them back in step 2.
-   When the device has booted, its log must show `Encryption: offered, plaintext accepted`.
+   components the stepping stone does not need for this one build and put them back in step 2; that can include
+   `mqtt:` (its entities are unavailable until step 2), unless the CLI finds the device through MQTT rather than
+   mDNS, in which case keep it and set `use_address` to the device's IP instead. When the device has booted, its log
+   must show `Encryption: offered, plaintext accepted`.
 
 2. **Move the key to the OTA platform and require encryption.** Remove the `api:` block, add `encryption:` under the
    OTA platform with the same key, and remove the `password:`; the encrypted handshake authenticates the upload, so

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -268,8 +268,8 @@ Without `api:` the running firmware cannot offer encryption, so an `api:` block 
 #### Notes
 
 - The step 1 upload is plaintext, the running firmware does not offer encryption yet, and validation warns about the
-  password next to the key; both are expected and end with step 2. That plaintext fallback is planned to go away no earlier
-  than ESPHome 2027.3.0, so do step 1 before then; after that the block arrives by serial flash or through the
+  password next to the key; both are expected and end with step 2. That plaintext fallback is planned to go away no
+  earlier than ESPHome 2027.3.0, so do step 1 before then; after that the block arrives by serial flash or through the
   [web server OTA platform](/components/ota/web_server/).
 - The step 1 build is larger, it includes the API server and the noise library. On a device with 1 MB of flash, leave
   out components you do not need for that one build.

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -153,7 +153,7 @@ ota:
 
 > [!WARNING]
 > A device flashed by serial can carry `encryption:` from the start. A device updated over the air gets it once it
-> runs ESPHome 2026.9.0 or newer with an API encryption key, and keeps it from then on. Older firmware cannot offer
+> runs firmware that offers encryption, and keeps it from then on. Older firmware cannot offer
 > encryption, and with the block in the config the CLI refuses to send
 > plaintext, so an install against it stops with
 > `the device did not offer encryption; refusing to send the image in plaintext`. See
@@ -188,31 +188,86 @@ logger:
 
 ### Enabling Encryption on an Existing Device
 
-A device on ESPHome 2026.9.0 or newer with an API encryption key already offers OTA encryption, and `esphome run` uses
-that key whenever the device offers; the `encryption:` block is what makes the device require it. Add the block, remove
-any `password:`, and install; the encrypted handshake authenticates that upload, so the password is not needed for it.
-If the device still runs older firmware, install once without the block first, keeping any existing `password:` and
-with `api: encryption: key:` set: until ESPHome 2027.3.0 that upload falls back to plaintext with a warning and lands
-a firmware that offers, then add the block and drop the password. From 2027.3.0 the CLI no longer falls back to
-plaintext when it has a key to use, so a device with an API encryption key still on firmware older than 2026.9.0 must
-be updated before then; after that, update it by serial flash or through the
-[web server OTA platform](/components/ota/web_server/).
+The block goes into the config only after the device runs firmware that offers encryption, because with the block in
+place the CLI never sends plaintext. Which steps apply depends on whether the device uses the native API.
 
-An OTA `password:` next to an API key only serves older clients and costs about 3.5 KB of flash on an ESP8266, so
-validation warns.
+#### Devices with an API encryption key
 
-A key provisioned at runtime by Home Assistant (an API `encryption:` block without a `key:`) makes the device offer
-too, but the CLI cannot use a key it does not have, so those uploads stay plaintext until one of these is done:
+1. Install ESPHome 2026.9.0 or newer with the config as it is, without the block. Keep any existing `password:`. If the
+   device still runs older firmware this install is plaintext, with a warning; the firmware it lands offers OTA
+   encryption with the API key.
 
-- Put the key Home Assistant provisioned into `api: encryption: key:`. The Device Builder writes it there when Home
-  Assistant hands it over; do not generate a fresh one, that locks Home Assistant out after the next install.
-- Give the OTA `encryption:` block its own `key:`, which leaves the device with two keys: the provisioned API key and
-  the OTA key in the config.
+   ```yaml
+   api:
+     encryption:
+       key: !secret device_name__encryption_key
 
-A device without a static API key cannot get its own OTA `key:` over the air: its running firmware either offers no
-encryption at all (an MQTT device) or offers with the provisioned API key rather than the OTA key the CLI would
-present, and with the block in the config the CLI does not send plaintext. Put the block in by serial flash or through
-the [web server OTA platform](/components/ota/web_server/); after that, installs are encrypted with the OTA key.
+   ota:
+     - platform: esphome
+       password: !secret device_name__ota_password
+   ```
+
+2. Add `encryption:` under the OTA platform, remove the `password:`, and install. This install is encrypted with the
+   API key, and from now on the device refuses plaintext uploads.
+
+   ```yaml
+   api:
+     encryption:
+       key: !secret device_name__encryption_key
+
+   ota:
+     - platform: esphome
+       encryption:
+   ```
+
+A key provisioned at runtime by Home Assistant (an API `encryption:` block without a `key:`) has to be in the yaml
+before step 1: the Device Builder writes it there when Home Assistant hands it over. Do not generate a fresh key for
+such a device, that locks Home Assistant out after the next install.
+
+#### Devices without the native API
+
+MQTT devices, and anything else without an `api:` block, use an `api:` block once as a stepping stone: only an API key
+can make the running firmware offer encryption, and the OTA key then has to arrive over an encrypted upload.
+
+1. Generate a key. Add a temporary `api:` block with it and `reboot_timeout: 0s`, since a device with `api:` and no
+   client would otherwise reboot every 15 minutes. Keep any existing `password:` and install. If the device still runs
+   older firmware this install is plaintext, with a warning; the firmware it lands offers OTA encryption with that key.
+
+   ```yaml
+   mqtt:
+     broker: !secret mqtt_broker
+
+   # Temporary, removed again in step 2
+   api:
+     encryption:
+       key: !secret device_name__ota_esphome_key
+     reboot_timeout: 0s
+
+   ota:
+     - platform: esphome
+       password: !secret device_name__ota_password
+   ```
+
+2. Remove the `api:` block, give the OTA platform `encryption:` with the same key, remove the `password:`, and
+   install. This install is encrypted with that key, which is now the device's OTA key.
+
+   ```yaml
+   mqtt:
+     broker: !secret mqtt_broker
+
+   ota:
+     - platform: esphome
+       encryption:
+         key: !secret device_name__ota_esphome_key
+   ```
+
+#### Notes
+
+- Step 1 relies on the CLI falling back to plaintext when the device does not offer encryption. That fallback is
+  removed in ESPHome 2027.3.0, so a device still on firmware older than 2026.9.0 must be updated before then; after
+  that, update it by serial flash or through the [web server OTA platform](/components/ota/web_server/).
+- An OTA `password:` next to an API key only serves older clients and costs about 3.5 KB of flash on an ESP8266, so
+  validation warns.
 
 ## Updating the partition table on ESP32
 

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -269,8 +269,8 @@ Without `api:` the running firmware cannot offer encryption, so an `api:` block 
 - The step 1 upload is plaintext, the running firmware has no key to offer, and validation warns about the password
   next to the key; both are expected and end with step 2. That plaintext fallback is planned to go away no earlier
   than ESPHome 2027.3.0, so do step 1 before then.
-- Step 1 grows the build by the API server and the noise library. On a device with 1 MB of flash, leave out components
-  you do not need for that one build.
+- The step 1 build is larger, it includes the API server and the noise library. On a device with 1 MB of flash, leave
+  out components you do not need for that one build.
 - Home Assistant asks for the key after step 1 if one was added, and discovers the temporary `api:` device on the
   second path; ignore that, it disappears after step 2.
 

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -296,9 +296,9 @@ that has `api:` follows the path above instead. As above, do not start step 2 un
 
 - Step 1 relies on the CLI falling back to plaintext when the device does not offer encryption. That fallback is
   planned to go away no earlier than ESPHome 2027.3.0, the release notes will announce the release that drops it. Do
-  step 1 while it exists, both for devices on firmware older than 2026.9.0 and for devices without the native API,
-  whose firmware has no key to offer at any version; after that, the block arrives by serial flash or through the
-  [web server OTA platform](/components/ota/web_server/).
+  step 1 while it exists for every device whose running firmware has no key to offer: older than 2026.9.0, on
+  2026.9.0 or newer without an API encryption key, or without the native API at all; after that, the block arrives by
+  serial flash or through the [web server OTA platform](/components/ota/web_server/).
 - An OTA `password:` next to an API key only serves older clients and costs about 3.5 KB of flash on an ESP8266, so
   validation warns.
 

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -198,8 +198,9 @@ apply depends on whether the device uses the native API.
 
 #### Devices With the Native API
 
-A key provisioned by Home Assistant must already be in the yaml; the Device Builder writes it there. Never generate a
-fresh key for such a device, that locks Home Assistant out.
+A key provisioned by Home Assistant must be in the yaml before step 1: the Device Builder writes it there, otherwise
+copy the key Home Assistant provisioned into `api: encryption: key:`. Never generate a fresh key for such a device,
+that locks Home Assistant out.
 
 1. **Install a firmware that offers encryption.** Keep the config as it is; if `api:` has no `encryption:` yet, add
    one with a key. Install with ESPHome 2026.9.0 or newer, then check the device log for
@@ -266,8 +267,8 @@ Without `api:` the running firmware cannot offer encryption, so an `api:` block 
 
 #### Notes
 
-- The step 1 upload is plaintext, the running firmware has no key to offer, and validation warns about the password
-  next to the key; both are expected and end with step 2. That plaintext fallback is planned to go away no earlier
+- The step 1 upload is plaintext, the running firmware does not offer encryption yet, and validation warns about the
+  password next to the key; both are expected and end with step 2. That plaintext fallback is planned to go away no earlier
   than ESPHome 2027.3.0, so do step 1 before then; after that the block arrives by serial flash or through the
   [web server OTA platform](/components/ota/web_server/).
 - The step 1 build is larger, it includes the API server and the noise library. On a device with 1 MB of flash, leave

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -137,8 +137,10 @@ ota:
     encryption:
 ```
 
-Only give the OTA block its own `key:` when there is no static API key to use, for example a device that talks MQTT
-and has no `api:` block, or one whose API key is provisioned at runtime by Home Assistant. Generate a key with the on
+Only give the OTA block its own `key:` when there is no `api:` block at all, for example a device that talks MQTT. A
+device whose API key is provisioned at runtime by Home Assistant keeps one key: the provisioned key goes into the
+yaml and the OTA block inherits it, see
+[Enabling Encryption on an Existing Device](#enabling-encryption-on-an-existing-device). Generate a key with the on
 demand generator in the [API component documentation](/components/api#configuration-variables):
 
 ```yaml
@@ -191,7 +193,7 @@ logger:
 Over the air, the block goes into the config only after the device runs firmware that offers encryption, because with
 the block in place the CLI never sends plaintext. Which steps apply depends on whether the device uses the native API.
 
-#### Devices with an API encryption key
+#### Devices With an API Encryption Key
 
 1. Build and install with ESPHome 2026.9.0 or newer, with the config as it is and without the block. Keep any
    existing `password:`. If the device still runs older firmware this install is plaintext, with a warning; the
@@ -225,7 +227,7 @@ A key provisioned at runtime by Home Assistant (an API `encryption:` block witho
 before step 1: the Device Builder writes it there when Home Assistant hands it over. Do not generate a fresh key for
 such a device, that locks Home Assistant out after the next install.
 
-#### Devices without the native API
+#### Devices Without the Native API
 
 MQTT devices, and anything else without an `api:` block, use an `api:` block once as a stepping stone: only an API key
 can make the running firmware offer encryption, and the OTA key then has to arrive over an encrypted upload.
@@ -234,7 +236,8 @@ can make the running firmware offer encryption, and the OTA key then has to arri
    block with it and `reboot_timeout: 0s`, since a device with `api:` and no client would otherwise reboot every 15
    minutes. Keep any existing `password:`, then build and install with ESPHome 2026.9.0 or newer. The running firmware
    has no key to offer, so this install is always plaintext, with a warning; the firmware it lands offers OTA
-   encryption with that key.
+   encryption with that key. The temporary block adds the API server and the noise library to this one build, so on a
+   device with 1 MB of flash check that the build still fits before installing.
 
    ```yaml
    mqtt:

--- a/src/content/docs/guides/security_best_practices.mdx
+++ b/src/content/docs/guides/security_best_practices.mdx
@@ -450,7 +450,7 @@ ota:
 
 ```
 
-A device already in the field cannot receive that OTA block over the air; see [Enabling Encryption on an Existing Device](/components/ota/esphome/#enabling-encryption-on-an-existing-device).
+A device already in the field gets that block in two installs; see [Enabling Encryption on an Existing Device](/components/ota/esphome/#enabling-encryption-on-an-existing-device).
 
 **Best practices:**
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Follow up to #7327. The enablement section was one dense paragraph and it told devices without the native API that the OTA block cannot arrive over the air, which is wrong: a temporary `api: encryption: key:` makes the running firmware offer encryption, and the next install can then carry the same key in the OTA block and remove the api block again. The section is now split into two user groups, each with numbered steps and a full yaml per step: devices with an API encryption key (install 2026.9.0+ first, then add the block and drop the password) and devices without the native API (temporary api block with `reboot_timeout: 0s`, then the OTA block with the same key). The runtime provisioned key note, the 2027.3.0 fallback removal and the password cost move to a short notes list, the warning box points at the steps, and the security guide's MQTT note no longer claims the block needs a serial flash.

The MQTT steps were run on a D1 mini with an MQTT config and no `api:` block: step 1 went through the plaintext fallback and landed a firmware that offers with the temporary key, step 2 uploaded over an encrypted connection and left the device requiring encryption, and a further install was encrypted again.

**Related issue (if applicable):** follows #7327

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#18979 (merged)

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>

