### PR TITLE
[made_for_esphome] Add logger and ids to the example configuration

### DIFF
--- a/src/content/docs/guides/made_for_esphome.mdx
+++ b/src/content/docs/guides/made_for_esphome.mdx
@@ -99,7 +99,7 @@ fetches the manifest and the binary, so a dead link or a chip family mismatch wi
 
 ## Example Configuration
 
-The pieces every Made for ESPHome configuration needs, with a single entity to show the `id` requirement:
+The pieces every Made for ESPHome configuration needs:
 
 ```yaml
 esphome:
@@ -119,13 +119,16 @@ api:
 
 ota:
   - platform: esphome
+    id: ota_esphome
   - platform: http_request
+    id: ota_http_request
 
 http_request:
+  id: http_request_id
 
 update:
   - platform: http_request
-    id: esphome_update
+    id: update_http_request
     name: "ESPHome update"
     source: https://acme.example.com/widget/manifest.json
 
@@ -134,6 +137,8 @@ wifi:
 
 esp32_improv:
   authorizer: none
+
+logger:
 
 improv_serial:
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Follow-up to #7342, which was merged before these changes were pushed.

- Adds `logger:` to the example configuration. `improv_serial` requires the serial logger, so the example failed validation without it.
- Adds ids to both `ota` platforms and `http_request`, and renames the update entity id to `update_http_request`, so the example follows the id requirement the page documents.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#<esphome PR number goes here>

## Checklist

- [ ] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [x] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.