### PR TITLE
[remote_transmitter] Document that a transmit while busy is dropped

### DIFF
--- a/src/content/docs/components/remote_transmitter.mdx
+++ b/src/content/docs/components/remote_transmitter.mdx
@@ -64,6 +64,14 @@ remote_transmitter:
 | ESP32-S3      | 192 symbols      | 48 symbols |
 
 - **clock_resolution** (*Optional*, int): The clock resolution used by the RMT peripheral in Hz. Defaults to `1000000`.
+- **queue_depth** (*Optional*, int): Number of transmissions the RMT hardware can hold at once when `non_blocking`
+  is enabled. A transmit that arrives while the hardware is busy is queued instead of blocking the main loop, and
+  queued transmissions are sent back to back. Each slot keeps its own encoded copy of the last transmission it sent.
+  Defaults to `4`.
+- **max_pending** (*Optional*, int): Total number of transmissions accepted while the hardware is busy, including
+  the `queue_depth` slots. Transmissions beyond `queue_depth` wait in a backlog that only uses memory while it holds
+  something. Once `max_pending` is reached, further transmits are dropped with a warning until the backlog drains.
+  Defaults to twice `queue_depth`.
 - **use_dma** (*Optional*, boolean): Enable DMA on variants that support it. If enabled `rmt_symbols` controls
   the DMA buffer size and can be set to a large value.
 

--- a/src/content/docs/components/remote_transmitter.mdx
+++ b/src/content/docs/components/remote_transmitter.mdx
@@ -37,9 +37,10 @@ remote_transmitter:
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): Manually specify the ID used for code generation. Useful when multiple
   transmitters are connected to a single device.
 - **non_blocking** (*Optional*, boolean): If enabled, transmissions return immediately and complete in the
-  background; the `on_complete` automation triggers once the transmission finishes. Only available on ESP32
-  variants with RMT hardware, where it defaults to `true`, and on RTL8720C and BK7238, where it defaults
-  to `false`.
+  background; the `on_complete` automation triggers once the transmission finishes. A transmission requested
+  while the previous one is still being sent is dropped with a warning, so wait for `on_complete` before
+  sending the next one. Only available on ESP32 variants with RMT hardware, where it defaults to `true`, and
+  on RTL8720C and BK7238, where it defaults to `false`.
 
 ### ESP32 RMT configuration variables
 
@@ -64,14 +65,6 @@ remote_transmitter:
 | ESP32-S3      | 192 symbols      | 48 symbols |
 
 - **clock_resolution** (*Optional*, int): The clock resolution used by the RMT peripheral in Hz. Defaults to `1000000`.
-- **queue_depth** (*Optional*, int): Number of transmissions the RMT hardware can hold at once when `non_blocking`
-  is enabled. A transmit that arrives while the hardware is busy is queued instead of blocking the main loop, and
-  queued transmissions are sent back to back. Each slot keeps its own encoded copy of the last transmission it sent.
-  Defaults to `4`.
-- **max_pending** (*Optional*, int): Total number of transmissions accepted while the hardware is busy, including
-  the `queue_depth` slots. Transmissions beyond `queue_depth` wait in a backlog that only uses memory while it holds
-  something. Once `max_pending` is reached, further transmits are dropped with a warning until the backlog drains.
-  Defaults to twice `queue_depth`.
 - **use_dma** (*Optional*, boolean): Enable DMA on variants that support it. If enabled `rmt_symbols` controls
   the DMA buffer size and can be set to a large value.
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Documents that a `non_blocking` `remote_transmitter` drops a transmit requested while the previous one is still being sent, instead of blocking the main loop.

**Related issue (if applicable):** fixes esphome/esphome#19033

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#19085

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
