### PR TITLE
[adc] Remove Firebeetle ESP32-E battery voltage section

### DIFF
--- a/src/content/docs/components/sensor/adc.mdx
+++ b/src/content/docs/components/sensor/adc.mdx
@@ -194,25 +194,6 @@ sensor:
 
 You can only use as many ADC sensors as your device can support. The ESP8266 only has one ADC and can only handle one sensor at a time. For example, on the ESP8266, you can measure the value of an analog pin (A0 on ESP8266) or VCC (see above) but NOT both simultaneously. Using both at the same time will result in incorrect sensor values.
 
-## Measuring battery voltage on the Firebeetle ESP32-E
-
-This board has a internal voltage divider and the battery voltage can easily be measured like this using 12dB attenuation
-on GPIO34.
-
-```yaml
-- platform: adc
-  name: "Battery voltage"
-  pin: GPIO34
-  accuracy_decimals: 2
-  update_interval: 60s
-  attenuation: 12dB
-  samples: 10
-  filters:
-    - multiply: 2.0  # The voltage divider requires us to multiply by 2
-```
-
-This works on SKU:DFR0654. For more information see: [manufacturer's website](https://wiki.dfrobot.com/FireBeetle_Board_ESP32_E_SKU_DFR0654).
-
 ## See Also
 
 - [Sensor Filters](/components/sensor#sensor-filters)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Removes the "Measuring battery voltage on the Firebeetle ESP32-E" section from the ADC component page. Board-specific wiring and voltage divider details belong on devices.esphome.io, not on the generic ADC component page. There is currently no Firebeetle ESP32-E page on devices.esphome.io; the removed content can be added there as a device page if wanted.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.