### PR TITLE
Document the remote_receiver buffer_size unit and defaults

### DIFF
--- a/src/content/docs/components/remote_receiver.mdx
+++ b/src/content/docs/components/remote_receiver.mdx
@@ -80,9 +80,14 @@ Multiple remote receivers can be configured as a list of dict definitions within
     to `100%` or `0` to `4294967295us`.
 
 - **buffer_size** (*Optional*, int): The size in bytes of the internal buffer for storing the remote codes. On ESP32
-  variants with RMT the default is four receive slots derived from `receive_symbols` (3136 bytes at the defaults), and
-  the value can be set explicitly down to two slots. On other platforms each buffered pulse takes 4 bytes; the default
-  is `4000b`, which holds 1000 pulses.
+  variants with RMT one receive slot is `receive_symbols` x 4 + 16 bytes; the default is four slots and an explicit
+  value can go down to two. On other platforms each buffered pulse takes 4 bytes; the default is `4000B`, which holds
+  1000 pulses.
+
+  > [!WARNING]
+  > Before 2026.10.0 the value was applied as a number of pulses on ESP8266, RP2040, LibreTiny, ESP32-C2 and
+  > ESP32-C61, four times the bytes requested. Multiply an explicit `buffer_size` on those platforms by 4 to keep the
+  > same capacity.
 
 - **filter** (*Optional*, [Time](/guides/configuration-types#time)): Filter any pulses that are shorter than this. Useful for removing
   glitches from noisy signals. Allowed values are in range `0` to `4294967295us`. Defaults to `50us`.

--- a/src/content/docs/components/remote_receiver.mdx
+++ b/src/content/docs/components/remote_receiver.mdx
@@ -79,8 +79,10 @@ Multiple remote receivers can be configured as a list of dict definitions within
   - **value** (**Required**, int or [Time](/guides/configuration-types#time)): The percentage or time value. Allowed values are in range `0`
     to `100%` or `0` to `4294967295us`.
 
-- **buffer_size** (*Optional*, int): The size of the internal buffer for storing the remote codes. Defaults to `10kB`
-  on the ESP32 and `1kB` on the ESP8266.
+- **buffer_size** (*Optional*, int): The size in bytes of the internal buffer for storing the remote codes. On ESP32
+  variants with RMT the default is four receive slots derived from `receive_symbols` (3136 bytes at the defaults), and
+  the value can be set explicitly down to two slots. On other platforms each buffered pulse takes 4 bytes; the default
+  is `4000b`, which holds 1000 pulses.
 
 - **filter** (*Optional*, [Time](/guides/configuration-types#time)): Filter any pulses that are shorter than this. Useful for removing
   glitches from noisy signals. Allowed values are in range `0` to `4294967295us`. Defaults to `50us`.

--- a/src/content/docs/components/remote_receiver.mdx
+++ b/src/content/docs/components/remote_receiver.mdx
@@ -80,9 +80,9 @@ Multiple remote receivers can be configured as a list of dict definitions within
     to `100%` or `0` to `4294967295us`.
 
 - **buffer_size** (*Optional*, int): The size in bytes of the internal buffer for storing the remote codes. On ESP32
-  variants with RMT one receive slot is `receive_symbols` x 4 + 16 bytes; the default is four slots and an explicit
-  value can go down to two. On other platforms each buffered pulse takes 4 bytes; the default is `4000B`, which holds
-  1000 pulses.
+  variants with RMT one receive slot is `receive_symbols` x 4 + 16 bytes (784 bytes at the default 192 symbols); the
+  default is four slots, 3136 bytes, and an explicit value below two slots is raised to two. On other platforms each
+  buffered pulse takes 4 bytes; the default is `4000B`, which holds 1000 pulses.
 
   > [!WARNING]
   > Before 2026.10.0 the value was applied as a number of pulses on ESP8266, RP2040, LibreTiny, ESP32-C2 and
@@ -128,7 +128,7 @@ Multiple remote receivers can be configured as a list of dict definitions within
 | ESP32-S3      | 192 symbols      | 48 symbols |
 
 - **receive_symbols** (*Optional*, int): Maximum receive length in symbols. On some variants the maximum receive is
-  limited to `rmt_symbols`.
+  limited to `rmt_symbols`. Defaults to `192`.
 
 - **filter_symbols** (*Optional*, int): Filter out any data received with a length in symbols less than
   `filter_symbols`. Useful for filtering out short bursts of noise.

--- a/src/content/docs/components/remote_receiver.mdx
+++ b/src/content/docs/components/remote_receiver.mdx
@@ -87,7 +87,8 @@ Multiple remote receivers can be configured as a list of dict definitions within
   > [!WARNING]
   > Before 2026.10.0 the value was applied as a number of pulses on ESP8266, RP2040, LibreTiny, ESP32-C2 and
   > ESP32-C61, four times the bytes requested. Multiply an explicit `buffer_size` on those platforms by 4 to keep the
-  > same capacity.
+  > same capacity. On ESP32 variants with RMT the default was `10kB`; an explicit `buffer_size: 10kb` copied from that
+  > can be removed, since the default now follows `receive_symbols`.
 
 - **filter** (*Optional*, [Time](/guides/configuration-types#time)): Filter any pulses that are shorter than this. Useful for removing
   glitches from noisy signals. Allowed values are in range `0` to `4294967295us`. Defaults to `50us`.
@@ -128,7 +129,8 @@ Multiple remote receivers can be configured as a list of dict definitions within
 | ESP32-S3      | 192 symbols      | 48 symbols |
 
 - **receive_symbols** (*Optional*, int): Maximum receive length in symbols. On some variants the maximum receive is
-  limited to `rmt_symbols`. Defaults to `192`.
+  limited to `rmt_symbols`. Defaults to `192` on every variant; the receive slot size follows this value, while the
+  longest frame that can be received is limited by `rmt_symbols` where that is lower.
 
 - **filter_symbols** (*Optional*, int): Filter out any data received with a length in symbols less than
   `filter_symbols`. Useful for filtering out short bursts of noise.

--- a/src/content/docs/guides/setting_up_rmt_devices.mdx
+++ b/src/content/docs/guides/setting_up_rmt_devices.mdx
@@ -100,7 +100,6 @@ remote_receiver:
   tolerance: 25%
   filter: 250us
   idle: 4ms
-  buffer_size: 8kB # only for ESP8266, 2000 pulses
 ```
 
 The `tolerance` setting defaults to `25%`. If a known protocol fails to decode, raise

--- a/src/content/docs/guides/setting_up_rmt_devices.mdx
+++ b/src/content/docs/guides/setting_up_rmt_devices.mdx
@@ -100,7 +100,7 @@ remote_receiver:
   tolerance: 25%
   filter: 250us
   idle: 4ms
-  buffer_size: 2kb # only for ESP8266
+  buffer_size: 8kB # only for ESP8266, 2000 pulses
 ```
 
 The `tolerance` setting defaults to `25%`. If a known protocol fails to decode, raise

--- a/src/content/docs/guides/setting_up_rmt_devices.mdx
+++ b/src/content/docs/guides/setting_up_rmt_devices.mdx
@@ -102,6 +102,9 @@ remote_receiver:
   idle: 4ms
 ```
 
+A noisy receiver that truncates long codes may need `buffer_size` raised above its default; see the
+[remote_receiver](/components/remote_receiver) options.
+
 The `tolerance` setting defaults to `25%`. If a known protocol fails to decode, raise
 it in small steps. Avoid values close to `50%` — wide windows for adjacent timing slots
 within a protocol start to overlap, and the decoder can match the wrong symbol and emit

--- a/src/content/docs/guides/setting_up_rmt_devices.mdx
+++ b/src/content/docs/guides/setting_up_rmt_devices.mdx
@@ -103,7 +103,7 @@ remote_receiver:
 ```
 
 A noisy receiver that truncates long codes may need `buffer_size` raised above its default; see the
-[remote_receiver](/components/remote_receiver) options.
+[remote_receiver](/components/remote_receiver/) options.
 
 The `tolerance` setting defaults to `25%`. If a known protocol fails to decode, raise
 it in small steps. Avoid values close to `50%` — wide windows for adjacent timing slots


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

`buffer_size` is documented as an amount of data but its unit and defaults were out of date. On ESP32 variants with RMT the ring is now sized from `receive_symbols` unless set (esphome/esphome#19100), and on the other platforms the value now means bytes as the option always said, with the default moved to `4000b` so the number of buffered pulses stays at 1000 (esphome/esphome#19101). Anyone with an explicit `buffer_size` on ESP8266, RP2040, LibreTiny, ESP32-C2 or ESP32-C61 should multiply it by 4 to keep the same capacity. The RF guide's `buffer_size: 2kb` line for ESP8266 is removed rather than rescaled: with the unit fixed it would shrink the ring below the default, and the default already holds 1000 pulses; a sentence after the example points noisy receivers at the option.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#19100
- esphome/esphome#19101

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.
