### PR TITLE
[bmp581] Note that pressure is published in pascals

### DIFF
--- a/src/content/docs/components/sensor/bmp581.mdx
+++ b/src/content/docs/components/sensor/bmp581.mdx
@@ -70,6 +70,13 @@ sensor:
 - **update_interval** (*Optional*, [Time](/guides/configuration-types#time)): The interval to check the
   sensor. Defaults to `60s`.
 
+> [!NOTE]
+> The pressure sensor publishes values in **pascals (Pa)**. Most other ESPHome pressure sensors publish
+> hectopascals (hPa), so a `multiply: 0.01` [filter](/components/sensor#sensor-filters) is required when feeding
+> this sensor to something that expects hPa. One example is the [SCD4x](/components/sensor/scd4x) component's
+> `ambient_pressure_compensation_source`, which expects hPa and will report incorrect CO₂ values if given pascals.
+> Set `unit_of_measurement: hPa` on the sensor as well, so the converted value is recorded under the correct unit.
+
 ### I²C
 
 - **address** (*Optional*, int): Manually specify the I²C address of the sensor.


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

The `bmp581_i2c` / `bmp581_spi` pressure sensor is declared `UNIT_PASCAL`, while most other ESPHome pressure
sensors (`bme280`, `bmp280`, `bmp3xx`) publish hectopascals. The page does not currently state the unit.

This matters when the sensor feeds another component. The SCD4x `ambient_pressure_compensation_source` expects
hPa — `set_ambient_pressure_compensation(float pressure_in_hpa)` — and casts to `uint16_t`, so passing raw pascals
wraps: ~99752 Pa becomes 34216, and the sensor reports 0 ppm. The failure is silent, with no warning logged.

The SCD4x page already says the source must report hPa, and its example uses a `bme280`, which is correct
unconverted — so nothing currently suggests a conversion is ever needed.

Adds a note under the `pressure` configuration variable covering the unit and the required `multiply: 0.01` filter.

**Related issue (if applicable):** n/a

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** n/a

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.