### PR TITLE
[preferences] Move to its own page

### DIFF
--- a/src/components/AnchorRedirects.astro
+++ b/src/components/AnchorRedirects.astro
@@ -12,14 +12,15 @@ const { anchorRedirects } = Astro.locals.starlightRoute.entry.data;
 const table = JSON.stringify(anchorRedirects ?? {}).replace(/</g, "\\u003c");
 
 // Resolving through `URL` keeps a target's own query string and anchor intact; a query on the
-// dead link is carried over so that campaign parameters survive the redirect.
+// dead link is carried over so that campaign parameters survive the redirect. Targets are
+// constrained to site-relative paths by the collection schema, so this cannot leave the origin.
 const script =
   anchorRedirects && Object.keys(anchorRedirects).length > 0
     ? `const t = ${table}[location.hash.slice(1)];
 if (t) {
   const u = new URL(t, location.origin);
   if (!u.search) u.search = location.search;
-  location.replace(u);
+  location.replace(u.href);
 }`
     : null;
 ---

--- a/src/components/AnchorRedirects.astro
+++ b/src/components/AnchorRedirects.astro
@@ -1,0 +1,27 @@
+---
+/**
+ * Forwards dead section anchors to the page their section moved to, for pages that declare
+ * `anchorRedirects` in their frontmatter. Renders nothing on every other page.
+ *
+ * The script has to be inline and unbundled: Astro defers a bundled script, so the redirect
+ * would only fire once the reader was already looking at the wrong page.
+ */
+const { anchorRedirects } = Astro.locals.starlightRoute.entry.data;
+
+// `<` is escaped so that a target containing `</script>` cannot break out of the tag.
+const table = JSON.stringify(anchorRedirects ?? {}).replace(/</g, "\\u003c");
+
+// Resolving through `URL` keeps a target's own query string and anchor intact; a query on the
+// dead link is carried over so that campaign parameters survive the redirect.
+const script =
+  anchorRedirects && Object.keys(anchorRedirects).length > 0
+    ? `const t = ${table}[location.hash.slice(1)];
+if (t) {
+  const u = new URL(t, location.origin);
+  if (!u.search) u.search = location.search;
+  location.replace(u);
+}`
+    : null;
+---
+
+{script && <script is:inline set:html={script} />}

--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -1,30 +1,12 @@
 ---
+import AnchorRedirects from "./AnchorRedirects.astro";
 import Default from "@astrojs/starlight/components/Head.astro";
 import PlausibleAnalytics from "./PlausibleAnalytics.astro";
 ---
 
 <Default {...Astro.props}><slot /></Default>
 
-<!--
-  Redirects for anchors that no longer exist because the section they pointed at moved to its own page.
-  Fragments are never sent to the server, so Netlify redirects cannot do this - it has to happen client-side.
-  Keyed by pathname (no trailing slash), then by hash. Add an entry here whenever a documented section moves.
-  `is:inline` is required: a bundled script is deferred and would redirect after the wrong page has rendered.
--->
-<script is:inline>
-  (() => {
-    const ANCHOR_REDIRECTS = {
-      "/components/esphome": {
-        "#preferences-component": "/components/preferences/",
-        "#preferences-flash_write_interval": "/components/preferences/",
-      },
-    };
-
-    if (!location.hash) return;
-    const target = ANCHOR_REDIRECTS[location.pathname.replace(/\/$/, "")]?.[location.hash];
-    if (target) location.replace(target);
-  })();
-</script>
+<AnchorRedirects />
 
 <link rel="icon" href="/favicon.ico" sizes="any" />
 <link rel="icon" type="image/svg+xml" href="/favicon.svg" />

--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -5,6 +5,27 @@ import PlausibleAnalytics from "./PlausibleAnalytics.astro";
 
 <Default {...Astro.props}><slot /></Default>
 
+<!--
+  Redirects for anchors that no longer exist because the section they pointed at moved to its own page.
+  Fragments are never sent to the server, so Netlify redirects cannot do this - it has to happen client-side.
+  Keyed by pathname (no trailing slash), then by hash. Add an entry here whenever a documented section moves.
+  `is:inline` is required: a bundled script is deferred and would redirect after the wrong page has rendered.
+-->
+<script is:inline>
+  (() => {
+    const ANCHOR_REDIRECTS = {
+      "/components/esphome": {
+        "#preferences-component": "/components/preferences/",
+        "#preferences-flash_write_interval": "/components/preferences/",
+      },
+    };
+
+    if (!location.hash) return;
+    const target = ANCHOR_REDIRECTS[location.pathname.replace(/\/$/, "")]?.[location.hash];
+    if (target) location.replace(target);
+  })();
+</script>
+
 <link rel="icon" href="/favicon.ico" sizes="any" />
 <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -21,6 +21,13 @@ export const collections = {
            * and can be published before the post. See CrosspostBadges.astro.
            */
           crosspostCover: z.string().optional(),
+          /**
+           * Anchors on this page that no longer resolve because the section they
+           * pointed at moved to its own page, mapped to the URL that now covers it.
+           * Keys omit the leading "#". A URL fragment is never sent to the server,
+           * so Netlify cannot redirect these. See AnchorRedirects.astro.
+           */
+          anchorRedirects: z.record(z.string(), z.string()).optional(),
         }),
     }),
   }),

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -26,8 +26,20 @@ export const collections = {
            * pointed at moved to its own page, mapped to the URL that now covers it.
            * Keys omit the leading "#". A URL fragment is never sent to the server,
            * so Netlify cannot redirect these. See AnchorRedirects.astro.
+           *
+           * Targets are restricted to site-relative paths. AnchorRedirects.astro
+           * feeds them to location.replace(), so allowing an absolute URL would turn
+           * a typo into an open redirect, and a "javascript:" URL into an XSS sink.
+           * Rejecting a leading "//" keeps protocol-relative URLs out too.
            */
-          anchorRedirects: z.record(z.string(), z.string()).optional(),
+          anchorRedirects: z
+            .record(
+              z.string(),
+              z
+                .string()
+                .regex(/^\/(?!\/)/, 'anchor redirect targets must be site-relative paths starting with a single "/"'),
+            )
+            .optional(),
         }),
     }),
   }),

--- a/src/content/docs/components/button/factory_reset.mdx
+++ b/src/content/docs/components/button/factory_reset.mdx
@@ -6,7 +6,7 @@ title: "Factory Reset Button"
 import { Image } from 'astro:assets';
 import APIRef from '@components/APIRef.astro';
 
-The `factory_reset` button allows you to remotely invalidate (reset) all ESPHome [preferences](/components/esphome#preferences-flash_write_interval) stored in flash memory and reboot your node.
+The `factory_reset` button allows you to remotely invalidate (reset) all ESPHome [preferences](/components/preferences/) stored in flash memory and reboot your node.
 After reboot all states, parameters and variables will be reinitialized with their default values. This is useful:
 
 - for devices preflashed with ESPHome to reset behavior back to factory state

--- a/src/content/docs/components/button/factory_reset.mdx
+++ b/src/content/docs/components/button/factory_reset.mdx
@@ -6,7 +6,7 @@ title: "Factory Reset Button"
 import { Image } from 'astro:assets';
 import APIRef from '@components/APIRef.astro';
 
-The `factory_reset` button allows you to remotely invalidate (reset) all ESPHome [preferences](/components/preferences/) stored in flash memory and reboot your node.
+The `factory_reset` button allows you to remotely invalidate (reset) all ESPHome [preferences](/components/preferences/) and reboot your node.
 After reboot all states, parameters and variables will be reinitialized with their default values. This is useful:
 
 - for devices preflashed with ESPHome to reset behavior back to factory state

--- a/src/content/docs/components/button/factory_reset.mdx
+++ b/src/content/docs/components/button/factory_reset.mdx
@@ -1,5 +1,5 @@
 ---
-description: "Instructions for setting up buttons that can remotely invalidate all ESPHome preferences stored in flash and reboot ESP."
+description: "Instructions for setting up buttons that can remotely invalidate all ESPHome preferences and reboot your device."
 title: "Factory Reset Button"
 ---
 

--- a/src/content/docs/components/esphome.mdx
+++ b/src/content/docs/components/esphome.mdx
@@ -1,6 +1,9 @@
 ---
 description: "Instructions for setting up the core ESPHome configuration."
 title: "ESPHome Core Configuration"
+anchorRedirects:
+  preferences-component: /components/preferences/
+  preferences-flash_write_interval: /components/preferences/
 ---
 
 Here you specify some core information that ESPHome needs to create

--- a/src/content/docs/components/esphome.mdx
+++ b/src/content/docs/components/esphome.mdx
@@ -302,47 +302,6 @@ By default, ESPHome does not include any libraries into the project. This means 
 Arduino, such as `Wire` or `EEPROM`, aren't available. If you need to use them, you should list them manually under
 this option. If they are used by another library, they should be listed before the library that uses them.
 
-<span id="preferences-flash_write_interval"></span>
-
-## Preferences Component
-
-This component is used to store data in the flash memory which is persisted across device reboots, e.g. the latest
-state of a light or the accumulated energy used by an appliance.
-
-```yaml
-# Example configuration entry
-preferences:
-  flash_write_interval: 1min
-```
-
-### Configuration variables
-
-- **flash_write_interval** (*Optional*, [Time](/guides/configuration-types#time)): Customize the frequency in which data is
-  flushed to the flash. This setting helps to prevent rapid changes to a component from being quickly
-  written to the flash and wearing it out. Defaults to `1min`. Set to `never` to disable this feature.
-
-- **rtc_storage** (*Optional*, boolean): Only useful on ESP32. Compile RTC-memory-backed preference storage into the
-  firmware even when no other option selects it (options such as `safe_mode`'s and `fast_connect`'s `storage: rtc`
-  enable it automatically). This is intended for external components that request RTC storage through the C++
-  preferences API; without it, such requests fall back to flash (NVS) with a warning in the log. Not available on
-  ESP32 variants without RTC memory (C2 and C61). On ESP8266, RTC storage is integral and always enabled: `true` is
-  accepted (and does nothing), while `false` is rejected since it cannot be disabled.
-
-As all devices have a limited number of flash write cycles, this setting helps to reduce the number of flash writes
-due to quickly changing components. In the past, when components such as `light`, `switch`, `fan` and `globals`
-were changed, the state was immediately committed to flash. The result of this was that the last state of these
-components would always restore to its last state on power loss, however, this has the cost of potentially quickly
-damaging the flash if these components are quickly changed.
-
-A safety feature has thus been implemented to mitigate issues resulting from the limited number of flash write cycles,
-the state is first stored in memory before being flushed to flash after the `flash_write_interval` has passed. This
-results in fewer flash writes, preserving the flash health.
-
-This behavior can be modified by setting `flash_write_interval` to `0s` to commit the changes to flash as soon as possible,
-however, be aware that this may lead to increased flash wearing and a shortened device lifespan!
-
-For [ESP8266](/components/esp8266/), `restore_from_flash` must also be set to `true` for states to be written to flash.
-
 <span id="esphome-changing_node_name"></span>
 
 ## Changing ESPHome Node Name

--- a/src/content/docs/components/factory_reset.mdx
+++ b/src/content/docs/components/factory_reset.mdx
@@ -1,5 +1,5 @@
 ---
-description: "Instructions for setting up conditions that can remotely invalidate all ESPHome preferences stored in flash and reboot ESP."
+description: "Instructions for setting up conditions that can remotely invalidate all ESPHome preferences and reboot your device."
 title: "Factory Reset"
 ---
 import APIRef from '@components/APIRef.astro';

--- a/src/content/docs/components/factory_reset.mdx
+++ b/src/content/docs/components/factory_reset.mdx
@@ -5,7 +5,7 @@ title: "Factory Reset"
 import APIRef from '@components/APIRef.astro';
 
 
-The `factory_reset` component allows you to invalidate (reset) all ESPHome [preferences](/components/esphome#preferences-flash_write_interval) stored in flash memory and reboot your node.
+The `factory_reset` component allows you to invalidate (reset) all ESPHome [preferences](/components/preferences/) stored in flash memory and reboot your node.
 After reboot all states, parameters and variables will be reinitialized with their default values. This is useful:
 
 - for devices preflashed with ESPHome to reset behavior back to factory state

--- a/src/content/docs/components/factory_reset.mdx
+++ b/src/content/docs/components/factory_reset.mdx
@@ -5,7 +5,7 @@ title: "Factory Reset"
 import APIRef from '@components/APIRef.astro';
 
 
-The `factory_reset` component allows you to invalidate (reset) all ESPHome [preferences](/components/preferences/) stored in flash memory and reboot your node.
+The `factory_reset` component allows you to invalidate (reset) all ESPHome [preferences](/components/preferences/) and reboot your node.
 After reboot all states, parameters and variables will be reinitialized with their default values. This is useful:
 
 - for devices preflashed with ESPHome to reset behavior back to factory state

--- a/src/content/docs/components/host.mdx
+++ b/src/content/docs/components/host.mdx
@@ -35,7 +35,7 @@ The `esphome run yourfile.yaml` command will compile and automatically run the b
 
 ## Preferences
 
-The host platform supports persistence of preferences. See [Preferences](/components/esphome/#preferences-component)
+The host platform supports persistence of preferences. See [Preferences](/components/preferences/)
 for more information. The preferences are stored in a file in the directory specified by the environment
 variable `ESPHOME_PREFDIR`. If that variable is unset, they are stored in a directory named `.esphome/prefs`
 under the user's home directory. If neither `ESPHOME_PREFDIR` is set nor the home directory can be determined

--- a/src/content/docs/components/index.mdx
+++ b/src/content/docs/components/index.mdx
@@ -82,6 +82,7 @@ ESPHome-specific components or components supporting ESPHome device provisioning
   ["Interval", "/components/interval/", "description.svg", "dark-invert"],
   ["JSON", "/components/json/", "json.svg", "dark-invert"],
   ["Mapping", "/components/mapping/", "mapping.svg", "dark-invert"],
+  ["Preferences", "/components/preferences/", "settings.svg", "dark-invert"],
   ["Provisioning", "/components/provisioning/", "timer.svg", "dark-invert"],
   ["XXTEA", "/components/xxtea/", "xxtea.svg"],
   ["Script", "/components/script/", "description.svg", "dark-invert"],

--- a/src/content/docs/components/preferences.mdx
+++ b/src/content/docs/components/preferences.mdx
@@ -4,8 +4,9 @@ title: "Preferences"
 ---
 import APIRef from '@components/APIRef.astro';
 
-This component is used to store data in the flash memory which is persisted across device reboots, e.g. the latest
-state of a light or the accumulated energy used by an appliance.
+This component is used to store data which is persisted across device reboots, e.g. the latest state of a light or
+the accumulated energy used by an appliance. The data is normally stored in flash memory; the
+[host](/components/host/) platform stores it in a file instead, and on ESP32 it can optionally be kept in RTC memory.
 
 ```yaml
 # Example configuration entry

--- a/src/content/docs/components/preferences.mdx
+++ b/src/content/docs/components/preferences.mdx
@@ -29,7 +29,7 @@ preferences:
 
 ## Flash Wear
 
-As all devices have a limited number of flash write cycles, this setting helps to reduce the number of flash writes
+As flash memory has a limited number of write cycles, this setting helps to reduce the number of flash writes
 due to quickly changing components. In the past, when components such as `light`, `switch`, `fan` and `globals`
 were changed, the state was immediately committed to flash. The result of this was that the last state of these
 components would always restore to its last state on power loss, however, this has the cost of potentially quickly

--- a/src/content/docs/components/preferences.mdx
+++ b/src/content/docs/components/preferences.mdx
@@ -1,0 +1,50 @@
+---
+description: "Instructions for setting up how ESPHome stores state which persists across device reboots."
+title: "Preferences"
+---
+import APIRef from '@components/APIRef.astro';
+
+This component is used to store data in the flash memory which is persisted across device reboots, e.g. the latest
+state of a light or the accumulated energy used by an appliance.
+
+```yaml
+# Example configuration entry
+preferences:
+  flash_write_interval: 1min
+```
+
+## Configuration variables
+
+- **flash_write_interval** (*Optional*, [Time](/guides/configuration-types#time)): Customize the frequency in which
+  data is flushed to the flash. This setting helps to prevent rapid changes to a component from being quickly
+  written to the flash and wearing it out. Defaults to `1min`. Set to `never` to disable this feature.
+
+- **rtc_storage** (*Optional*, boolean): Only useful on ESP32. Compile RTC-memory-backed preference storage into the
+  firmware even when no other option selects it (options such as `safe_mode`'s and `fast_connect`'s `storage: rtc`
+  enable it automatically). This is intended for external components that request RTC storage through the C++
+  preferences API; without it, such requests fall back to flash (NVS) with a warning in the log. Not available on
+  ESP32 variants without RTC memory (C2 and C61). On ESP8266, RTC storage is integral and always enabled: `true` is
+  accepted (and does nothing), while `false` is rejected since it cannot be disabled.
+
+## Flash Wear
+
+As all devices have a limited number of flash write cycles, this setting helps to reduce the number of flash writes
+due to quickly changing components. In the past, when components such as `light`, `switch`, `fan` and `globals`
+were changed, the state was immediately committed to flash. The result of this was that the last state of these
+components would always restore to its last state on power loss, however, this has the cost of potentially quickly
+damaging the flash if these components are quickly changed.
+
+A safety feature has thus been implemented to mitigate issues resulting from the limited number of flash write cycles,
+the state is first stored in memory before being flushed to flash after the `flash_write_interval` has passed. This
+results in fewer flash writes, preserving the flash health.
+
+This behavior can be modified by setting `flash_write_interval` to `0s` to commit the changes to flash as soon as
+possible, however, be aware that this may lead to increased flash wearing and a shortened device lifespan!
+
+For [ESP8266](/components/esp8266/), `restore_from_flash` must also be set to `true` for states to be written to flash.
+
+## See Also
+
+- [ESPHome Core Configuration](/components/esphome/)
+- [Factory Reset](/components/factory_reset/)
+- <APIRef text="syncer.h" path="preferences/syncer.h" />

--- a/src/content/docs/components/preferences.mdx
+++ b/src/content/docs/components/preferences.mdx
@@ -1,11 +1,11 @@
 ---
-description: "Instructions for setting up how ESPHome stores state which persists across device reboots."
+description: "Instructions for setting up how ESPHome stores state that persists across device reboots."
 title: "Preferences"
 ---
 import APIRef from '@components/APIRef.astro';
 
-This component is used to store data which is persisted across device reboots, e.g. the latest state of a light or
-the accumulated energy used by an appliance. The data is normally stored in flash memory; the
+This component is used to store data that persists across device reboots, e.g. the latest state of a light or the
+accumulated energy used by an appliance. The data is normally stored in flash memory; the
 [host](/components/host/) platform stores it in a file instead, and on ESP32 it can optionally be kept in RTC memory.
 
 ```yaml

--- a/src/content/docs/components/preferences.mdx
+++ b/src/content/docs/components/preferences.mdx
@@ -35,7 +35,7 @@ were changed, the state was immediately committed to flash. The result of this w
 components would always restore to its last state on power loss, however, this has the cost of potentially quickly
 damaging the flash if these components are quickly changed.
 
-A safety feature has thus been implemented to mitigate issues resulting from the limited number of flash write cycles,
+A safety feature has thus been implemented to mitigate issues resulting from the limited number of flash write cycles:
 the state is first stored in memory before being flushed to flash after the `flash_write_interval` has passed. This
 results in fewer flash writes, preserving the flash health.
 

--- a/src/content/docs/components/preferences.mdx
+++ b/src/content/docs/components/preferences.mdx
@@ -29,18 +29,16 @@ preferences:
 
 ## Flash Wear
 
-As flash memory has a limited number of write cycles, this setting helps to reduce the number of flash writes
-due to quickly changing components. In the past, when components such as `light`, `switch`, `fan` and `globals`
-were changed, the state was immediately committed to flash. The result of this was that the last state of these
-components would always restore to its last state on power loss, however, this has the cost of potentially quickly
-damaging the flash if these components are quickly changed.
+As flash memory has a limited number of write cycles, `flash_write_interval` reduces the number of flash writes
+caused by rapidly changing components. In the past, when components such as `light`, `switch`, `fan` and `globals`
+were changed, the state was immediately committed to flash. This meant those components always restored their most
+recent state after power loss, but at the cost of potentially damaging the flash when they changed frequently.
 
-A safety feature has thus been implemented to mitigate issues resulting from the limited number of flash write cycles:
-the state is first stored in memory before being flushed to flash after the `flash_write_interval` has passed. This
-results in fewer flash writes, preserving the flash health.
+To mitigate this, the state is now first stored in memory and only flushed to flash once the `flash_write_interval`
+has passed. This results in fewer flash writes, preserving the flash health.
 
 This behavior can be modified by setting `flash_write_interval` to `0s` to commit the changes to flash as soon as
-possible, however, be aware that this may lead to increased flash wearing and a shortened device lifespan!
+possible. Be aware that this may lead to increased flash wearing and a shortened device lifespan!
 
 For [ESP8266](/components/esp8266/), `restore_from_flash` must also be set to `true` for states to be written to flash.
 

--- a/src/content/docs/components/switch/factory_reset.mdx
+++ b/src/content/docs/components/switch/factory_reset.mdx
@@ -1,5 +1,5 @@
 ---
-description: "Instructions for setting up switches that can remotely invalidate all ESPHome preferences stored in flash and reboot ESP."
+description: "Instructions for setting up switches that can remotely invalidate all ESPHome preferences and reboot your device."
 title: "Factory Reset Switch"
 ---
 

--- a/src/content/docs/components/switch/factory_reset.mdx
+++ b/src/content/docs/components/switch/factory_reset.mdx
@@ -6,7 +6,7 @@ title: "Factory Reset Switch"
 import { Image } from 'astro:assets';
 import APIRef from '@components/APIRef.astro';
 
-The `factory_reset` switch allows you to remotely invalidate (reset) all ESPHome [preferences](/components/esphome#preferences-flash_write_interval) stored in flash memory and reboot your node.
+The `factory_reset` switch allows you to remotely invalidate (reset) all ESPHome [preferences](/components/preferences/) stored in flash memory and reboot your node.
 After reboot all states, parameters and variables will be reinitialized with their default values. This is useful:
 
 - for devices preflashed with ESPHome to reset behavior back to factory state

--- a/src/content/docs/components/switch/factory_reset.mdx
+++ b/src/content/docs/components/switch/factory_reset.mdx
@@ -6,7 +6,7 @@ title: "Factory Reset Switch"
 import { Image } from 'astro:assets';
 import APIRef from '@components/APIRef.astro';
 
-The `factory_reset` switch allows you to remotely invalidate (reset) all ESPHome [preferences](/components/preferences/) stored in flash memory and reboot your node.
+The `factory_reset` switch allows you to remotely invalidate (reset) all ESPHome [preferences](/components/preferences/) and reboot your node.
 After reboot all states, parameters and variables will be reinitialized with their default values. This is useful:
 
 - for devices preflashed with ESPHome to reset behavior back to factory state


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

`preferences` is a top-level configuration section, but it was documented as a subsection of the ESPHome core component page, sitting between two `esphome:` sub-options. That placement implies it belongs under `esphome:`, which it does not. This moves the section to its own page at `/components/preferences/`.

The content is unchanged apart from the flash-wear prose getting its own `Flash Wear` heading, the intro no longer claiming preferences always live in flash (the host platform stores them in a file, and ESP32 can use RTC memory), and the page gaining a `See Also` block. Inbound links from `factory_reset` (component, button and switch) and `host` are retargeted to the new page, and an entry is added to the ESPHome Components table on the component index.

Moving the section also breaks existing deep links to `/components/esphome/#preferences-component` and `#preferences-flash_write_interval`. Netlify redirects cannot help here because a URL fragment is never sent to the server, so `Head.astro` gained a small inline script that maps the dead anchors to the new page. It is keyed by pathname and then by hash, so future section moves add a table entry rather than new machinery. `is:inline` is required: a bundled script is deferred and would redirect only after the wrong page had rendered.

Verified against a production build that both old anchors land on `/components/preferences/`, that other anchors on the ESPHome core page still resolve and scroll normally, and that pages without a hash (or with the same hash on a different path) are untouched.

**Related issue (if applicable):** fixes https://github.com/esphome/esphome.io/issues/7067

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [x] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.