### PR TITLE
[spd2010] Document Waveshare 1.46 display and touchscreen support

### DIFF
--- a/src/content/docs/components/display/mipi_spi.mdx
+++ b/src/content/docs/components/display/mipi_spi.mdx
@@ -258,15 +258,22 @@ A touchscreen, if present, must be configured separately. See the [Touchscreen](
 
 ## Waveshare ESP32-S3-Touch-LCD-1.46
 
-This board uses a 412×412 SPD2010 panel over quad SPI. The model defaults to RGB565, SPI mode 3, 40MHz,
+This board uses a 412×412 SPD2010 panel over quad SPI. The model defaults to RGB565, SPI mode 0, 40MHz,
 and four-pixel draw rounding. Keep `draw_rounding: 4` when using LVGL. Hardware mirroring is supported;
 axis swapping requires software rotation.
 
 The LCD reset signal is on pin 1 of the board's [PCA9554 GPIO expander](/components/pca9554/).
-Configure that expander with ID `board_expander` and address `0x20` on the board's I²C bus
-(SDA GPIO11, SCL GPIO10). Configure the display as follows:
+The display model selects that pin automatically when a single PCA9554 is configured. Declare the
+expander on the board's I²C bus and configure the display as follows:
 
 ```yaml
+i2c:
+  sda: GPIO11
+  scl: GPIO10
+
+pca9554:
+  - id: board_expander
+
 spi:
   type: quad
   clk_pin: GPIO40
@@ -276,11 +283,9 @@ display:
   - platform: mipi_spi
     model: WAVESHARE-ESP32-S3-TOUCH-LCD-1.46
     id: main_display
-    reset_pin:
-      pca9554: board_expander
-      number: 1
 ```
 
-The model uses GPIO21 for chip select. Provide the hardware reset pin as shown; this model skips software reset.
+The PCA9554 defaults to address `0x20`. The display model uses GPIO21 for chip select and PCA9554 pin 1
+for hardware reset; the driver manages the required reset and sleep-out sequencing.
 The backlight is controlled separately on GPIO5. For touch input, use the
 [SPD2010 touchscreen](/components/touchscreen/spd2010/).

--- a/src/content/docs/components/display/mipi_spi.mdx
+++ b/src/content/docs/components/display/mipi_spi.mdx
@@ -102,6 +102,7 @@ the pins used to interface to the display to be specified.
 | WAVESHARE-ESP32-S3-TOUCH-AMOLED-1.64 | Waveshare    | [https://www.waveshare.com/ESP32-S3-Touch-AMOLED-1.64.htm](https://www.waveshare.com/ESP32-S3-Touch-AMOLED-1.64.htm)               |
 | WAVESHARE-ESP32-S3-TOUCH-AMOLED-1.75 | Waveshare    | [https://www.waveshare.com/esp32-s3-touch-amoled-1.75.htm](https://www.waveshare.com/esp32-s3-touch-amoled-1.75.htm)               |
 | WAVESHARE-ESP32-S3-TOUCH-AMOLED-2.16 | Waveshare    | [https://www.waveshare.com/esp32-s3-touch-amoled-2.16.htm](https://www.waveshare.com/esp32-s3-touch-amoled-2.16.htm)               |
+| WAVESHARE-ESP32-S3-TOUCH-LCD-1.46 | Waveshare | [ESP32-S3-Touch-LCD-1.46](https://www.waveshare.com/wiki/ESP32-S3-Touch-LCD-1.46B) |
 | WAVESHARE-ESP32-S3-TOUCH-LCD-3.49    | Waveshare    | [https://www.waveshare.com/esp32-s3-touch-lcd-3.49.htm](https://www.waveshare.com/esp32-s3-touch-lcd-3.49.htm)                     |
 | WAVESHARE-ESP32-S3-TOUCH-LCD-3.5B    | Waveshare    | [https://www.waveshare.com/esp32-s3-touch-lcd-3.5b.htm](https://www.waveshare.com/esp32-s3-touch-lcd-3.5b.htm)                     |
 | WT32-SC01-PLUS                       | Wireless-Tag | [https://www.wireless-tag.com/portfolio/wt32-sc01-plus/](https://www.wireless-tag.com/portfolio/wt32-sc01-plus/)                   |
@@ -254,3 +255,32 @@ A touchscreen, if present, must be configured separately. See the [Touchscreen](
 - [Display Component](/components/display/)
 - [LVGL Graphics](/components/lvgl/)
 - <APIRef text="mipi_spi.h" path="mipi_spi/mipi_spi.h" />
+
+## Waveshare ESP32-S3-Touch-LCD-1.46
+
+This board uses a 412×412 SPD2010 panel over quad SPI. The model defaults to RGB565, SPI mode 3, 40MHz,
+and four-pixel draw rounding. Keep `draw_rounding: 4` when using LVGL. Hardware mirroring is supported;
+axis swapping requires software rotation.
+
+The LCD reset signal is on pin 1 of the board's [PCA9554 GPIO expander](/components/pca9554/).
+Configure that expander with ID `board_expander` and address `0x20` on the board's I²C bus
+(SDA GPIO11, SCL GPIO10). Configure the display as follows:
+
+```yaml
+spi:
+  type: quad
+  clk_pin: GPIO40
+  data_pins: [GPIO46, GPIO45, GPIO42, GPIO41]
+
+display:
+  - platform: mipi_spi
+    model: WAVESHARE-ESP32-S3-TOUCH-LCD-1.46
+    id: main_display
+    reset_pin:
+      pca9554: board_expander
+      number: 1
+```
+
+The model uses GPIO21 for chip select. Provide the hardware reset pin as shown; this model skips software reset.
+The backlight is controlled separately on GPIO5. For touch input, use the
+[SPD2010 touchscreen](/components/touchscreen/spd2010/).

--- a/src/content/docs/components/index.mdx
+++ b/src/content/docs/components/index.mdx
@@ -1130,6 +1130,7 @@ Used for creating infrared (IR) remote control transmitters and/or receivers.
   ["GSL3670", "/components/touchscreen/gsl3670/", "touchscreen.svg", "dark-invert"],
   ["GT911", "/components/touchscreen/gt911/", "esp32_s3_box_3.png"],
   ["Lilygo T5 4.7", "/components/touchscreen/lilygo_t5_47/", "lilygo_t5_47_touch.jpg"],
+  ["SPD2010", "/components/touchscreen/spd2010/", "touch.svg", "dark-invert"],
   ["ST7123", "/components/touchscreen/st7123/", "touch.svg", "dark-invert"],
   ["TT21100", "/components/touchscreen/tt21100/", "esp32-s3-korvo-2-lcd.png"],
   ["XPT2046", "/components/touchscreen/xpt2046/", "xpt2046.jpg"],

--- a/src/content/docs/components/touchscreen/index.mdx
+++ b/src/content/docs/components/touchscreen/index.mdx
@@ -291,6 +291,7 @@ binary_sensor:
 - [TT21100 Touch Screen Controller](/components/touchscreen/tt21100/)
 - [GSL3670 Touch Screen Controller](/components/touchscreen/gsl3670/)
 - [gt911 Touch Screen Controller](/components/touchscreen/gt911/)
+- [SPD2010 Touchscreen Controller](/components/touchscreen/spd2010/)
 - [ST7123 Touch Screen Controller](/components/touchscreen/st7123/)
 - <APIRef text="touchscreen.h" path="touchscreen/touchscreen.h" />
 - <APIRef text="touchscreen_binary_sensor.h" path="touchscreen/binary_sensor/touchscreen_binary_sensor.h" />

--- a/src/content/docs/components/touchscreen/spd2010.mdx
+++ b/src/content/docs/components/touchscreen/spd2010.mdx
@@ -1,0 +1,52 @@
+---
+title: "SPD2010 Touchscreen"
+description: "Configure the SPD2010 I²C capacitive touchscreen controller in ESPHome."
+---
+
+import APIRef from '@components/APIRef.astro';
+
+The `spd2010` touchscreen platform supports the capacitive touch controller used on the Waveshare
+ESP32-S3-Touch-LCD-1.46. It requires an [I²C bus](/components/i2c/) and a
+[display](/components/display/). The default calibration covers the board's 412×412 display.
+
+```yaml
+touchscreen:
+  - platform: spd2010
+    display: main_display
+```
+
+## Configuration Variables
+
+- **interrupt_pin** (*Optional*, [Pin Schema](/guides/configuration-types/#pin-schema)):
+  The controller's interrupt pin. Must be an internal GPIO. When omitted, the controller is polled.
+- **reset_pin** (*Optional*, [Pin Schema](/guides/configuration-types/#pin-schema)):
+  The controller's active-low reset pin. GPIO expanders are supported. Omit this if the board handles touch reset.
+- **address** (*Optional*, int): I²C address. Defaults to `0x53`.
+- **update_interval** (*Optional*, Time): Polling interval when no interrupt pin is configured. Defaults to `50ms`.
+- **calibration** (*Optional*): Defaults to `x_min: 0`, `x_max: 411`, `y_min: 0`, and `y_max: 411`.
+  Override these values for other panel dimensions.
+- All other options from [Touchscreen](/components/touchscreen/#config-touchscreen).
+
+## Waveshare ESP32-S3-Touch-LCD-1.46
+
+Use the board's I²C bus on SDA GPIO11 and SCL GPIO10. The interrupt signal is GPIO4.
+With the [MIPI SPI display](/components/display/mipi_spi/)
+configured as `main_display`, use:
+
+```yaml
+touchscreen:
+  - platform: spd2010
+    display: main_display
+    interrupt_pin:
+      number: GPIO4
+      mode: INPUT_PULLUP
+```
+
+The driver reports each contact using its controller ID and releases contacts when their strength becomes zero.
+Use ESPHome's touchscreen automations or LVGL for gestures.
+
+## See Also
+
+- [Touchscreen](/components/touchscreen/)
+- [MIPI SPI Display](/components/display/mipi_spi/)
+- <APIRef text="spd2010_touchscreen.h" path="spd2010/spd2010_touchscreen.h" />


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Documents the Waveshare ESP32-S3-Touch-LCD-1.46 model in `mipi_spi` and the new `spd2010` touchscreen platform. Includes board pin mappings, PCA9554 display reset, touchscreen defaults, and component index links.

Validation: documentation lint passes. Both drivers compile together in an ESP32-S3/PCA9554/LVGL example. The full documentation build passes (909 pages). Hardware validation of the new drivers is still pending.

**Related issue (if applicable):** No separate issue.

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- https://github.com/esphome/esphome/pull/19056
- https://github.com/esphome/esphome/pull/19057

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [x] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
