### PR TITLE
[changelog] Refresh the 2026.9.0 release notes for the beta changes

### DIFF
--- a/src/content/docs/blog/2026/09/16/esphome-2026-9.mdx
+++ b/src/content/docs/blog/2026/09/16/esphome-2026-9.mdx
@@ -67,10 +67,11 @@ encryption costs in flash by close to half on every platform, brings Improv prov
 boards, teaches WiFi provisioning to shut down the AP and captive portal when the window closes, and rewrites
 IR transmission on Beken and Realtek chips to run from a hardware timer interrupt instead of a busy-wait. The
 multi-release modbus overhaul continues with a heap-free write path, a consolidated range-join option, and
-continuous polling. Seven new components (ds1603l, d01, sfa40, mk2pvrouter, snapshot, noise, template climate)
-and roughly a dozen feature additions to existing components round out the release. The bundled Device Builder
+continuous polling. Six new components (ds1603l, d01, sfa40, mk2pvrouter, snapshot, noise) and
+around twenty feature additions to existing components round out the release. The bundled Device Builder
 masks credentials in the YAML diff view, boots ESP32-C6 boards after a browser flash, and lets paired build
-servers recover from an address change on their own. {/* RELEASE_OVERVIEW_END */}
+servers recover from an address change on their own.
+{/* RELEASE_OVERVIEW_END */}
 
 ## Upgrade Checklist
 
@@ -137,7 +138,7 @@ after an sdkconfig change (~2.2s on desktop, several times more on SBCs). Platfo
 registry library is a private package before it looks at its own cache, and that check sleeps half a second
 under the account client's rate limit before failing at once on any machine without a PlatformIO login;
 ESPHome never uses private packages, so it now answers the check itself, which takes a no-op rebuild of a
-six-library config from 2.9 s to 0.4 s ([#18823](https://github.com/esphome/esphome/pull/18823)). When two
+six-library config from 2.9s to 0.4s ([#18823](https://github.com/esphome/esphome/pull/18823)). When two
 builds want the same archive at once the
 waiting one shows the other's download progress instead of sitting at 0%
 ([#18983](https://github.com/esphome/esphome/pull/18983)).
@@ -271,8 +272,8 @@ in this release, static RAM being the image's own data, not per-connection heap:
 | ESP32 AtomU (IDF) | 65.9 KB | 37.7 KB | 56 B | 32 B |
 | Pico W (RP2040) | 65.5 KB | 34.7 KB | 48 B | 24 B |
 
-A Noise handshake drops from about 580 ms to about 300 ms on the ESP8266 and from 63 ms to 46 ms on the
-ESP32; an encrypted API connect to a d1 mini goes from a 377 ms median to 139 ms. Nothing to configure.
+A Noise handshake drops from about 580ms to about 300ms on the ESP8266 and from 63ms to 46ms on the
+ESP32; an encrypted API connect to a d1 mini goes from a 377ms median to 139ms. Nothing to configure.
 
 ## Improv Serial Beyond WiFi
 
@@ -337,7 +338,7 @@ requested state instead of the inverted one. Users of `custom_command`, `registe
 
 ## New Components And Hardware Support
 
-Seven new components join the tree:
+Six new components join the tree:
 
 - **[ds1603l](/components/sensor/ds1603l/)** by [@JakeLC15](https://github.com/JakeLC15) - a UART ultrasonic
   liquid-level sensor with configurable min/max level and volume mapping
@@ -357,10 +358,6 @@ Seven new components join the tree:
 - **noise** by [@bdraco](https://github.com/bdraco) - a shared internal Noise
   primitives component that api and the new encrypted OTA both consume; no user configuration
   ([#18490](https://github.com/esphome/esphome/pull/18490))
-- **[template climate](/components/climate/template/)** by [@rsre](https://github.com/rsre) - a climate
-  platform whose mode, targets, fan, swing and presets are plain state driven from lambdas and actions, so a
-  UART or I²C thermostat can be exposed without the template-plus-lambda workarounds
-  ([#14455](https://github.com/esphome/esphome/pull/14455))
 
 ## New Features In Existing Components
 
@@ -446,9 +443,10 @@ because holding the shared radio for over a second at a time starves WiFi and ca
 separately from the upload window and reports total OTA time
 ([#18582](https://github.com/esphome/esphome/pull/18582)), so users see why there is a silent pause after the
 handshake instead of interpreting it as a stall. On a lossy link an OTA upload could give up moments before a
-lost chunk acknowledgement was retransmitted; the device now waits 105 s for data and the CLI 160 s for an
+lost chunk acknowledgement was retransmitted; the device now waits 105s for data and the CLI 160s for an
 acknowledgement, so a retry always finds the device free
 ([#19041](https://github.com/esphome/esphome/pull/19041)).
+
 On the ESP8266, LEAmDNS could free the same packet buffer twice when an mDNS packet arrived while a send was
 failing, corrupting the heap right as Home Assistant connected; its main loop calls are now guarded against
 that re-entrancy ([#18990](https://github.com/esphome/esphome/pull/18990)). Stack traces on the ESP32-S3 are no
@@ -476,6 +474,7 @@ PRs [#18338](https://github.com/esphome/esphome/pull/18338) through
 `from __future__ import annotations`, every annotation is evaluated at import time, so the sweep also had to
 add every missing import for the names it introduced; an all-modules import check pins that. No behaviour
 changes.
+
 ## Other Fixes
 
 Audio on ESP32 got a round of fixes: a speaker start request that arrived while the previous task was still

--- a/src/content/docs/blog/2026/09/16/esphome-2026-9.mdx
+++ b/src/content/docs/blog/2026/09/16/esphome-2026-9.mdx
@@ -429,8 +429,8 @@ Seven new components join the tree:
 - **[esp32_ble](/components/esp32_ble/)** by [@jesserockz](https://github.com/jesserockz) reference counts
   advertising, so a device that only uses `esp32_improv` stops advertising once provisioning ends instead of
   showing up in every phone's Bluetooth list forever ([#18943](https://github.com/esphome/esphome/pull/18943))
-- **[sendspin media source](/components/media_source/sendspin/)** by [@kahrendt](https://github.com/kahrendt) adds a `codecs`
-  option that sets which audio codecs the media source advertises, in order of preference
+- **[sendspin media source](/components/media_source/sendspin/)** by [@kahrendt](https://github.com/kahrendt)
+  adds a `codecs` option that sets which audio codecs the media source advertises, in order of preference
   ([#19047](https://github.com/esphome/esphome/pull/19047))
 
 ## Networking And Diagnostics

--- a/src/content/docs/blog/2026/09/16/esphome-2026-9.mdx
+++ b/src/content/docs/blog/2026/09/16/esphome-2026-9.mdx
@@ -274,8 +274,8 @@ per-connection heap:
 | Pico W (RP2040) | 65.5 KB | 34.7 KB | 48 B | 24 B |
 
 A Noise handshake drops from about 580ms to about 300ms on the ESP8266 and from 63ms to 46ms on the ESP32, and
-20 encrypted API connects to a d1 mini by IP with WiFi power save off go from a 496 to 584ms median and 359ms
-best on 2026.8.0 to a 309 to 382ms median and 212ms best. Nothing to configure.
+20 encrypted API connects to a d1 mini by IP with WiFi power save off go from a 496-584ms median and 359ms
+best on 2026.8.0 to a 309-382ms median and 212ms best. Nothing to configure.
 
 ## Improv Serial Beyond WiFi
 

--- a/src/content/docs/blog/2026/09/16/esphome-2026-9.mdx
+++ b/src/content/docs/blog/2026/09/16/esphome-2026-9.mdx
@@ -62,7 +62,8 @@ package phase drops from 36% of build time to 25% on CI benchmarks, and the dock
 ~100s to ~46s), and a sweep across 60 files pushes 211 conditional log string literals off ESP8266 RAM into
 flash.
 
-Beyond the platform work, this release adds Noise (ChaCha20-Poly1305) encryption for OTA updates, brings
+Beyond the platform work, this release adds Noise (ChaCha20-Poly1305) encryption for OTA updates, cuts what
+encryption costs in flash by close to half on every platform, brings
 Improv provisioning to Ethernet-only boards, teaches WiFi provisioning to shut down the AP and captive portal
 when the window closes, and rewrites IR transmission on Beken and Realtek chips to run from a hardware timer
 interrupt instead of a busy-wait. The multi-release modbus overhaul continues with a heap-free write path, a
@@ -233,6 +234,36 @@ sits on top of a new shared `noise` component ([#18490](https://github.com/espho
 lifts the noise-c dependency, HWRNG binding, error strings, PSK context, encryption key validation and the
 handshake responder out of the api component so both api and ota can share them; there is no user
 configuration for `noise` itself.
+
+## Smaller And Faster Encryption
+
+The two libraries behind API and OTA encryption, the esphome-libs forks of noise-c and libsodium, were
+reworked through the beta ([#18989](https://github.com/esphome/esphome/pull/18989),
+[#19030](https://github.com/esphome/esphome/pull/19030)), with a final bump tagged for this release
+([#19062](https://github.com/esphome/esphome/pull/19062)). On the ESP8266 the X25519 Diffie-Hellman now runs
+on BearSSL's 13-bit limb arithmetic, which needs none of the 64-bit products the LX106 has to emulate, so
+the handshake's DH step is twice as fast; the RP2040's Cortex-M0+ has the same gap and gets the same ladder.
+The Ed25519 base point table used for the ephemeral key shrank from 30 KB to 12 KB on every platform and no
+longer thrashes the flash cache, the SHA256 transform went from fully unrolled to four rounds per pass, which
+makes it two to three times faster when cold, and on the ESP8266 the ChaCha20-Poly1305 transport is a quarter
+cheaper per packet while the SHA256 and AEAD constants moved out of DRAM. The final bump computes the
+ephemeral key on the same 13-bit arithmetic on the ESP8266 and RP2040, so ref10's field and Edwards code
+leaves those images and the base point multiply gets a third faster, and the ESP32 links one copy of the
+field functions instead of two.
+
+What turning on API encryption costs, measured as the difference between `api:` with and without a key on
+the same build (logger, wifi, api, ota), 2026.8.0 against this release with the final bump:
+
+| Board | 2026.8.0 flash | 2026.9.0 flash | 2026.8.0 RAM | 2026.9.0 RAM |
+| --- | --- | --- | --- | --- |
+| ESP8266 d1 mini | 82796 B | 42912 B | 1376 B | 48 B |
+| ESP32 AtomU (IDF) | 67484 B | 38628 B | 56 B | 32 B |
+| Pico W (RP2040) | 67068 B | 35516 B | 48 B | 24 B |
+
+A Noise handshake in RAM goes from about 580 ms to about 300 ms on the ESP8266 at 80 MHz, from 63 ms to
+46 ms on the ESP32, and from about 260 ms to about 205 ms on the RP2040; 20 encrypted API connects to a d1
+mini from `aioesphomeapi` went from a 377 ms median to 139 ms. Every device with API or OTA encryption gets
+this automatically; there is nothing to configure.
 
 ## Improv Serial Beyond WiFi
 

--- a/src/content/docs/blog/2026/09/16/esphome-2026-9.mdx
+++ b/src/content/docs/blog/2026/09/16/esphome-2026-9.mdx
@@ -297,16 +297,18 @@ configured with an access point and no station credentials.
 
 ## ISR-Driven IR Transmission On LibreTiny
 
-[@kbx81](https://github.com/kbx81) rewrites `remote_transmitter` on Beken BK7231N/BK7238 and Realtek RTL8720C
+[@kbx81](https://github.com/kbx81) rewrites `remote_transmitter` on the Beken BK7238 and Realtek RTL8720C
 to pace the IR envelope with a hardware timer interrupt chain instead of a priority-boosted busy-wait
 ([#18648](https://github.com/esphome/esphome/pull/18648),
 [#18660](https://github.com/esphome/esphome/pull/18660)). Interrupts stay enabled throughout, so WiFi and
 lwIP tasks run normally during long transmissions and `remote_receiver` decodes the device's own frames off
-the air during a send. `non_blocking:` is now supported on both families (previously ESP32-RMT only): the
+the air during a send. `non_blocking:` is now supported on those two chips (previously ESP32-RMT only): the
 send returns immediately after arming the chain and `on_complete` fires from `loop()`. Bench measurements on
 an RM4 Pro (RTL8720CF) show 25.01-25.09ms repeat gaps for a configured 25ms (tighter than the busy-wait's
 25.02-25.05ms) and 27 captured transmissions all bit-perfect; an FK UFO-R4 (BK7238) measured 16-30us
-duty-apply latency and 39/39 bit-perfect NEC envelopes.
+duty-apply latency and 39/39 bit-perfect NEC envelopes. The BK7231N keeps the bit-bang implementation it had
+before, since its SDK snapshot lacks the PWM driver interface the interrupt chain needs
+([#18958](https://github.com/esphome/esphome/pull/18958)).
 
 ## Modbus Controller Overhaul
 
@@ -472,8 +474,6 @@ PRs [#18338](https://github.com/esphome/esphome/pull/18338) through
 `from __future__ import annotations`, every annotation is evaluated at import time, so the sweep also had to
 add every missing import for the names it introduced; an all-modules import check pins that. No behaviour
 changes.
-{/* FEATURE_HIGHLIGHTS_END */}
-
 ## Other Fixes
 
 Audio on ESP32 got a round of fixes: a speaker start request that arrived while the previous task was still
@@ -499,10 +499,12 @@ re-asserts the temperature unit on every poll ([#17141](https://github.com/espho
 ([#18968](https://github.com/esphome/esphome/pull/18968)), and the removed `udp` options moved to
 `packet_transport` no longer appear in the generated schema ([#19032](https://github.com/esphome/esphome/pull/19032)).
 
+{/* FEATURE_HIGHLIGHTS_END */}
+
 ## Thank You, Contributors
 
 {/* CONTRIBUTORS_START */}
-This release includes 275 pull requests from over 30 contributors. A huge thank you to everyone who made 2026.9.0
+This release includes 275 pull requests from over 40 contributors. A huge thank you to everyone who made 2026.9.0
 possible:
 
 - [@exciton](https://github.com/exciton) - 25 PRs including the multi-release Modbus overhaul: PollingDevice-based
@@ -517,7 +519,7 @@ possible:
   benchmark reliability fixes
 - [@kbx81](https://github.com/kbx81) - 9 PRs including the provisioning window shutdown behavior, `improv_serial`
   support for Ethernet and non-WiFi interfaces, the ESP32 custom eFuse base-MAC fix, and ISR-driven `remote_transmitter`
-  on RTL8720C and BK7231N/BK7238
+  on RTL8720C and BK7238
 - [@guillempages](https://github.com/guillempages) - 8 PRs including `runtime_image` format auto-detection, QOI
   decoding, MIME types, decoder retention, and BMP dimension validation, plus the portable `str_contains_ignore_case`
   helper
@@ -561,9 +563,6 @@ contributions, and to everyone who reported issues, tested pre-releases, and hel
 {/* BREAKING_CHANGES_USERS_START */}
 ### Component Changes
 
-- **Remote Transmitter**: The hardware PWM path on LibreTiny is limited to BK7238; BK7231N returns to the bit-bang
-  implementation it used before 2026.9, and `non_blocking: true` is rejected there at validation.
-  [#18958](https://github.com/esphome/esphome/pull/18958)
 - **Modbus Controller**: `custom_command` renamed to `custom_pdu` and now takes the PDU only (function code + data), not
   a full frame. The controller's `address:` and CRC are appended automatically. Configs whose first byte matched the
   controller's `address:` are auto-migrated with a deprecation warning until 2027.3.0; frames targeting a different unit

--- a/src/content/docs/blog/2026/09/16/esphome-2026-9.mdx
+++ b/src/content/docs/blog/2026/09/16/esphome-2026-9.mdx
@@ -133,10 +133,12 @@ leg, and the CI compile-test image now compresses with multithreaded zstd instea
 ([#18812](https://github.com/esphome/esphome/pull/18812)), taking another 40s off the pipeline. ESP-IDF native
 builds also now cache the discovered component list inside the extracted framework directory
 ([#18752](https://github.com/esphome/esphome/pull/18752)), skipping a full CMake configure pass on every rebuild
-after an sdkconfig change (~2.2s on desktop, several times more on SBCs). Every compile also paid PlatformIO's
-private package authorization probe, a fixed 2.5 s of throttle sleep for a request that never leaves the
-machine; ESPHome now answers it directly, taking a no-op rebuild from 2.9 s to 0.4 s
-([#18823](https://github.com/esphome/esphome/pull/18823)), and when two builds want the same archive at once the
+after an sdkconfig change (~2.2s on desktop, several times more on SBCs). PlatformIO also checks whether each
+registry library is a private package before it looks at its own cache, and that check sleeps half a second
+under the account client's rate limit before failing at once on any machine without a PlatformIO login;
+ESPHome never uses private packages, so it now answers the check itself, which takes a no-op rebuild of a
+six-library config from 2.9 s to 0.4 s ([#18823](https://github.com/esphome/esphome/pull/18823)). When two
+builds want the same archive at once the
 waiting one shows the other's download progress instead of sitting at 0%
 ([#18983](https://github.com/esphome/esphome/pull/18983)).
 

--- a/src/content/docs/blog/2026/09/16/esphome-2026-9.mdx
+++ b/src/content/docs/blog/2026/09/16/esphome-2026-9.mdx
@@ -237,22 +237,13 @@ configuration for `noise` itself.
 
 ## Smaller And Faster Encryption
 
-[@bdraco](https://github.com/bdraco) reworked the two libraries behind API and OTA encryption, the
-esphome-libs forks of noise-c and libsodium ([#18989](https://github.com/esphome/esphome/pull/18989),
-[#19030](https://github.com/esphome/esphome/pull/19030),
-[#19062](https://github.com/esphome/esphome/pull/19062)). On the ESP8266 the X25519 Diffie-Hellman now runs
-on BearSSL's 13-bit limb arithmetic, which needs none of the 64-bit products the LX106 has to emulate, so
-the handshake's DH step is twice as fast; the RP2040's Cortex-M0+ has the same gap and gets the same ladder.
-The Ed25519 base point table used for the ephemeral key shrank from 30 KB to 12 KB on every platform and no
-longer thrashes the flash cache, the SHA256 transform went from fully unrolled to four rounds per pass, which
-makes it two to three times faster when cold, and on the ESP8266 the ChaCha20-Poly1305 transport is a quarter
-cheaper per packet while the SHA256 and AEAD constants moved out of DRAM. The last of the three computes the
-ephemeral key on the same 13-bit arithmetic on the ESP8266 and RP2040, so ref10's field and Edwards code
-leaves those images and the base point multiply gets a third faster, and the ESP32 links one copy of the
-field functions instead of two.
-
-What turning on API encryption costs, measured as the difference between `api:` with and without a key on
-the same build (logger, wifi, api, ota), 2026.8.0 against this release:
+[@bdraco](https://github.com/bdraco) reworked the noise-c and libsodium forks behind API and OTA encryption
+([#18989](https://github.com/esphome/esphome/pull/18989), [#19030](https://github.com/esphome/esphome/pull/19030),
+[#19062](https://github.com/esphome/esphome/pull/19062)). The ESP8266 and RP2040 now run X25519 on 13-bit limb
+arithmetic that needs no 64-bit products, the Ed25519 base point table shrank from 30 KB to 12 KB on every
+platform, the SHA256 transform is compact and two to three times faster when cold, and on the ESP8266 the
+ChaCha20-Poly1305 transport is a quarter cheaper per packet with its constants out of DRAM. What turning on
+API encryption costs, 2026.8.0 against this release:
 
 | Board | 2026.8.0 flash | 2026.9.0 flash | 2026.8.0 RAM | 2026.9.0 RAM |
 | --- | --- | --- | --- | --- |
@@ -260,10 +251,8 @@ the same build (logger, wifi, api, ota), 2026.8.0 against this release:
 | ESP32 AtomU (IDF) | 67484 B | 38628 B | 56 B | 32 B |
 | Pico W (RP2040) | 67068 B | 35516 B | 48 B | 24 B |
 
-A Noise handshake in RAM goes from about 580 ms to about 300 ms on the ESP8266 at 80 MHz, from 63 ms to
-46 ms on the ESP32, and from about 260 ms to about 205 ms on the RP2040; 20 encrypted API connects to a d1
-mini from `aioesphomeapi` went from a 377 ms median to 139 ms. Every device with API or OTA encryption gets
-this automatically; there is nothing to configure.
+A Noise handshake drops from about 580 ms to about 300 ms on the ESP8266 and from 63 ms to 46 ms on the
+ESP32; an encrypted API connect to a d1 mini goes from a 377 ms median to 139 ms. Nothing to configure.
 
 ## Improv Serial Beyond WiFi
 

--- a/src/content/docs/blog/2026/09/16/esphome-2026-9.mdx
+++ b/src/content/docs/blog/2026/09/16/esphome-2026-9.mdx
@@ -67,8 +67,8 @@ encryption costs in flash by close to half on every platform, brings
 Improv provisioning to Ethernet-only boards, teaches WiFi provisioning to shut down the AP and captive portal
 when the window closes, and rewrites IR transmission on Beken and Realtek chips to run from a hardware timer
 interrupt instead of a busy-wait. The multi-release modbus overhaul continues with a heap-free write path, a
-consolidated range-join option, and continuous polling. Six new components (ds1603l, d01, sfa40, mk2pvrouter,
-snapshot, noise) and roughly a dozen feature additions to existing components round out the release. The bundled
+consolidated range-join option, and continuous polling. Seven new components (ds1603l, d01, sfa40, mk2pvrouter,
+snapshot, noise, template climate) and roughly a dozen feature additions to existing components round out the release. The bundled
 Device Builder masks credentials in the YAML diff view, boots ESP32-C6 boards after a browser flash, and lets paired
 build servers recover from an address change on their own.
 {/* RELEASE_OVERVIEW_END */}
@@ -134,7 +134,12 @@ leg, and the CI compile-test image now compresses with multithreaded zstd instea
 ([#18812](https://github.com/esphome/esphome/pull/18812)), taking another 40s off the pipeline. ESP-IDF native
 builds also now cache the discovered component list inside the extracted framework directory
 ([#18752](https://github.com/esphome/esphome/pull/18752)), skipping a full CMake configure pass on every rebuild
-after an sdkconfig change (~2.2s on desktop, several times more on SBCs).
+after an sdkconfig change (~2.2s on desktop, several times more on SBCs). Every compile also paid PlatformIO's
+private package authorization probe, a fixed 2.5 s of throttle sleep for a request that never leaves the
+machine; ESPHome now answers it directly, taking a no-op rebuild from 2.9 s to 0.4 s
+([#18823](https://github.com/esphome/esphome/pull/18823)), and when two builds want the same archive at once the
+waiting one shows the other's download progress instead of sitting at 0%
+([#18983](https://github.com/esphome/esphome/pull/18983)).
 
 ## ESP8266 RAM Savings
 
@@ -215,6 +220,18 @@ never again trigger a fleet-wide regeneration on upgrade ([#2617](https://github
 the Docker container reaps orphaned processes when running as PID 1
 ([#2636](https://github.com/esphome/device-builder/pull/2636)), and version history ignores the fake executable bit
 Samba puts on files edited from Windows ([#2646](https://github.com/esphome/device-builder/pull/2646)).
+
+Later builds keep an explicit OTA encryption key in step with the API key
+([#2665](https://github.com/esphome/device-builder/pull/2665)) and nudge devices that already offer OTA
+encryption toward `ota: encryption:` ([frontend#1714](https://github.com/esphome/device-builder-frontend/pull/1714)),
+render the catalog picker only while its dialog is open and mount one picker per automation editor and one
+navigator per page, which makes large automations noticeably lighter
+([frontend#1698](https://github.com/esphome/device-builder-frontend/pull/1698),
+[frontend#1710](https://github.com/esphome/device-builder-frontend/pull/1710),
+[frontend#1715](https://github.com/esphome/device-builder-frontend/pull/1715)), resolve platform-scoped
+component triggers by the instance's platform ([#2671](https://github.com/esphome/device-builder/pull/2671),
+[frontend#1720](https://github.com/esphome/device-builder-frontend/pull/1720)), and serialise non-string keys in
+the JSON config endpoint ([#2660](https://github.com/esphome/device-builder/pull/2660)).
 
 ## Encrypted OTA Updates
 
@@ -316,7 +333,7 @@ requested state instead of the inverted one. Users of `custom_command`, `registe
 
 ## New Components And Hardware Support
 
-Six new components join the tree:
+Seven new components join the tree:
 
 - **[ds1603l](/components/sensor/ds1603l/)** by [@JakeLC15](https://github.com/JakeLC15) - a UART ultrasonic
   liquid-level sensor with configurable min/max level and volume mapping
@@ -336,6 +353,10 @@ Six new components join the tree:
 - **noise** by [@bdraco](https://github.com/bdraco) - a shared internal Noise
   primitives component that api and the new encrypted OTA both consume; no user configuration
   ([#18490](https://github.com/esphome/esphome/pull/18490))
+- **[template climate](/components/climate/template/)** by [@rsre](https://github.com/rsre) - a climate
+  platform whose mode, targets, fan, swing and presets are plain state driven from lambdas and actions, so a
+  UART or I²C thermostat can be exposed without the template-plus-lambda workarounds
+  ([#14455](https://github.com/esphome/esphome/pull/14455))
 
 ## New Features In Existing Components
 
@@ -400,6 +421,15 @@ Six new components join the tree:
 - **[rp2_ble_tracker automation](/components/bluetooth_proxy/)** by
   [@Bl00d-B0b](https://github.com/Bl00d-B0b) wires the shared BLE automation surface onto the RP2 tracker
   ([#18717](https://github.com/esphome/esphome/pull/18717))
+- **[esp32_hosted](/components/esp32_hosted/)** by [@jesserockz](https://github.com/jesserockz) gains ESP-NOW on
+  the ESP32-P4: the host forwards every `esp_now_*` call to the co-processor over esp-hosted, so `espnow:` works
+  unchanged on boards like the M5Stack Tab5 ([#17712](https://github.com/esphome/esphome/pull/17712))
+- **[esp32_ble](/components/esp32_ble/)** by [@jesserockz](https://github.com/jesserockz) reference counts
+  advertising, so a device that only uses `esp32_improv` stops advertising once provisioning ends instead of
+  showing up in every phone's Bluetooth list forever ([#18943](https://github.com/esphome/esphome/pull/18943))
+- **[sendspin](/components/media_player/sendspin/)** by [@kahrendt](https://github.com/kahrendt) adds a `codecs`
+  option that sets which audio codecs the media source advertises, in order of preference
+  ([#19047](https://github.com/esphome/esphome/pull/19047))
 
 ## Networking And Diagnostics
 
@@ -411,7 +441,16 @@ because holding the shared radio for over a second at a time starves WiFi and ca
 ([#18725](https://github.com/esphome/esphome/pull/18725)). `espota2` now logs the erase-prepare window
 separately from the upload window and reports total OTA time
 ([#18582](https://github.com/esphome/esphome/pull/18582)), so users see why there is a silent pause after the
-handshake instead of interpreting it as a stall.
+handshake instead of interpreting it as a stall. On a lossy link an OTA upload could give up moments before a
+lost chunk acknowledgement was retransmitted; the device now waits 105 s for data and the CLI 160 s for an
+acknowledgement, so a retry always finds the device free
+([#19041](https://github.com/esphome/esphome/pull/19041)).
+On the ESP8266, LEAmDNS could free the same packet buffer twice when an mDNS packet arrived while a send was
+failing, corrupting the heap right as Home Assistant connected; its main loop calls are now guarded against
+that re-entrancy ([#18990](https://github.com/esphome/esphome/pull/18990)). Stack traces on the ESP32-S3 are no
+longer garbled when the UART clock runs from APB ([#17939](https://github.com/esphome/esphome/pull/17939)), and
+the `debug` component reports the reboot source after a watchdog-flavoured `esp_restart()` and no longer prints
+an empty source ([#17537](https://github.com/esphome/esphome/pull/17537)).
 
 ## ESP32 Custom eFuse MAC Applied Consistently
 
@@ -434,6 +473,31 @@ PRs [#18338](https://github.com/esphome/esphome/pull/18338) through
 add every missing import for the names it introduced; an all-modules import check pins that. No behaviour
 changes.
 {/* FEATURE_HIGHLIGHTS_END */}
+
+## Other Fixes
+
+Audio on ESP32 got a round of fixes: a speaker start request that arrived while the previous task was still
+stopping is kept instead of dropped ([#19027](https://github.com/esphome/esphome/pull/19027)), the I2S driver is
+no longer started a second time while the bus lock is still held, which cost a one second delay before playback
+([#19045](https://github.com/esphome/esphome/pull/19045)), an MP3 stream whose format changes mid-stream is
+reconfigured instead of treated as a decoder failure ([#19028](https://github.com/esphome/esphome/pull/19028)),
+buffer validity checks across the audio components use a lock and null test instead of `use_count()`
+([#19046](https://github.com/esphome/esphome/pull/19046)), and a running `StaticTask` is suspended before its
+stack is freed, closing a use-after-free ([#19048](https://github.com/esphome/esphome/pull/19048)).
+
+Elsewhere, MQTT light discovery publishes `brightness: true` again so Home Assistant sends brightness and colour
+separately ([#18950](https://github.com/esphome/esphome/pull/18950)), `dallas_temp` filters the 85 °C reading a
+DS18B20 returns after a reset ([#17877](https://github.com/esphome/esphome/pull/17877)), `ble_client` nodes that
+never read services now report established so the client releases its discovered services
+([#17920](https://github.com/esphome/esphome/pull/17920)), `tuya` builds without a network component
+([#18948](https://github.com/esphome/esphome/pull/18948)), the LVGL `qrcode`, `keyboard` and `tabview` widgets
+declare their label dependency ([#18387](https://github.com/esphome/esphome/pull/18387)), `rf_bridge` bucket
+sniffing works with the Portisch firmware ([#17683](https://github.com/esphome/esphome/pull/17683)), `anova`
+re-asserts the temperature unit on every poll ([#17141](https://github.com/esphome/esphome/pull/17141)),
+`atm90e32` verifies its offset calibration writes ([#18701](https://github.com/esphome/esphome/pull/18701)),
+`usb_uart` keeps working when the comm interface claim fails
+([#18968](https://github.com/esphome/esphome/pull/18968)), and the removed `udp` options moved to
+`packet_transport` no longer appear in the generated schema ([#19032](https://github.com/esphome/esphome/pull/19032)).
 
 ## Thank You, Contributors
 
@@ -484,8 +548,12 @@ Also thank you to [@bdraco](https://github.com/bdraco), [@ireun](https://github.
 [@alaraun](https://github.com/alaraun), [@zweckj](https://github.com/zweckj),
 [@kahrendt](https://github.com/kahrendt), [@luar123](https://github.com/luar123),
 [@Gafielt](https://github.com/Gafielt), [@MakerYuichi](https://github.com/MakerYuichi),
-[@mfishma](https://github.com/mfishma), and [@Zebble](https://github.com/Zebble) for their contributions, and to
-everyone who reported issues, tested pre-releases, and helped in the community.
+[@mfishma](https://github.com/mfishma), [@Zebble](https://github.com/Zebble), [@rsre](https://github.com/rsre),
+[@mipa87](https://github.com/mipa87), [@ryan-ronnander](https://github.com/ryan-ronnander),
+[@AndreKR](https://github.com/AndreKR), [@ssieb](https://github.com/ssieb), [@ptr727](https://github.com/ptr727),
+[@dmd79](https://github.com/dmd79), [@Gytisla](https://github.com/Gytisla), [@btli](https://github.com/btli),
+[@raykholo](https://github.com/raykholo), and [@CircuitSetup](https://github.com/CircuitSetup) for their
+contributions, and to everyone who reported issues, tested pre-releases, and helped in the community.
 {/* CONTRIBUTORS_END */}
 
 ## Breaking Changes
@@ -493,6 +561,9 @@ everyone who reported issues, tested pre-releases, and helped in the community.
 {/* BREAKING_CHANGES_USERS_START */}
 ### Component Changes
 
+- **Remote Transmitter**: The hardware PWM path on LibreTiny is limited to BK7238; BK7231N returns to the bit-bang
+  implementation it used before 2026.9, and `non_blocking: true` is rejected there at validation.
+  [#18958](https://github.com/esphome/esphome/pull/18958)
 - **Modbus Controller**: `custom_command` renamed to `custom_pdu` and now takes the PDU only (function code + data), not
   a full frame. The controller's `address:` and CRC are appended automatically. Configs whose first byte matched the
   controller's `address:` are auto-migrated with a deprecation warning until 2027.3.0; frames targeting a different unit
@@ -561,6 +632,9 @@ everyone who reported issues, tested pre-releases, and helped in the community.
   updated, and 802.15.4 (Thread/Zigbee) nodes may need to be re-commissioned. Devices without a custom eFuse MAC (the
   vast majority) are unaffected; setting `ignore_efuse_custom_mac: true` under `esp32: advanced:` disables the
   behavior. [#18452](https://github.com/esphome/esphome/pull/18452)
+- **ESP8266**: Arduino framework versions before 3.0.0 are rejected at validation. Those builds have failed since
+  ESPHome moved to C++20 in 2025.7, so nothing that compiled changes; remove the `framework: version:` pin or move it to
+  3.1.2. [#18917](https://github.com/esphome/esphome/pull/18917)
 - **ESP32 Hosted**: Now requires ESP-IDF 5.3 or newer. The legacy fallback to esp_hosted 2.0.11 (which had a known
   double-free crash on ESP32-P4 + C6) has been removed and older ESP-IDF versions now fail validation with a clear
   error. Configs that pin an ESP-IDF version below 5.3 alongside `esp32_hosted` must remove the pin or bump it to

--- a/src/content/docs/blog/2026/09/16/esphome-2026-9.mdx
+++ b/src/content/docs/blog/2026/09/16/esphome-2026-9.mdx
@@ -274,8 +274,9 @@ per-connection heap:
 | ESP32 AtomU (IDF) | 65.9 KB | 37.7 KB | 56 B | 32 B |
 | Pico W (RP2040) | 65.5 KB | 34.7 KB | 48 B | 24 B |
 
-A Noise handshake drops from about 580ms to about 300ms on the ESP8266 and from 63ms to 46ms on the
-ESP32; an encrypted API connect to a d1 mini goes from a 377ms median to 139ms. Nothing to configure.
+A Noise handshake drops from about 580ms to about 300ms on the ESP8266 and from 63ms to 46ms on the ESP32;
+the first of the three bumps alone took 20 encrypted API connects to a d1 mini from a 377ms median to 139ms.
+Nothing to configure.
 
 ## Improv Serial Beyond WiFi
 

--- a/src/content/docs/blog/2026/09/16/esphome-2026-9.mdx
+++ b/src/content/docs/blog/2026/09/16/esphome-2026-9.mdx
@@ -264,8 +264,9 @@ made them faster in most cases ([#18989](https://github.com/esphome/esphome/pull
 The ESP8266 and RP2040 now run X25519 on 13-bit limb arithmetic that needs no 64-bit products, the Ed25519
 base point table shrank from 30 KB to 12 KB on every platform, the SHA256 transform is compact on every
 platform and, on the ESP32 and RP2040, two to three times faster when cold, and on the ESP8266 the
-ChaCha20-Poly1305 transport is a quarter cheaper per packet with its constants out of DRAM. What turning on API encryption costs in 2026.8.0 and
-in this release, static RAM being the image's own data, not per-connection heap:
+ChaCha20-Poly1305 transport is a quarter cheaper per packet with its constants out of DRAM. What turning on
+API encryption costs in 2026.8.0 and in this release, static RAM being the image's own data, not
+per-connection heap:
 
 | Board | Flash 2026.8.0 | Flash 2026.9.0 | Static RAM 2026.8.0 | Static RAM 2026.9.0 |
 | --- | --- | --- | --- | --- |

--- a/src/content/docs/blog/2026/09/16/esphome-2026-9.mdx
+++ b/src/content/docs/blog/2026/09/16/esphome-2026-9.mdx
@@ -135,10 +135,10 @@ leg, and the CI compile-test image now compresses with multithreaded zstd instea
 builds also now cache the discovered component list inside the extracted framework directory
 ([#18752](https://github.com/esphome/esphome/pull/18752)), skipping a full CMake configure pass on every rebuild
 after an sdkconfig change (~2.2s on desktop, several times more on SBCs). PlatformIO also checks whether each
-registry library is a private package before it looks at its own cache, and that check sleeps half a second
-under the account client's rate limit before failing at once on any machine without a PlatformIO login;
-ESPHome never uses private packages, so it now answers the check itself, which takes a no-op rebuild of a
-six-library config from 2.9s to 0.4s ([#18823](https://github.com/esphome/esphome/pull/18823)). When two
+registry library is a private package before it looks at its own cache; on any machine without a PlatformIO
+login that check sleeps half a second under the account client's rate limit and then fails. ESPHome never uses
+private packages, so it now answers the check itself, cutting a no-op rebuild of a six-library config from
+2.9s to 0.4s ([#18823](https://github.com/esphome/esphome/pull/18823)). When two
 builds want the same archive at once, the waiting one shows the other's download progress instead of
 sitting at 0% ([#18983](https://github.com/esphome/esphome/pull/18983)).
 

--- a/src/content/docs/blog/2026/09/16/esphome-2026-9.mdx
+++ b/src/content/docs/blog/2026/09/16/esphome-2026-9.mdx
@@ -274,9 +274,9 @@ per-connection heap:
 | ESP32 AtomU (IDF) | 65.9 KB | 37.7 KB | 56 B | 32 B |
 | Pico W (RP2040) | 65.5 KB | 34.7 KB | 48 B | 24 B |
 
-A Noise handshake drops from about 580ms to about 300ms on the ESP8266 and from 63ms to 46ms on the ESP32;
-the first of the three bumps alone took 20 encrypted API connects to a d1 mini from a 377ms median to 139ms.
-Nothing to configure.
+A Noise handshake drops from about 580ms to about 300ms on the ESP8266 and from 63ms to 46ms on the ESP32, and
+20 encrypted API connects to a d1 mini by IP with WiFi power save off go from a 496 to 584ms median and 359ms
+best on 2026.8.0 to a 309 to 382ms median and 212ms best. Nothing to configure.
 
 ## Improv Serial Beyond WiFi
 

--- a/src/content/docs/blog/2026/09/16/esphome-2026-9.mdx
+++ b/src/content/docs/blog/2026/09/16/esphome-2026-9.mdx
@@ -237,13 +237,14 @@ configuration for `noise` itself.
 
 ## Smaller And Faster Encryption
 
-[@bdraco](https://github.com/bdraco) reworked the noise-c and libsodium forks behind API and OTA encryption
-([#18989](https://github.com/esphome/esphome/pull/18989), [#19030](https://github.com/esphome/esphome/pull/19030),
-[#19062](https://github.com/esphome/esphome/pull/19062)). The ESP8266 and RP2040 now run X25519 on 13-bit limb
-arithmetic that needs no 64-bit products, the Ed25519 base point table shrank from 30 KB to 12 KB on every
-platform, the SHA256 transform is compact and two to three times faster when cold, and on the ESP8266 the
-ChaCha20-Poly1305 transport is a quarter cheaper per packet with its constants out of DRAM. What turning on
-API encryption costs, 2026.8.0 against this release:
+The noise-c and libsodium forks behind API and OTA encryption had only been lightly adapted for embedded
+targets. [@bdraco](https://github.com/bdraco) went through them in full and cut them by nearly half in size,
+faster in most cases ([#18989](https://github.com/esphome/esphome/pull/18989),
+[#19030](https://github.com/esphome/esphome/pull/19030), [#19062](https://github.com/esphome/esphome/pull/19062)).
+The ESP8266 and RP2040 now run X25519 on 13-bit limb arithmetic that needs no 64-bit products, the Ed25519
+base point table shrank from 30 KB to 12 KB on every platform, the SHA256 transform is compact and two to
+three times faster when cold, and on the ESP8266 the ChaCha20-Poly1305 transport is a quarter cheaper per
+packet with its constants out of DRAM. What turning on API encryption costs, 2026.8.0 against this release:
 
 | Board | 2026.8.0 flash | 2026.9.0 flash | 2026.8.0 RAM | 2026.9.0 RAM |
 | --- | --- | --- | --- | --- |

--- a/src/content/docs/blog/2026/09/16/esphome-2026-9.mdx
+++ b/src/content/docs/blog/2026/09/16/esphome-2026-9.mdx
@@ -63,15 +63,14 @@ package phase drops from 36% of build time to 25% on CI benchmarks, and the dock
 flash.
 
 Beyond the platform work, this release adds Noise (ChaCha20-Poly1305) encryption for OTA updates, cuts what
-encryption costs in flash by close to half on every platform, brings
-Improv provisioning to Ethernet-only boards, teaches WiFi provisioning to shut down the AP and captive portal
-when the window closes, and rewrites IR transmission on Beken and Realtek chips to run from a hardware timer
-interrupt instead of a busy-wait. The multi-release modbus overhaul continues with a heap-free write path, a
-consolidated range-join option, and continuous polling. Seven new components (ds1603l, d01, sfa40, mk2pvrouter,
-snapshot, noise, template climate) and roughly a dozen feature additions to existing components round out the
-release. The bundled Device Builder masks credentials in the YAML diff view, boots ESP32-C6 boards after a browser
-flash, and lets paired build servers recover from an address change on their own.
-{/* RELEASE_OVERVIEW_END */}
+encryption costs in flash by close to half on every platform, brings Improv provisioning to Ethernet-only
+boards, teaches WiFi provisioning to shut down the AP and captive portal when the window closes, and rewrites
+IR transmission on Beken and Realtek chips to run from a hardware timer interrupt instead of a busy-wait. The
+multi-release modbus overhaul continues with a heap-free write path, a consolidated range-join option, and
+continuous polling. Seven new components (ds1603l, d01, sfa40, mk2pvrouter, snapshot, noise, template climate)
+and roughly a dozen feature additions to existing components round out the release. The bundled Device Builder
+masks credentials in the YAML diff view, boots ESP32-C6 boards after a browser flash, and lets paired build
+servers recover from an address change on their own. {/* RELEASE_OVERVIEW_END */}
 
 ## Upgrade Checklist
 
@@ -255,19 +254,20 @@ configuration for `noise` itself.
 ## Smaller And Faster Encryption
 
 The noise-c and libsodium forks behind API and OTA encryption had only been lightly adapted for embedded
-targets. [@bdraco](https://github.com/bdraco) went through them in full and cut them by nearly half in size,
-faster in most cases ([#18989](https://github.com/esphome/esphome/pull/18989),
+targets. [@bdraco](https://github.com/bdraco) went through them in full, cut them by nearly half in size and
+made them faster in most cases ([#18989](https://github.com/esphome/esphome/pull/18989),
 [#19030](https://github.com/esphome/esphome/pull/19030), [#19062](https://github.com/esphome/esphome/pull/19062)).
 The ESP8266 and RP2040 now run X25519 on 13-bit limb arithmetic that needs no 64-bit products, the Ed25519
-base point table shrank from 30 KB to 12 KB on every platform, the SHA256 transform is compact and two to
-three times faster when cold, and on the ESP8266 the ChaCha20-Poly1305 transport is a quarter cheaper per
-packet with its constants out of DRAM. What turning on API encryption costs, 2026.8.0 against this release:
+base point table shrank from 30 KB to 12 KB on every platform, the SHA256 transform is compact on every
+platform and two to three times faster when cold, and on the ESP8266 the ChaCha20-Poly1305 transport is a
+quarter cheaper per packet with its constants out of DRAM. What turning on API encryption costs in 2026.8.0 and
+in this release, static RAM being the image's own data, not per-connection heap:
 
-| Board | 2026.8.0 flash | 2026.9.0 flash | 2026.8.0 RAM | 2026.9.0 RAM |
+| Board | Flash 2026.8.0 | Flash 2026.9.0 | Static RAM 2026.8.0 | Static RAM 2026.9.0 |
 | --- | --- | --- | --- | --- |
-| ESP8266 d1 mini | 82796 B | 42912 B | 1376 B | 48 B |
-| ESP32 AtomU (IDF) | 67484 B | 38628 B | 56 B | 32 B |
-| Pico W (RP2040) | 67068 B | 35516 B | 48 B | 24 B |
+| ESP8266 d1 mini | 80.9 KB | 41.9 KB | 1376 B | 48 B |
+| ESP32 AtomU (IDF) | 65.9 KB | 37.7 KB | 56 B | 32 B |
+| Pico W (RP2040) | 65.5 KB | 34.7 KB | 48 B | 24 B |
 
 A Noise handshake drops from about 580 ms to about 300 ms on the ESP8266 and from 63 ms to 46 ms on the
 ESP32; an encrypted API connect to a d1 mini goes from a 377 ms median to 139 ms. Nothing to configure.

--- a/src/content/docs/blog/2026/09/16/esphome-2026-9.mdx
+++ b/src/content/docs/blog/2026/09/16/esphome-2026-9.mdx
@@ -223,17 +223,18 @@ the Docker container reaps orphaned processes when running as PID 1
 ([#2636](https://github.com/esphome/device-builder/pull/2636)), and version history ignores the fake executable bit
 Samba puts on files edited from Windows ([#2646](https://github.com/esphome/device-builder/pull/2646)).
 
-Later builds keep an explicit OTA encryption key in step with the API key
-([#2665](https://github.com/esphome/device-builder/pull/2665)) and nudge devices that already offer OTA
-encryption toward `ota: encryption:` ([frontend#1714](https://github.com/esphome/device-builder-frontend/pull/1714)),
-render the catalog picker only while its dialog is open and mount one picker per automation editor and one
-navigator per page, which makes large automations noticeably lighter
+Later builds keep OTA encryption in step with the API key: rewriting a static API key replaces a duplicated
+`ota: encryption: key:` with the bare block that inherits it
+([#2665](https://github.com/esphome/device-builder/pull/2665)), and devices that already offer OTA encryption are
+nudged toward `ota: encryption:` ([frontend#1714](https://github.com/esphome/device-builder-frontend/pull/1714)).
+The catalog picker renders only while its dialog is open, with one picker per automation editor and one
+navigator per page
 ([frontend#1698](https://github.com/esphome/device-builder-frontend/pull/1698),
 [frontend#1710](https://github.com/esphome/device-builder-frontend/pull/1710),
-[frontend#1715](https://github.com/esphome/device-builder-frontend/pull/1715)), resolve platform-scoped
-component triggers by the instance's platform ([#2671](https://github.com/esphome/device-builder/pull/2671),
-[frontend#1720](https://github.com/esphome/device-builder-frontend/pull/1720)), and serialise non-string keys in
-the JSON config endpoint ([#2660](https://github.com/esphome/device-builder/pull/2660)).
+[frontend#1715](https://github.com/esphome/device-builder-frontend/pull/1715)), platform-scoped component
+triggers resolve by the instance's platform ([#2671](https://github.com/esphome/device-builder/pull/2671),
+[frontend#1720](https://github.com/esphome/device-builder-frontend/pull/1720)), and the JSON config endpoint
+serialises non-string keys ([#2660](https://github.com/esphome/device-builder/pull/2660)).
 
 ## Encrypted OTA Updates
 
@@ -262,8 +263,8 @@ made them faster in most cases ([#18989](https://github.com/esphome/esphome/pull
 [#19030](https://github.com/esphome/esphome/pull/19030), [#19062](https://github.com/esphome/esphome/pull/19062)).
 The ESP8266 and RP2040 now run X25519 on 13-bit limb arithmetic that needs no 64-bit products, the Ed25519
 base point table shrank from 30 KB to 12 KB on every platform, the SHA256 transform is compact on every
-platform and two to three times faster when cold, and on the ESP8266 the ChaCha20-Poly1305 transport is a
-quarter cheaper per packet with its constants out of DRAM. What turning on API encryption costs in 2026.8.0 and
+platform and, on the ESP32 and RP2040, two to three times faster when cold, and on the ESP8266 the
+ChaCha20-Poly1305 transport is a quarter cheaper per packet with its constants out of DRAM. What turning on API encryption costs in 2026.8.0 and
 in this release, static RAM being the image's own data, not per-connection heap:
 
 | Board | Flash 2026.8.0 | Flash 2026.9.0 | Static RAM 2026.8.0 | Static RAM 2026.9.0 |
@@ -424,7 +425,8 @@ Six new components join the tree:
   ([#18717](https://github.com/esphome/esphome/pull/18717))
 - **[esp32_hosted](/components/esp32_hosted/)** by [@jesserockz](https://github.com/jesserockz) gains ESP-NOW on
   the ESP32-P4: the host forwards every `esp_now_*` call to the co-processor over esp-hosted, so `espnow:` works
-  unchanged on boards like the M5Stack Tab5 ([#17712](https://github.com/esphome/esphome/pull/17712))
+  unchanged on boards like the M5Stack Tab5 once the co-processor runs the matching esp-hosted firmware
+  ([#17712](https://github.com/esphome/esphome/pull/17712))
 - **[esp32_ble](/components/esp32_ble/)** by [@jesserockz](https://github.com/jesserockz) reference counts
   advertising, so a device that only uses `esp32_improv` stops advertising once provisioning ends instead of
   showing up in every phone's Bluetooth list forever ([#18943](https://github.com/esphome/esphome/pull/18943))
@@ -449,8 +451,9 @@ acknowledgement, so a retry always finds the device free
 
 On the ESP8266, LEAmDNS could free the same packet buffer twice when an mDNS packet arrived while a send was
 failing, corrupting the heap right as Home Assistant connected; its main loop calls are now guarded against
-that re-entrancy ([#18990](https://github.com/esphome/esphome/pull/18990)). Stack traces on the ESP32-S3 are no
-longer garbled when the UART clock runs from APB ([#17939](https://github.com/esphome/esphome/pull/17939)), and
+that re-entrancy ([#18990](https://github.com/esphome/esphome/pull/18990)). The logger's UART on the ESP32-S3
+now runs from the XTAL clock, which stops the garbled stack traces the APB clock produced
+([#17939](https://github.com/esphome/esphome/pull/17939)), and
 the `debug` component reports the reboot source after a watchdog-flavoured `esp_restart()` and no longer prints
 an empty source ([#17537](https://github.com/esphome/esphome/pull/17537)).
 
@@ -480,14 +483,16 @@ changes.
 Audio on ESP32 got a round of fixes: a speaker start request that arrived while the previous task was still
 stopping is kept instead of dropped ([#19027](https://github.com/esphome/esphome/pull/19027)), the I2S driver is
 no longer started a second time while the bus lock is still held, which cost a one second delay before playback
-([#19045](https://github.com/esphome/esphome/pull/19045)), an MP3 stream whose format changes mid-stream is
-reconfigured instead of treated as a decoder failure ([#19028](https://github.com/esphome/esphome/pull/19028)),
-buffer validity checks across the audio components use a lock and null test instead of `use_count()`
+([#19045](https://github.com/esphome/esphome/pull/19045)), the MP3 decoder treats a mid-stream format notice as
+the recoverable status it is instead of ending playback
+([#19028](https://github.com/esphome/esphome/pull/19028)), the audio components check their buffers through a
+locked pointer or a null test instead of `use_count()`
 ([#19046](https://github.com/esphome/esphome/pull/19046)), and a running `StaticTask` is suspended before its
 stack is freed, closing a use-after-free ([#19048](https://github.com/esphome/esphome/pull/19048)).
 
 Elsewhere, MQTT light discovery publishes `brightness: true` again so Home Assistant sends brightness and colour
-separately ([#18950](https://github.com/esphome/esphome/pull/18950)), `dallas_temp` filters the 85 °C reading a
+as separate fields instead of folding one into the other
+([#18950](https://github.com/esphome/esphome/pull/18950)), `dallas_temp` filters the 85 °C reading a
 DS18B20 returns after a reset ([#17877](https://github.com/esphome/esphome/pull/17877)), `ble_client` nodes that
 never read services now report established so the client releases its discovered services
 ([#17920](https://github.com/esphome/esphome/pull/17920)), `tuya` builds without a network component
@@ -633,8 +638,9 @@ contributions, and to everyone who reported issues, tested pre-releases, and hel
   vast majority) are unaffected; setting `ignore_efuse_custom_mac: true` under `esp32: advanced:` disables the
   behavior. [#18452](https://github.com/esphome/esphome/pull/18452)
 - **ESP8266**: Arduino framework versions before 3.0.0 are rejected at validation. Those builds have failed since
-  ESPHome moved to C++20 in 2025.7, so nothing that compiled changes; remove the `framework: version:` pin or move it to
-  3.1.2. [#18917](https://github.com/esphome/esphome/pull/18917)
+  ESPHome moved to C++20 in 2025.7, so nothing that compiled changes, but the check also covers `config`, `logs` and
+  `upload`, so a YAML still pinned below 3.0.0 needs the `framework: version:` pin removed or moved to 3.1.2 before
+  those commands work again. [#18917](https://github.com/esphome/esphome/pull/18917)
 - **ESP32 Hosted**: Now requires ESP-IDF 5.3 or newer. The legacy fallback to esp_hosted 2.0.11 (which had a known
   double-free crash on ESP32-P4 + C6) has been removed and older ESP-IDF versions now fail validation with a clear
   error. Configs that pin an ESP-IDF version below 5.3 alongside `esp32_hosted` must remove the pin or bump it to

--- a/src/content/docs/blog/2026/09/16/esphome-2026-9.mdx
+++ b/src/content/docs/blog/2026/09/16/esphome-2026-9.mdx
@@ -237,22 +237,22 @@ configuration for `noise` itself.
 
 ## Smaller And Faster Encryption
 
-The two libraries behind API and OTA encryption, the esphome-libs forks of noise-c and libsodium, were
-reworked through the beta ([#18989](https://github.com/esphome/esphome/pull/18989),
-[#19030](https://github.com/esphome/esphome/pull/19030)), with a final bump tagged for this release
-([#19062](https://github.com/esphome/esphome/pull/19062)). On the ESP8266 the X25519 Diffie-Hellman now runs
+[@bdraco](https://github.com/bdraco) reworked the two libraries behind API and OTA encryption, the
+esphome-libs forks of noise-c and libsodium ([#18989](https://github.com/esphome/esphome/pull/18989),
+[#19030](https://github.com/esphome/esphome/pull/19030),
+[#19062](https://github.com/esphome/esphome/pull/19062)). On the ESP8266 the X25519 Diffie-Hellman now runs
 on BearSSL's 13-bit limb arithmetic, which needs none of the 64-bit products the LX106 has to emulate, so
 the handshake's DH step is twice as fast; the RP2040's Cortex-M0+ has the same gap and gets the same ladder.
 The Ed25519 base point table used for the ephemeral key shrank from 30 KB to 12 KB on every platform and no
 longer thrashes the flash cache, the SHA256 transform went from fully unrolled to four rounds per pass, which
 makes it two to three times faster when cold, and on the ESP8266 the ChaCha20-Poly1305 transport is a quarter
-cheaper per packet while the SHA256 and AEAD constants moved out of DRAM. The final bump computes the
+cheaper per packet while the SHA256 and AEAD constants moved out of DRAM. The last of the three computes the
 ephemeral key on the same 13-bit arithmetic on the ESP8266 and RP2040, so ref10's field and Edwards code
 leaves those images and the base point multiply gets a third faster, and the ESP32 links one copy of the
 field functions instead of two.
 
 What turning on API encryption costs, measured as the difference between `api:` with and without a key on
-the same build (logger, wifi, api, ota), 2026.8.0 against this release with the final bump:
+the same build (logger, wifi, api, ota), 2026.8.0 against this release:
 
 | Board | 2026.8.0 flash | 2026.9.0 flash | 2026.8.0 RAM | 2026.9.0 RAM |
 | --- | --- | --- | --- | --- |

--- a/src/content/docs/blog/2026/09/16/esphome-2026-9.mdx
+++ b/src/content/docs/blog/2026/09/16/esphome-2026-9.mdx
@@ -68,9 +68,9 @@ Improv provisioning to Ethernet-only boards, teaches WiFi provisioning to shut d
 when the window closes, and rewrites IR transmission on Beken and Realtek chips to run from a hardware timer
 interrupt instead of a busy-wait. The multi-release modbus overhaul continues with a heap-free write path, a
 consolidated range-join option, and continuous polling. Seven new components (ds1603l, d01, sfa40, mk2pvrouter,
-snapshot, noise, template climate) and roughly a dozen feature additions to existing components round out the release. The bundled
-Device Builder masks credentials in the YAML diff view, boots ESP32-C6 boards after a browser flash, and lets paired
-build servers recover from an address change on their own.
+snapshot, noise, template climate) and roughly a dozen feature additions to existing components round out the
+release. The bundled Device Builder masks credentials in the YAML diff view, boots ESP32-C6 boards after a browser
+flash, and lets paired build servers recover from an address change on their own.
 {/* RELEASE_OVERVIEW_END */}
 
 ## Upgrade Checklist

--- a/src/content/docs/blog/2026/09/16/esphome-2026-9.mdx
+++ b/src/content/docs/blog/2026/09/16/esphome-2026-9.mdx
@@ -139,9 +139,8 @@ registry library is a private package before it looks at its own cache, and that
 under the account client's rate limit before failing at once on any machine without a PlatformIO login;
 ESPHome never uses private packages, so it now answers the check itself, which takes a no-op rebuild of a
 six-library config from 2.9s to 0.4s ([#18823](https://github.com/esphome/esphome/pull/18823)). When two
-builds want the same archive at once the
-waiting one shows the other's download progress instead of sitting at 0%
-([#18983](https://github.com/esphome/esphome/pull/18983)).
+builds want the same archive at once, the waiting one shows the other's download progress instead of
+sitting at 0% ([#18983](https://github.com/esphome/esphome/pull/18983)).
 
 ## ESP8266 RAM Savings
 
@@ -455,9 +454,9 @@ On the ESP8266, LEAmDNS could free the same packet buffer twice when an mDNS pac
 failing, corrupting the heap right as Home Assistant connected; its main loop calls are now guarded against
 that re-entrancy ([#18990](https://github.com/esphome/esphome/pull/18990)). The logger's UART on the ESP32-S3
 now runs from the XTAL clock, which stops the garbled stack traces the APB clock produced
-([#17939](https://github.com/esphome/esphome/pull/17939)), and
-the `debug` component reports the reboot source after a watchdog-flavoured `esp_restart()` and no longer prints
-an empty source ([#17537](https://github.com/esphome/esphome/pull/17537)).
+([#17939](https://github.com/esphome/esphome/pull/17939)), and the `debug` component reports the reboot source
+after a watchdog-flavoured `esp_restart()` and no longer prints an empty source
+([#17537](https://github.com/esphome/esphome/pull/17537)).
 
 ## ESP32 Custom eFuse MAC Applied Consistently
 

--- a/src/content/docs/blog/2026/09/16/esphome-2026-9.mdx
+++ b/src/content/docs/blog/2026/09/16/esphome-2026-9.mdx
@@ -65,7 +65,7 @@ flash.
 Beyond the platform work, this release adds Noise (ChaCha20-Poly1305) encryption for OTA updates, cuts what
 encryption costs in flash by close to half on every platform, brings Improv provisioning to Ethernet-only
 boards, teaches WiFi provisioning to shut down the AP and captive portal when the window closes, and rewrites
-IR transmission on Beken and Realtek chips to run from a hardware timer interrupt instead of a busy-wait. The
+IR transmission on the BK7238 and RTL8720C to run from a hardware timer interrupt instead of a busy-wait. The
 multi-release modbus overhaul continues with a heap-free write path, a consolidated range-join option, and
 continuous polling. Six new components (ds1603l, d01, sfa40, mk2pvrouter, snapshot, noise) and
 around twenty feature additions to existing components round out the release. The bundled Device Builder

--- a/src/content/docs/blog/2026/09/16/esphome-2026-9.mdx
+++ b/src/content/docs/blog/2026/09/16/esphome-2026-9.mdx
@@ -429,7 +429,7 @@ Seven new components join the tree:
 - **[esp32_ble](/components/esp32_ble/)** by [@jesserockz](https://github.com/jesserockz) reference counts
   advertising, so a device that only uses `esp32_improv` stops advertising once provisioning ends instead of
   showing up in every phone's Bluetooth list forever ([#18943](https://github.com/esphome/esphome/pull/18943))
-- **[sendspin](/components/media_player/sendspin/)** by [@kahrendt](https://github.com/kahrendt) adds a `codecs`
+- **[sendspin media source](/components/media_source/sendspin/)** by [@kahrendt](https://github.com/kahrendt) adds a `codecs`
   option that sets which audio codecs the media source advertises, in order of preference
   ([#19047](https://github.com/esphome/esphome/pull/19047))
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Refreshes the 2026.9.0 release notes for everything that landed after the first beta. A new section covers the noise-c and libsodium work (esphome/esphome#18989, esphome/esphome#19030, esphome/esphome#19062) with the cost of API encryption measured on three boards at 2026.8.0 against this release; the new template climate component, the ESP-NOW shim for the ESP32-P4, BLE advertising reference counting and the sendspin codec list join their sections; the OTA ack timeout, the ESP8266 mDNS guard, the stack trace and reboot source fixes go under networking and diagnostics; the PlatformIO probe and download progress changes go under the build system; the ESP8266 Arduino 3.0.0 floor goes under breaking changes and the BK7231N scope into the IR highlight; the audio fixes and the other component fixes get a section of their own; the Device Builder section covers the 1.14.x builds that shipped since; the overview and the contributor list are updated to match.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#19062

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
