### PR TITLE
[esp32] Document enable_full_scanf

### DIFF
--- a/src/content/docs/components/esp32.mdx
+++ b/src/content/docs/components/esp32.mdx
@@ -648,9 +648,11 @@ The following options disable unused VFS features to save flash memory:
   At build time ESPHome scans lambda and `includes:` source for any float conversion (`%f`, `%e`, `%g`, `%a` and
   their variants) and keeps the C library version when it finds one. It cannot see inside external components.
   Set to `true` if an external component needs float parsing with `sscanf()`; otherwise such a call stops the
-  device with a message naming the format and this option. Set to `false` to keep the replacement even when user
-  code scans a float. Has no effect on the ESP32-C2 and ESP32-C6, whose ROM already provides `sscanf()`, or on the
-  Arduino framework. Defaults to automatic: the replacement, or the C library version when user code scans a float.
+  device with a message naming the format and this option. Set to `false` to keep the replacement even when a
+  lambda or include scans a float. The replacement only exists in Bluetooth builds on ESP-IDF 5.x (newlib); other
+  builds, the Arduino framework, and the ESP32-C2 and ESP32-C6 (whose ROM already provides `sscanf()`) use the C
+  library version and ignore this option. Defaults to automatic: the replacement, or the C library version when a
+  lambda or `includes:` file scans a float.
 
 Some options can be disabled to save flash memory without affecting typical ESPHome functionality. The performance
 options (defaulting to `true`) improve socket operation performance but can be disabled if you need better

--- a/src/content/docs/components/esp32.mdx
+++ b/src/content/docs/components/esp32.mdx
@@ -646,9 +646,10 @@ The following options disable unused VFS features to save flash memory:
   link newlib's whole scanf engine (about 13 KB of flash) into every Bluetooth build. ESPHome therefore supplies a
   small `sscanf()` that handles integer, character, string and scanset conversions but not floating point ones.
   At build time ESPHome scans lambda, `includes:` and external component source for any float conversion (`%f`,
-  `%e`, `%g`, `%a` and their variants) and keeps the C library version when it finds one. It cannot see a format
-  string that is built at runtime. Set to `true` if such code needs float parsing with `sscanf()`; otherwise the
-  call stops the device with a message naming the format and this option. Set to `false` to keep the replacement
+  `%e`, `%g`, `%a` and their variants) and keeps the C library version when it finds one; a format that is not a
+  string literal counts as one too. Set to `true` if code the scan cannot see, such as a library fetched at build
+  time, needs float parsing with `sscanf()`; otherwise the call stops the device with a message naming the format
+  and this option. Set to `false` to keep the replacement
   even when the scan finds a float conversion. The replacement only exists in Bluetooth builds on ESP-IDF 5.x
   (newlib); other builds and the Arduino framework use the C library version and ignore this option. The ESP32-C2
   and ESP32-C6 ignore it too, because their ROM already provides `sscanf()` at no flash cost. Defaults to

--- a/src/content/docs/components/esp32.mdx
+++ b/src/content/docs/components/esp32.mdx
@@ -744,7 +744,8 @@ esp32:
 
       # C library options
       enable_full_printf: false  # Saves ~11 KB flash
-      enable_full_scanf: false  # Saves ~13 KB flash on Bluetooth builds
+      # enable_full_scanf is unset by default: Bluetooth builds get the small sscanf
+      # replacement (saves ~13 KB flash) unless a lambda scans a float
 
       # Debug options (disabled by default for production)
       disable_debug_stubs: true  # Saves code size

--- a/src/content/docs/components/esp32.mdx
+++ b/src/content/docs/components/esp32.mdx
@@ -646,11 +646,11 @@ The following options disable unused VFS features to save flash memory:
   link newlib's whole scanf engine (about 13 KB of flash) into every Bluetooth build. ESPHome therefore supplies a
   small `sscanf()` that handles integer, character, string and scanset conversions but not floating point ones.
   At build time ESPHome scans lambda and `includes:` source for any float conversion (`%f`, `%e`, `%g`, `%a` and
-  their variants) and keeps the C library version when it finds one; it cannot see inside external components, so
-  set `true` if one of those needs float parsing with `sscanf()`, otherwise such a call stops the device with a
-  message naming the format and this option. Set to `false` to keep the replacement even when user code scans a
-  float. Has no effect on the ESP32-C2 and ESP32-C6, whose ROM already provides `sscanf()`, or on the Arduino
-  framework. Defaults to automatic: the replacement, or the C library version when user code scans a float.
+  their variants) and keeps the C library version when it finds one. It cannot see inside external components.
+  Set to `true` if an external component needs float parsing with `sscanf()`; otherwise such a call stops the
+  device with a message naming the format and this option. Set to `false` to keep the replacement even when user
+  code scans a float. Has no effect on the ESP32-C2 and ESP32-C6, whose ROM already provides `sscanf()`, or on the
+  Arduino framework. Defaults to automatic: the replacement, or the C library version when user code scans a float.
 
 Some options can be disabled to save flash memory without affecting typical ESPHome functionality. The performance
 options (defaulting to `true`) improve socket operation performance but can be disabled if you need better

--- a/src/content/docs/components/esp32.mdx
+++ b/src/content/docs/components/esp32.mdx
@@ -645,14 +645,14 @@ The following options disable unused VFS features to save flash memory:
   replacement. Nothing in ESPHome calls `sscanf()`, but the Bluetooth stack does in two places, and those two calls
   link newlib's whole scanf engine (about 13 KB of flash) into every Bluetooth build. ESPHome therefore supplies a
   small `sscanf()` that handles integer, character, string and scanset conversions but not floating point ones.
-  At build time ESPHome scans lambda and `includes:` source for any float conversion (`%f`, `%e`, `%g`, `%a` and
-  their variants) and keeps the C library version when it finds one. It cannot see inside external components.
-  Set to `true` if an external component needs float parsing with `sscanf()`; otherwise such a call stops the
-  device with a message naming the format and this option. Set to `false` to keep the replacement even when a
-  lambda or include scans a float. The replacement only exists in Bluetooth builds on ESP-IDF 5.x (newlib); other
-  builds and the Arduino framework use the C library version and ignore this option. The ESP32-C2 and ESP32-C6
-  ignore it too, because their ROM already provides `sscanf()` at no flash cost. Defaults to automatic: the
-  replacement, or the C library version when a lambda or `includes:` file scans a float.
+  At build time ESPHome scans lambda, `includes:` and external component source for any float conversion (`%f`,
+  `%e`, `%g`, `%a` and their variants) and keeps the C library version when it finds one. It cannot see a format
+  string that is built at runtime. Set to `true` if such code needs float parsing with `sscanf()`; otherwise the
+  call stops the device with a message naming the format and this option. Set to `false` to keep the replacement
+  even when the scan finds a float conversion. The replacement only exists in Bluetooth builds on ESP-IDF 5.x
+  (newlib); other builds and the Arduino framework use the C library version and ignore this option. The ESP32-C2
+  and ESP32-C6 ignore it too, because their ROM already provides `sscanf()` at no flash cost. Defaults to
+  automatic: the replacement, or the C library version when the scan finds a float conversion.
 
 Some options can be disabled to save flash memory without affecting typical ESPHome functionality. The performance
 options (defaulting to `true`) improve socket operation performance but can be disabled if you need better

--- a/src/content/docs/components/esp32.mdx
+++ b/src/content/docs/components/esp32.mdx
@@ -646,10 +646,9 @@ The following options disable unused VFS features to save flash memory:
   link newlib's whole scanf engine (about 13 KB of flash) into every Bluetooth build. ESPHome therefore supplies a
   small `sscanf()` that handles integer, character, string and scanset conversions but not floating point ones.
   At build time ESPHome scans lambda, `includes:` and external component source for any float conversion (`%f`,
-  `%e`, `%g`, `%a` and their variants) and keeps the C library version when it finds one; a format that is not a
-  string literal counts as one too. Set to `true` if code the scan cannot see, such as a library fetched at build
-  time, needs float parsing with `sscanf()`; otherwise the call stops the device with a message naming the format
-  and this option. Set to `false` to keep the replacement
+  `%e`, `%g`, `%a` and their variants) and keeps the C library version when it finds one. It cannot see a format
+  string that is built at runtime. Set to `true` if such code needs float parsing with `sscanf()`; otherwise the
+  call stops the device with a message naming the format and this option. Set to `false` to keep the replacement
   even when the scan finds a float conversion. The replacement only exists in Bluetooth builds on ESP-IDF 5.x
   (newlib); other builds and the Arduino framework use the C library version and ignore this option. The ESP32-C2
   and ESP32-C6 ignore it too, because their ROM already provides `sscanf()` at no flash cost. Defaults to

--- a/src/content/docs/components/esp32.mdx
+++ b/src/content/docs/components/esp32.mdx
@@ -645,11 +645,12 @@ The following options disable unused VFS features to save flash memory:
   replacement. Nothing in ESPHome calls `sscanf()`, but the Bluetooth stack does in two places, and those two calls
   link newlib's whole scanf engine (about 13 KB of flash) into every Bluetooth build. ESPHome therefore supplies a
   small `sscanf()` that handles integer, character, string and scanset conversions but not floating point ones.
-  If a lambda uses `sscanf()` with a float format such as `%f`, ESPHome detects it and keeps the C library version
-  automatically. Set to `true` if an external component needs float parsing with `sscanf()`; otherwise such a call
-  stops the device with a message naming this option. Set to `false` to keep the replacement even when a lambda
-  scans a float. Has no effect on the ESP32-C2 and ESP32-C6, whose ROM already provides `sscanf()`, or on the
-  Arduino framework. Defaults to unset (the replacement, unless a lambda scans a float).
+  At build time ESPHome scans lambda and `includes:` source for any float conversion (`%f`, `%e`, `%g`, `%a` and
+  their variants) and keeps the C library version when it finds one; it cannot see inside external components, so
+  set `true` if one of those needs float parsing with `sscanf()`, otherwise such a call stops the device with a
+  message naming the format and this option. Set to `false` to keep the replacement even when user code scans a
+  float. Has no effect on the ESP32-C2 and ESP32-C6, whose ROM already provides `sscanf()`, or on the Arduino
+  framework. Defaults to automatic: the replacement, or the C library version when user code scans a float.
 
 Some options can be disabled to save flash memory without affecting typical ESPHome functionality. The performance
 options (defaulting to `true`) improve socket operation performance but can be disabled if you need better
@@ -744,7 +745,7 @@ esp32:
 
       # C library options
       enable_full_printf: false  # Saves ~11 KB flash
-      # enable_full_scanf: leave unset, saves ~13 KB flash on Bluetooth builds
+      # enable_full_scanf left unset, the replacement saves ~13 KB flash on Bluetooth builds
 
       # Debug options (disabled by default for production)
       disable_debug_stubs: true  # Saves code size

--- a/src/content/docs/components/esp32.mdx
+++ b/src/content/docs/components/esp32.mdx
@@ -641,6 +641,16 @@ The following options disable unused VFS features to save flash memory:
   (saving ~20 KB flash) because ESPHome supplies a `vasprintf` built on the ROM `vsnprintf`. This is automatic and is
   disabled together with `enable_full_printf: true`.
 
+- **enable_full_scanf** (*Optional*, boolean): Link the C library `sscanf()` instead of ESPHome's lightweight
+  replacement. Nothing in ESPHome calls `sscanf()`, but the Bluetooth stack does in two places, and those two calls
+  link newlib's whole scanf engine (about 13 KB of flash) into every Bluetooth build. ESPHome therefore supplies a
+  small `sscanf()` that handles integer, character, string and scanset conversions but not floating point ones.
+  If a lambda uses `sscanf()` with a float format such as `%f`, ESPHome detects it and keeps the C library version
+  automatically. Set to `true` if an external component needs float parsing with `sscanf()`; otherwise such a call
+  stops the device with a message naming this option. Set to `false` to keep the replacement even when a lambda
+  scans a float. Has no effect on the ESP32-C2 and ESP32-C6, whose ROM already provides `sscanf()`, or on the
+  Arduino framework. Defaults to unset (the replacement, unless a lambda scans a float).
+
 Some options can be disabled to save flash memory without affecting typical ESPHome functionality. The performance
 options (defaulting to `true`) improve socket operation performance but can be disabled if you need better
 multi-threaded scalability (which is uncommon since ESPHome uses an event loop).
@@ -734,6 +744,7 @@ esp32:
 
       # C library options
       enable_full_printf: false  # Saves ~11 KB flash
+      enable_full_scanf: false  # Saves ~13 KB flash on Bluetooth builds
 
       # Debug options (disabled by default for production)
       disable_debug_stubs: true  # Saves code size

--- a/src/content/docs/components/esp32.mdx
+++ b/src/content/docs/components/esp32.mdx
@@ -744,8 +744,7 @@ esp32:
 
       # C library options
       enable_full_printf: false  # Saves ~11 KB flash
-      # enable_full_scanf is unset by default: Bluetooth builds get the small sscanf
-      # replacement (saves ~13 KB flash) unless a lambda scans a float
+      # enable_full_scanf: leave unset, saves ~13 KB flash on Bluetooth builds
 
       # Debug options (disabled by default for production)
       disable_debug_stubs: true  # Saves code size

--- a/src/content/docs/components/esp32.mdx
+++ b/src/content/docs/components/esp32.mdx
@@ -650,9 +650,9 @@ The following options disable unused VFS features to save flash memory:
   Set to `true` if an external component needs float parsing with `sscanf()`; otherwise such a call stops the
   device with a message naming the format and this option. Set to `false` to keep the replacement even when a
   lambda or include scans a float. The replacement only exists in Bluetooth builds on ESP-IDF 5.x (newlib); other
-  builds, the Arduino framework, and the ESP32-C2 and ESP32-C6 (whose ROM already provides `sscanf()`) use the C
-  library version and ignore this option. Defaults to automatic: the replacement, or the C library version when a
-  lambda or `includes:` file scans a float.
+  builds and the Arduino framework use the C library version and ignore this option. The ESP32-C2 and ESP32-C6
+  ignore it too, because their ROM already provides `sscanf()` at no flash cost. Defaults to automatic: the
+  replacement, or the C library version when a lambda or `includes:` file scans a float.
 
 Some options can be disabled to save flash memory without affecting typical ESPHome functionality. The performance
 options (defaulting to `true`) improve socket operation performance but can be disabled if you need better


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Documents the new `enable_full_scanf` advanced option for the ESP32 ESP-IDF framework, next to `enable_full_printf`, and adds it to the flash saving example.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#19092

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.
