### PR TITLE
[blog] Add template climate to the 2026.9 release post

### DIFF
--- a/src/content/docs/blog/2026/09/16/esphome-2026-9.mdx
+++ b/src/content/docs/blog/2026/09/16/esphome-2026-9.mdx
@@ -49,6 +49,7 @@ import ImgTable from "@components/ImgTable.astro";
   ["DS1603L", "/components/sensor/ds1603l/", "ds1603l.jpg", "Acoustic distance"],
   ["Mk2PVRouter", "/components/sensor/mk2pvrouter/", "mk2pvrouter.jpg", "Surplus Energy Diverter"],
   ["Snapshot", "/components/display/snapshot/", "file-image-outline.svg", "dark-invert"],
+  ["Template Climate", "/components/climate/template/", "description.svg", "dark-invert"],
   // ["Component Name", "/components/path/", "image.png"],
 ]} />
 
@@ -323,6 +324,10 @@ Six new components join the tree:
   [@iago-veiga](https://github.com/iago-veiga) exposes a Tuya-MCU electric water heater as a single
   `water_heater` entity, collapsing the previous template-plus-lambda pattern into one block
   ([#17323](https://github.com/esphome/esphome/pull/17323))
+- **[template climate](/components/climate/template/)** by [@rsre](https://github.com/rsre) builds a full
+  climate entity out of ESPHome primitives, with per-field set actions, an `on_control` trigger, an optimistic
+  mode that applies commands locally, and a `climate.template.publish` action for reporting the device's own
+  state ([#14455](https://github.com/esphome/esphome/pull/14455))
 - **[lvgl list widget](/components/lvgl/widgets/#list)** by [@clydebarrow](https://github.com/clydebarrow)
   adds a scrollable container designed to be filled at runtime, with `add_text`, `add`, `remove` and `clear`
   actions plus `on_add`/`on_remove` triggers ([#18018](https://github.com/esphome/esphome/pull/18018))

--- a/src/content/docs/components/index.mdx
+++ b/src/content/docs/components/index.mdx
@@ -717,7 +717,7 @@ Often known as "tag" or "card" readers within the community.
 
 <ImgTable items={[
   ["Climate Core", "/components/climate/", "folder-open.svg", "dark-invert"],
-  ["Template Climate", "/components/climate/template/", "folder-open.svg", "dark-invert"],
+  ["Template Climate", "/components/climate/template/", "description.svg", "dark-invert"],
   ["Anova Cooker", "/components/climate/anova/", "anova.png"],
   ["Bang Bang Controller", "/components/climate/bang_bang/", "air-conditioner.svg", "dark-invert"],
   ["BedJet Climate System", "/components/climate/bedjet/", "bedjet.png"],


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

The template climate platform landed in esphome/esphome#14455 and its documentation landed in #6216, but it was not mentioned anywhere in the 2026.9.0 release post. This adds it to the featured component table and to the "New Features In Existing Components" list. Section choice follows the labelling pattern the rest of the post uses: PRs labelled `new-component` go under "New Components And Hardware Support", `new-platform`-only PRs (like tuya `water_heater`) go under "New Features In Existing Components". esphome/esphome#14455 is `new-platform` without `new-component`, so the "Six new components" count in the release overview is unchanged.

Also switches the Template Climate entry in `/src/content/docs/components/index.mdx` from `folder-open.svg` to `description.svg`, which is what every other `Template *` platform in the index uses.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#14455

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [x] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.