### PR TITLE
[made_for_esphome] Update and restructure the requirements page

### DIFF
--- a/src/content/docs/guides/made_for_esphome.mdx
+++ b/src/content/docs/guides/made_for_esphome.mdx
@@ -1,62 +1,176 @@
 ---
-description: "Information about the Made for ESPHome program"
+description: "Requirements, application process and logo assets for the Made for ESPHome program"
 title: "Made for ESPHome"
 ---
 
-import { Image } from 'astro:assets';
 import Figure from '@components/Figure.astro';
 
-<span id="made_for_esphome"></span>
+<Figure
+  src="/images/made-for-esphome-black-on-white.svg"
+  width={682}
+  height={202}
+  layout="constrained"
+  alt="Made for ESPHome badge"
+  style="width: 60%; margin: 0 auto 2rem;"
+/>
 
-ESPHome has a wonderful and active community that loves creating and sharing projects.
-You can apply for your project to get the `Made for ESPHome` stamp of approval.
-This ensures that your project is powered by ESPHome and guarantees a minimum level of customizability to users.
+`Made for ESPHome` is our stamp of approval for hardware that ships with ESPHome. It tells a buyer three things
+before they hand over any money: the device runs ESPHome out of the box, its configuration is public, and they can
+take full control of it whenever they like without opening the case or soldering anything.
+
+Approved devices are listed on [devices.esphome.io/made-for-esphome](https://devices.esphome.io/made-for-esphome/) and
+may carry the [logo](#logos) on the product and its packaging.
+
+## What the Badge Promises
+
+- **It runs ESPHome.** Not a fork, not a lookalike, and not a cloud service with an ESPHome-compatible mode.
+- **The configuration is public.** Anyone can read the YAML that builds what ships on the device before buying it.
+- **The user can take control.** ESPHome Device Builder adopts the device, and the configuration builds and runs
+  unmodified, so nothing breaks the moment ownership changes hands.
+- **Updates keep working.** The manufacturer ships updates, and the user can push their own builds over the air.
 
 ## Requirements
 
-There are a number of requirements your project must meet. These may vary based on its design. They are:
+The canonical list is the
+[Made for ESPHome checklist](https://github.com/esphome/devices.esphome.io/blob/main/.github/made-for-esphome-checklist.md)
+in the devices repository, which is added to your pull request automatically. The sections below explain what each
+item means and why it is there.
 
-### For projects which utilize Wi-Fi
+### Hardware
 
-Wi-Fi is quite common but requires configuration of the SSID and passphrase.
-As such, for easy end-user provisioning, your configuration must include:
+- The device uses an ESP32 or a *supported* ESP32 variant such as the C3, C6, S2 or S3. ESP8266 is not eligible.
+- The device ships with ESPHome already installed.
 
-- `esp32_improv` as described in [Esp32 Improv](/components/esp32_improv/)
-- `improv_serial` as described in [Improv Serial](/components/improv_serial/), if a USB connection is available (recommended)
+### Naming
 
-Note that these are **not** required for projects that only provide a physical/wired Ethernet port for connectivity.
+Your product name must not contain **ESPHome**, except when it *ends with* **for ESPHome**. "ESPHome Widget" is not
+acceptable; "Acme Widget for ESPHome" is.
 
-### For all projects
+### Configuration
 
-- Your project is powered by ESPHome (runs ESPHome as its firmware)
-- Your project is powered by an ESP32 or *supported* ESP32 variant such as the S2, S3, C3, etc.
-- Your ESPHome configuration is open source, available for end users to modify/update
-- Users should be able to apply updates if your project sells ready-made devices
-- All components/platforms used must have an `id` specified so users can easily refer to,
-  [Extend](/components/packages#extend) and/or [Remove](/components/packages#remove) configuration variables should they choose to
-  "take control"
+- The configuration is open source and published somewhere the public can read it, such as a GitHub repository.
+- Every entity and component (sensor, switch, i2c bus, output, and so on) has an `id`. Users need those ids to
+  [Extend](/components/packages#extend) or [Remove](/components/packages#remove) parts of your configuration when
+  they take control.
+- The configuration you ship contains no `!secret` references and no passwords, including the `wifi_ssid` /
+  `wifi_password` pair. Users provision their own Wi-Fi credentials, so anything baked in only leaves dummy
+  credentials sitting in the device's storage. Those secrets belong in the configuration a user ends up with *after*
+  adopting the device, not in what you ship.
+- Network configuration assumes defaults: no static IP addresses (`manual_ip`) and no hard-coded DNS servers.
+- The configuration is valid, builds and runs *without any user changes* after adoption. Remote packages are
+  permitted as long as this still holds.
 
-- Your project supports adoption via the `dashboard_import` feature of ESPHome (see
-  [Sharing](/guides/creators/)). In particular:
+### Wi-Fi Provisioning
 
-  - There are **no** references to secrets or passwords
-  - Network configuration must assume defaults (no static IPs or DNS configured)
-  - The configuration **must** be valid, compile and run successfully *without any user changes* after adopting it.
-  - Use of remote packages in the YAML is permitted only if the above criteria are met.
+Devices always arrive with no Wi-Fi credentials, so the user needs a way to supply them without a computer or a
+configuration file:
 
-- Your product name cannot contain "**ESPHome**" except in the case of *ending with* "**for ESPHome**"
+- [`esp32_improv`](/components/esp32_improv/) provisions credentials over Bluetooth LE.
+- [`improv_serial`](/components/improv_serial/) does the same over USB, and is required if the device exposes a USB
+  port.
 
-## When your project meets the requirements
+Improv is required whenever `wifi:` appears in the configuration. That includes devices with wired
+[Ethernet](/components/ethernet/), since Ethernet and Wi-Fi can be configured together with automatic fallback
+between them. Only a configuration with no `wifi:` block at all is exempt.
 
-- Create a new pull request in our [devices.esphome.io](https://github.com/esphome/devices.esphome.io/pulls) repository to
-  add your device on the [devices website](https://devices.esphome.io). We will review and merge this PR upon
-  confirming that your project meets all of the requirements listed above.
+### Taking Control
 
-- Apply for permission to carry the logo by emailing [esphome@openhomefoundation.org](mailto:esphome@openhomefoundation.org) -- **include a link to the PR** you've
-  created (as above) so we can associate your application with your PR and device(s).
+"Taking control" is a user adopting the device into their own ESPHome Device Builder and building ESPHome for it
+themselves. That requires:
 
-- We will review your application and reply to your email. We may request changes to your project if we find it does
-  not quite meet one or more of the requirements above. If we find everything is in order, we will approve your project.
+- [`dashboard_import`](/guides/creators/) with a `package_import_url` pointing at your public configuration.
+- [Project information](/components/esphome#esphome-creators_project) (`esphome` → `project` → `name` and `version`),
+  which is what the Device Builder matches on when it offers to adopt the device.
+- The [`api`](/components/api/) component, which the adoption flow relies on.
+- The [`esphome` OTA platform](/components/ota/esphome/), so the user can install their own builds over the air.
+- Serial flashing left enabled, as the escape hatch when everything else fails.
+
+### Updates
+
+Ship updates to devices you have sold using the
+[`http_request` update platform](/components/update/http_request/), which needs
+[`http_request`](/components/http_request/) and the
+[`http_request` OTA platform](/components/ota/http_request/) alongside it.
+
+The `source` URL must point at a publicly reachable
+[JSON manifest](/components/update/http_request#update_http_request-manifest_format) whose `builds` include a
+`chipFamily` matching your hardware and an `ota.path` that resolves to a downloadable binary. Our review tooling
+fetches the manifest and the binary, so a dead link or a chip family mismatch will fail the review.
+
+## Example Configuration
+
+The pieces every Made for ESPHome configuration needs, with a single entity to show the `id` requirement:
+
+```yaml
+esphome:
+  name: "acme-widget"
+  friendly_name: "Acme Widget"
+  # One build works for every unit
+  name_add_mac_suffix: true
+  project:
+    name: acme.widget
+    version: "1.0"
+
+esp32:
+  variant: esp32c3
+
+# Required by the adoption flow
+api:
+
+ota:
+  - platform: esphome
+  - platform: http_request
+
+http_request:
+
+update:
+  - platform: http_request
+    id: esphome_update
+    name: "ESPHome update"
+    source: https://acme.example.com/widget/manifest.json
+
+wifi:
+  ap:
+
+esp32_improv:
+  authorizer: none
+
+improv_serial:
+
+dashboard_import:
+  package_import_url: github://acme/acme-widget/widget.yaml@main
+
+switch:
+  - platform: gpio
+    id: relay
+    name: "Relay"
+    pin: GPIOXX
+```
+
+See [Sharing ESPHome devices](/guides/creators/) for a fuller walkthrough of these options.
+
+## Applying
+
+1. **Publish your configuration** in a public repository.
+
+1. **Add your device** to [devices.esphome.io](https://devices.esphome.io) by opening a pull request in the
+   [devices.esphome.io repository](https://github.com/esphome/devices.esphome.io). Set `made-for-esphome: true` in the
+   page's front matter, and reference your configuration with a live `` ```yaml url=… `` fence pointing at the YAML
+   file in your repository, so the page always shows what actually ships. The
+   [Adding Devices guide](https://devices.esphome.io/devices/adding-devices/) covers the page format.
+
+1. **Email [esphome@openhomefoundation.org](mailto:esphome@openhomefoundation.org)** to apply for permission to carry
+   the logo, and **include a link to the pull request** so we can tie your application to it.
+
+Opening the pull request labels it `made-for-esphome` and `made-for-esphome-pending`, appends the checklist to the
+description for you to complete, and runs an automated review that downloads your configuration, builds it and posts
+the results as a comment. Work through anything it reports before asking for a human review.
+
+If something does not meet the requirements we will ask for changes on the pull request. Once your submission is
+accepted we apply the `made-for-esphome-approved` label and merge the pull request. Either of those is your
+confirmation that the device is in the program, so there is no need to wait for a reply to your email. Your device
+then appears in the [Made for ESPHome listing](https://devices.esphome.io/made-for-esphome/), and you may use the
+[logos](#logos).
 
 ## Logos
 
@@ -67,10 +181,11 @@ After your project is approved, you may use these logos on your product and/or i
   width={682}
   height={202}
   layout="constrained"
-  alt="Made with ESPHome badge - black on white"
+  alt="Made for ESPHome badge - black on white"
+  style="width: 70%"
 >
   <p slot="caption">
-    Made with ESPHome black on white ([svg](/images/made-for-esphome-black-on-white.svg), [png](/images/made-for-esphome-black-on-white.png))
+    Black on white ([svg](/images/made-for-esphome-black-on-white.svg), [png](/images/made-for-esphome-black-on-white.png))
   </p>
 </Figure>
 
@@ -79,10 +194,11 @@ After your project is approved, you may use these logos on your product and/or i
   width={682}
   height={202}
   layout="constrained"
-  alt="Made with ESPHome badge - white on black"
+  alt="Made for ESPHome badge - white on black"
+  style="width: 70%"
 >
   <p slot="caption">
-    Made with ESPHome white on black ([svg](/images/made-for-esphome-white-on-black.svg), [png](/images/made-for-esphome-white-on-black.png))
+    White on black ([svg](/images/made-for-esphome-white-on-black.svg), [png](/images/made-for-esphome-white-on-black.png))
   </p>
 </Figure>
 
@@ -92,10 +208,11 @@ After your project is approved, you may use these logos on your product and/or i
     width={682}
     height={202}
     layout="constrained"
-    alt="Made with ESPHome badge - black on transparent"
+    alt="Made for ESPHome badge - black on transparent"
+    style="width: 70%"
   >
     <p slot="caption">
-      Made with ESPHome black on transparent ([svg](/images/made-for-esphome-black-on-transparent.svg), [png](/images/made-for-esphome-black-on-transparent.png))
+      Black on transparent ([svg](/images/made-for-esphome-black-on-transparent.svg), [png](/images/made-for-esphome-black-on-transparent.png))
     </p>
   </Figure>
 </div>
@@ -106,10 +223,18 @@ After your project is approved, you may use these logos on your product and/or i
     width={682}
     height={202}
     layout="constrained"
-    alt="Made with ESPHome badge - white on transparent"
+    alt="Made for ESPHome badge - white on transparent"
+    style="width: 70%"
   >
     <p slot="caption">
-      Made with ESPHome white on transparent ([svg](/images/made-for-esphome-white-on-transparent.svg), [png](/images/made-for-esphome-white-on-transparent.png))
+      White on transparent ([svg](/images/made-for-esphome-white-on-transparent.svg), [png](/images/made-for-esphome-white-on-transparent.png))
     </p>
   </Figure>
 </div>
+
+## See Also
+
+- [Sharing ESPHome devices](/guides/creators/) - the configuration options behind adoption and provisioning
+- [Made for ESPHome devices](https://devices.esphome.io/made-for-esphome/) - devices already approved
+- [Made for ESPHome checklist](https://github.com/esphome/devices.esphome.io/blob/main/.github/made-for-esphome-checklist.md) - the exact items we review against
+- [Adding Devices](https://devices.esphome.io/devices/adding-devices/) - how to write the device page


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

The Made for ESPHome requirements page had drifted from what the program actually enforces. This updates it against the checklist and automated review in the [devices repository](https://github.com/esphome/devices.esphome.io) (`.github/made-for-esphome-checklist.md`, `scripts/review-made-for-esphome.ts`, `scripts/validate-yaml-configs.ts` and the `made-for-esphome*` workflows).

Requirements that were missing or wrong:

- `ota:` must include `- platform: esphome`.
- Manufacturer updates ship via the `update:` `http_request` platform, alongside `http_request:` and the `http_request` OTA platform, with a publicly reachable manifest whose `chipFamily` matches the hardware and whose `ota.path` resolves to a real binary.
- Serial flashing must not be disabled.
- `dashboard_import` needs `package_import_url`, and adoption needs `esphome` -> `project` info plus `api:`.
- No `!secret` references and no passwords in the shipped configuration, the Wi-Fi pair included, because anything baked in leaves dummy credentials in the device's storage. No `manual_ip` or hard-coded DNS.
- The device page needs `made-for-esphome: true` in front matter and a live `url=` yaml fence pointing at the config in the manufacturer's repository, which CI now enforces.
- Improv is required whenever `wifi:` appears in the configuration, including devices that also have Ethernet, rather than only for devices without a wired port.
- ESP8266 called out as not eligible.

The page is also restructured: badge at the top, a short summary of what the badge promises, requirements grouped by subject instead of one flat list, an example configuration containing every required component, and application steps that explain what the automation does to the pull request and how approval is signalled (`made-for-esphome-approved` label and/or merge).

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.