### PR TITLE
[ota] Document compressed uploads for the esphome platform

### DIFF
--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -216,17 +216,18 @@ the [web server OTA platform](/components/ota/web_server/); after that, installs
 
 ## Compression
 
-Uploads are compressed automatically; there is nothing to configure, and an older device or an older `esphome`
-command line simply falls back to an uncompressed upload.
+Uploads are compressed automatically when both the device firmware and the `esphome` command line are ESPHome
+2026.10.0 or newer; there is nothing to configure, and an older device or an older command line simply falls back
+to an uncompressed upload.
 
 - **ESP8266 and RP2040**: the upload is a gzip file. The ESP8266 bootloader and the RP2040 OTA stub inflate it into
   the application area at reboot, so the reboot after an update takes a little longer (about 1.5 s more on an RP2040
   for a 500 KB image) while the upload itself is a third shorter. On the RP2040 the file is staged in the LittleFS
   region, so a firmware that did not fit there uncompressed may fit now.
-- **ESP32, Beken, Realtek and host**: their bootloaders cannot inflate, so the device inflates the stream while it
-  receives it. This needs about 5 KB of free heap for the duration of the update; when that is not available the
-  device asks for an uncompressed upload instead. The transfer is about a third smaller, which helps most on a slow
-  link.
+- **ESP32, [LibreTiny](/components/libretiny/) and [host](/components/host/)**: these cannot inflate at boot, so the
+  device inflates the stream while it receives it. On a microcontroller this needs about 5 KB of free heap for the
+  duration of the update; when that is not available the device asks for an uncompressed upload instead. The
+  transfer is about a third smaller, which helps most on a slow link.
 
 ## Updating the partition table on ESP32
 

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -216,9 +216,10 @@ the [web server OTA platform](/components/ota/web_server/); after that, installs
 
 ## Compression
 
-Uploads are compressed automatically when both the device firmware and the `esphome` command line are ESPHome
-2026.10.0 or newer; there is nothing to configure, and an older device or an older command line simply falls back
-to an uncompressed upload.
+Uploads are compressed automatically; there is nothing to configure. ESP8266 uploads have always been compressed.
+On ESP32, RP2040, LibreTiny and host they are compressed when both the device firmware and the `esphome` command
+line are ESPHome 2026.10.0 or newer; an older device or an older command line simply falls back to an uncompressed
+upload.
 
 - **ESP8266 and RP2040**: the upload is a gzip file. The ESP8266 bootloader and the RP2040 OTA stub inflate it into
   the application area at reboot, so the reboot after an update takes a little longer (about 1.5 s more on an RP2040

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -214,6 +214,20 @@ encryption at all (an MQTT device) or offers with the provisioned API key rather
 present, and with the block in the config the CLI does not send plaintext. Put the block in by serial flash or through
 the [web server OTA platform](/components/ota/web_server/); after that, installs are encrypted with the OTA key.
 
+## Compression
+
+Uploads are compressed automatically; there is nothing to configure, and an older device or an older `esphome`
+command line simply falls back to an uncompressed upload.
+
+- **ESP8266 and RP2040**: the upload is a gzip file. The ESP8266 bootloader and the RP2040 OTA stub inflate it into
+  the application area at reboot, so the reboot after an update takes a little longer (about 1.5 s more on an RP2040
+  for a 500 KB image) while the upload itself is a third shorter. On the RP2040 the file is staged in the LittleFS
+  region, so a firmware that did not fit there uncompressed may fit now.
+- **ESP32, Beken, Realtek and host**: their bootloaders cannot inflate, so the device inflates the stream while it
+  receives it. This needs about 5 KB of free heap for the duration of the update; when that is not available the
+  device asks for an uncompressed upload instead. The transfer is about a third smaller, which helps most on a slow
+  link.
+
 ## Updating the partition table on ESP32
 
 On the ESP32 it is possible to modify the partition table with an OTA update. This feature can be used to update devices that can't be flashed via serial and have an old partition table with a small NVS partition. It can also be used to [convert devices running Tasmota to ESPHome](/guides/migrate_sonoff_tasmota). Before you can update the partition table you need to add the option `allow_partition_access: true` to the config and install it to your device.

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -221,7 +221,7 @@ On ESP32, RP2040, LibreTiny and host they are compressed when both the device fi
 line are ESPHome 2026.10.0 or newer; an older device or an older command line simply falls back to an uncompressed
 upload.
 
-- **ESP8266 and RP2040**: the upload is a gzip file. The ESP8266 bootloader and the RP2040 OTA stub inflate it into
+- **ESP8266 and RP2040**: a compressed upload is a gzip file. The ESP8266 bootloader and the RP2040 OTA stub inflate it into
   the application area at reboot, so the reboot after an update takes a little longer (about 1.5 s more on an RP2040
   for a 500 KB image) while the upload itself is a third shorter. On the RP2040 the file is staged in the LittleFS
   region, so a firmware that did not fit there uncompressed may fit now.

--- a/src/content/docs/components/ota/esphome.mdx
+++ b/src/content/docs/components/ota/esphome.mdx
@@ -221,10 +221,10 @@ On ESP32, RP2040, LibreTiny and host they are compressed when both the device fi
 line are ESPHome 2026.10.0 or newer; an older device or an older command line simply falls back to an uncompressed
 upload.
 
-- **ESP8266 and RP2040**: a compressed upload is a gzip file. The ESP8266 bootloader and the RP2040 OTA stub inflate it into
-  the application area at reboot, so the reboot after an update takes a little longer (about 1.5 s more on an RP2040
-  for a 500 KB image) while the upload itself is a third shorter. On the RP2040 the file is staged in the LittleFS
-  region, so a firmware that did not fit there uncompressed may fit now.
+- **ESP8266 and RP2040**: a compressed upload is a gzip file. The ESP8266 bootloader and the RP2040 OTA stub
+  inflate it into the application area at reboot, so the reboot after an update takes a little longer (about 1.5 s
+  more on an RP2040 for a 500 KB image) while the upload itself is a third shorter. On the RP2040 the file is staged
+  in the LittleFS region, so a firmware that did not fit there uncompressed may fit now.
 - **ESP32, [LibreTiny](/components/libretiny/) and [host](/components/host/)**: these cannot inflate at boot, so the
   device inflates the stream while it receives it. On a microcontroller this needs about 5 KB of free heap for the
   duration of the update; when that is not available the device asks for an uncompressed upload instead. The


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Documents that OTA uploads through the esphome platform are now compressed on every platform: gzip inflated at reboot on the ESP8266 and RP2040, and a deflate stream inflated while it arrives on ESP32, Beken, Realtek and host, with the heap it needs and the fallback to an uncompressed upload.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#19037

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
