### PR TITLE
[mipi_spi] Add LCDwiki ES3C35P to the supported boards table

### DIFF
--- a/src/content/docs/components/display/mipi_spi.mdx
+++ b/src/content/docs/components/display/mipi_spi.mdx
@@ -71,6 +71,7 @@ the pins used to interface to the display to be specified.
 |--------------------------------------|--------------|------------------------------------------------------------------------------------------------------------------------------------|
 | ADAFRUIT-FUNHOUSE                    | Adafruit     | [https://www.adafruit.com/product/4985](https://www.adafruit.com/product/4985)                                                     |
 | ADAFRUIT-S2-TFT-FEATHER              | Adafruit     | [https://www.adafruit.com/product/6312](https://www.adafruit.com/product/6312)                                                     |
+| ES3C35P                              | LCDwiki      | 3.5" 320×480 QSPI display with ST77922 controller. [https://www.lcdwiki.com/3.5inch_ESP32-S3_Display](https://www.lcdwiki.com/3.5inch_ESP32-S3_Display) |
 | ESP32-2424S012                       | Sunton       | 1.28" round CYD with GC9A01A controller.                                                                                           |
 | ESP32-2432S028                       | Sunton       | 2.8" CYD. Original micro-USB version with ILI9341 controller.                                                                      |
 | ESP32-2432S028-7789                  | Sunton       | Dual-USB version with ST7789V.                                                                                                     |


### PR DESCRIPTION
Adds a row for the LCDwiki ES3C35P — a 3.5" 320x480 QSPI panel with a Sitronix ST77922, on an ESP32-S3.

Documents the model added in esphome/esphome#19011.

🤖 Generated with [Claude Code](https://claude.com/claude-code)