### PR TITLE
[host] Document the native ninja toolchain replacing PlatformIO

### DIFF
--- a/src/content/docs/components/host.mdx
+++ b/src/content/docs/components/host.mdx
@@ -32,6 +32,29 @@ host:
 ## Build and run
 
 The `esphome run yourfile.yaml` command will compile and automatically run the build file on the `host` platform.
+The compiled program is written to `.esphome/build/<name>/.pioenvs/<name>/program`.
+
+### Build requirements
+
+The `host` platform does not use PlatformIO. ESPHome generates a [ninja](https://ninja-build.org/) build and compiles
+the generated sources with the compilers installed on the machine. The following must be available:
+
+- A C++ compiler and a C compiler. ESPHome searches `PATH` for `g++`, `clang++` and `c++` (in that order) for C++, and
+  for `gcc`, `clang` and `cc` for C. Set the `CXX` and `CC` environment variables to use a specific compiler instead.
+  The `AR`, `OBJDUMP` and `READELF` environment variables override the corresponding tools in the same way.
+- `ninja`, either on `PATH` or from the `ninja` Python package bundled with ESPHome.
+
+If [ccache](https://ccache.dev/) is on `PATH` it is used automatically; set `ESPHOME_CCACHE_ENABLE=0` to disable it.
+Its cache is stored under `~/.cache/esphome/host/ccache` (the `ESPHOME_HOST_PREFIX` environment variable changes the
+root directory) and is removed by `esphome clean-all`.
+
+Libraries declared by components, `esphome.libraries` or `platformio_options.lib_deps` are fetched from the PlatformIO
+registry or git into `.esphome/pio_components/host/` and built into archives. A bare git checkout without a
+`library.json` or `library.properties` file is built using PlatformIO's default layout (`src/` and `include/`).
+
+Only the `build_unflags`, `lib_deps` and `lib_ignore` keys of `esphome.platformio_options` apply on `host`; other keys
+are ignored with a warning. `platformio_options.build_flags` still works but is deprecated in favour of
+`esphome.build_flags`.
 
 ## Preferences
 

--- a/src/content/docs/guides/cli.mdx
+++ b/src/content/docs/guides/cli.mdx
@@ -61,10 +61,12 @@ Please see [command line substitutions](/components/substitutions#command-line-s
 : Selects which toolchain to use for compiling the project. Supported values are:
 
 * `esp-idf` (ESP32 only)
+* `host` (host platform only)
 * `platformio`
 
 The toolchain can be configured using `esp32.toolchain` (see the [ESP32 toolchain configuration](/components/esp32#esp32-toolchain)).
-If not specified, ESP32 devices default to `esp-idf`; all other platforms use `platformio`.
+The host platform always uses `host` and rejects any other value. If not specified, ESP32 devices default to
+`esp-idf`; the remaining platforms use `platformio`.
 If both `esp32.toolchain` and the `--toolchain` CLI option are set, the CLI option takes precedence.
 
 Please see [ESP-IDF toolchain documentation](/guides/esp_idf/) for details on using the ESP-IDF integration.


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

The host platform no longer builds through PlatformIO. ESPHome generates a ninja build and compiles the generated sources with the machine's own C and C++ compiler, selected through a new `host` toolchain that the host platform always uses.

- `guides/cli.mdx`: add `host` to the `--toolchain` values and state that the host platform always uses `host`, ESP32 defaults to `esp-idf` and the remaining platforms use `platformio`.
- `components/host.mdx`: add a "Build requirements" subsection covering the compiler lookup order and the `CC`/`CXX`/`AR`/`OBJDUMP`/`READELF` overrides, where `ninja` comes from, automatic `ccache` use with its opt-out and cache location, how component libraries are fetched and built, and which `esphome.platformio_options` keys still apply on host. Also notes the compiled program's output path.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#19214

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
