### PR TITLE
[sendspin] Document the media source codecs option

### DIFF
--- a/src/content/docs/components/media_source/sendspin.mdx
+++ b/src/content/docs/components/media_source/sendspin.mdx
@@ -38,7 +38,7 @@ media_player:
 - **codecs** (*Optional*, list of strings): The audio codecs advertised to the Sendspin server, in
   order of preference. Each entry is one of `flac`, `opus`, or `pcm`, and a codec may only be listed
   once. Defaults to `[flac, opus, pcm]`, or `[flac, pcm]` when `sample_rate` is not `48000`, since
-  Opus only supports 48 kHz audio.
+  `opus` only supports 48 kHz audio.
 - **buffer_size** (*Optional*, positive integer): The size of the audio buffer in bytes. Must be at
   least `25000`. Defaults to `1000000`.
 - **fixed_delay** (*Optional*, [Time](/guides/configuration-types#time)): A constant, known playback

--- a/src/content/docs/components/media_source/sendspin.mdx
+++ b/src/content/docs/components/media_source/sendspin.mdx
@@ -35,6 +35,10 @@ media_player:
 
 - **sample_rate** (*Optional*, positive integer): The sample rate, in Hz, advertised to the Sendspin
   server. Must be between `16000` and `96000`. Defaults to `48000`.
+- **codecs** (*Optional*, list of strings): The audio codecs advertised to the Sendspin server, in
+  order of preference. Each entry is one of `flac`, `opus`, or `pcm`, and a codec may only be listed
+  once. Defaults to `[flac, opus, pcm]`, or `[flac, pcm]` when `sample_rate` is not `48000`, since
+  Opus only supports 48 kHz audio.
 - **buffer_size** (*Optional*, positive integer): The size of the audio buffer in bytes. Must be at
   least `25000`. Defaults to `1000000`.
 - **fixed_delay** (*Optional*, [Time](/guides/configuration-types#time)): A constant, known playback


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Documents the new codecs option on the sendspin media source, which sets which audio codecs are advertised to the Sendspin server and in what order of preference.

**Related issue (if applicable):** not applicable

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#19047

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
