### PR TITLE
[usb_host] `iManufacturer` and `iProduct` descriptor filters

### DIFF
--- a/src/content/docs/components/usb_host.mdx
+++ b/src/content/docs/components/usb_host.mdx
@@ -42,8 +42,26 @@ usb_host:
 - **id** (*Optional*, [ID](/guides/configuration-types#id)): An id to assign to the device.
 - **vid** (**Required**, int): The vendor ID of the device. Use 0 as a wildcard.
 - **pid** (**Required**, int): The product ID of the device. Use 0 as a wildcard.
+- **manufacturer** (*Optional*, string): Only match a device whose USB manufacturer string is exactly this.
+- **product** (*Optional*, string): Only match a device whose USB product string is exactly this.
 
-Setting both `vid` and `pid` to 0 will match any device.
+Setting both `vid` and `pid` to 0 will match any device. Two configured devices must not be able to
+match the same USB device; the configuration is rejected if they could.
+
+The `manufacturer` and `product` filters tell apart devices that share a vendor and product ID:
+
+```yaml
+usb_host:
+  devices:
+    - id: device_a
+      vid: 0x303A
+      pid: 0x4001
+      product: ZBT-2
+    - id: device_b
+      vid: 0x303A
+      pid: 0x4001
+      product: ZWA-2
+```
 
 If a device is configured and a device is connected that matches the configuration, the device will be
 connected to the ESP32 and log entries will appear at the DEBUG level. If the log level is set to VERBOSE,

--- a/src/content/docs/components/usb_host.mdx
+++ b/src/content/docs/components/usb_host.mdx
@@ -45,7 +45,7 @@ usb_host:
 - **manufacturer** (*Optional*, string): Only match a device whose USB manufacturer string is exactly this.
 - **product** (*Optional*, string): Only match a device whose USB product string is exactly this.
 
-Setting both `vid` and `pid` to 0 will match any device. Two configured devices must not be able to
+Setting `vid` and/or `pid` to 0 will disable filtering for that field. Two configured devices must not be able to
 match the same USB device; the configuration is rejected if they could.
 
 The `manufacturer` and `product` filters tell apart devices that share a vendor and product ID:

--- a/src/content/docs/components/usb_uart.mdx
+++ b/src/content/docs/components/usb_uart.mdx
@@ -52,8 +52,13 @@ usb_uart:
 - **channels** (**Required**, list): A list of channels to configure.
 - **vid** (*Optional*, int): The vendor ID of the device. Use 0 as a wildcard. Each type has a default VID which will be overridden if this is set.
 - **pid** (*Optional*, int): The product ID of the device. Use 0 as a wildcard. Each type has a default PID which will be overridden if this is set.
+- **manufacturer** (*Optional*, string): Only match a device whose USB manufacturer string is exactly this.
+- **product** (*Optional*, string): Only match a device whose USB product string is exactly this.
 
-Setting both `vid` and `pid` to 0 will match any device.
+Setting both `vid` and `pid` to 0 will match any device. Two configured devices must not be able to
+match the same USB device; the configuration is rejected if they could. See the
+[USB Host](/components/usb_host#device-configuration-options) component for an example of telling apart
+devices that share a vendor and product ID.
 
 ## Channel configuration options
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Documents the new `manufacturer` and `product` descriptor filters for `usb_host` and `usb_uart`.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#19095

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
