### PR TITLE
Document the esp32 flash chip option

### DIFF
--- a/src/content/docs/components/esp32.mdx
+++ b/src/content/docs/components/esp32.mdx
@@ -517,10 +517,15 @@ esp32:
   DRAM each. Naming the vendor drops the rest, roughly 1 KB of IRAM on the original ESP32 and 2 to 3 KB on the
   ESP32-S3.
 
-  Leave it unset first: ESPHome logs a line at boot such as `Flash driver gd in use. Set flash_chip: gd under
-  esp32 > framework > advanced` with the value to use. The value must match the flash on the board; ISSI and MXIC
-  chips and larger GigaDevice chips need their own driver for quad mode, and 32 MB Winbond and GigaDevice chips
-  need it for addressing. With a wrong value the generic driver is used and ESPHome logs a warning at boot.
+  Leave it unset first: ESPHome logs a line at boot such as `Set flash_chip: gd under esp32 > framework > advanced`
+  with the value to use.
+
+  A wrong value falls back to the generic driver and ESPHome logs a warning at boot. In the default `dio` and
+  `dout` flash modes that is the whole effect; the generic driver works with every chip. In `qio` and `qout`
+  mode an ISSI or MXIC chip, or a larger GigaDevice chip, needs its own driver to enable quad mode, and flash
+  init can fail at startup; an OTA update then rolls back to the previous firmware, a USB flash needs to be
+  repeated with the right value. Winbond and GigaDevice chips above 16 MB are limited to 16 MB under the generic
+  driver.
 
 - **enable_idf_experimental_features** (*Optional*, boolean): Can be set to `true` to enable experimental features. Use of
   experimental features may cause instability or other issues.

--- a/src/content/docs/components/esp32.mdx
+++ b/src/content/docs/components/esp32.mdx
@@ -511,6 +511,17 @@ esp32:
   the bootloader is already compatible. ESPHome will log a suggestion at boot if it detects a compatible bootloader
   and this option is not yet enabled.
 
+- **flash_chip** (*Optional*, string): Keep only the SPI flash vendor driver the board needs. One of `generic`,
+  `gd`, `issi`, `mxic`, `winbond`, `boya`, `th`, or `mxic_opi` (ESP32-S3 only). ESP-IDF links a driver for every
+  vendor it supports and picks one at boot from the flash ID; the others still take IRAM and about 124 bytes of
+  DRAM each. Naming the vendor drops the rest, roughly 1 KB of IRAM on the original ESP32 and 2 to 3 KB on the
+  ESP32-S3.
+
+  Leave it unset first: ESPHome logs a line at boot such as `Flash driver gd in use. Set flash_chip: gd under
+  esp32 > framework > advanced` with the value to use. The value must match the flash on the board; ISSI and MXIC
+  chips and larger GigaDevice chips need their own driver for quad mode, and 32 MB Winbond and GigaDevice chips
+  need it for addressing. With a wrong value the generic driver is used and ESPHome logs a warning at boot.
+
 - **enable_idf_experimental_features** (*Optional*, boolean): Can be set to `true` to enable experimental features. Use of
   experimental features may cause instability or other issues.
 
@@ -745,6 +756,8 @@ esp32:
       disable_fatfs: true  # Saves code size (auto-enabled by SD card components)
       disable_regi2c_in_iram: true  # Saves IRAM
       adc_oneshot_in_iram: false  # Auto-enabled by ADC component
+
+      # flash_chip: gd  # Keep one flash vendor driver; the boot log names the value
 
       # ESP32 (original) only options
       # sram1_as_iram: true  # +40 KB IRAM (requires bootloader from ESP-IDF >= 5.1)

--- a/src/content/docs/components/esp32.mdx
+++ b/src/content/docs/components/esp32.mdx
@@ -512,10 +512,10 @@ esp32:
   and this option is not yet enabled.
 
 - **flash_chip** (*Optional*, string): Keep only the SPI flash vendor driver the board needs. One of `generic`,
-  `gd`, `issi`, `mxic`, `winbond`, `boya`, `th`, or `mxic_opi` (ESP32-S3 with `flash_mode: opi` only). ESP-IDF links a driver for every
-  vendor it supports and picks one at boot from the flash ID; the others still take IRAM and about 124 bytes of
-  DRAM each. Naming the vendor drops the rest, roughly 1 KB of IRAM on the original ESP32 and 2 to 3 KB on the
-  ESP32-S3.
+  `gd`, `issi`, `mxic`, `winbond`, `boya`, `th`, or `mxic_opi` (ESP32-S3 with `flash_mode: opi` only). ESP-IDF
+  links a driver for every vendor it supports and picks one at boot from the flash ID; the others still take IRAM
+  and about 124 bytes of DRAM each. Naming the vendor drops the rest, roughly 1 KB of IRAM on the original ESP32
+  and 2 to 3 KB on the ESP32-S3.
 
   Leave it unset first: ESPHome logs a line at boot such as `Set flash_chip: gd under esp32 > framework > advanced`
   with the value to use.

--- a/src/content/docs/components/esp32.mdx
+++ b/src/content/docs/components/esp32.mdx
@@ -512,7 +512,7 @@ esp32:
   and this option is not yet enabled.
 
 - **flash_chip** (*Optional*, string): Keep only the SPI flash vendor driver the board needs. One of `generic`,
-  `gd`, `issi`, `mxic`, `winbond`, `boya`, `th`, or `mxic_opi` (ESP32-S3 only). ESP-IDF links a driver for every
+  `gd`, `issi`, `mxic`, `winbond`, `boya`, `th`, or `mxic_opi` (ESP32-S3 with `flash_mode: opi` only). ESP-IDF links a driver for every
   vendor it supports and picks one at boot from the flash ID; the others still take IRAM and about 124 bytes of
   DRAM each. Naming the vendor drops the rest, roughly 1 KB of IRAM on the original ESP32 and 2 to 3 KB on the
   ESP32-S3.


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Documents the new `flash_chip` option under `esp32 > framework > advanced`. ESP-IDF links a flash driver for every vendor it supports and picks one at boot; naming the vendor drops the others and frees IRAM and DRAM. The entry lists the values, says to leave it unset first and read the value from the boot log line ESPHome prints, and warns that the value must match the flash because ISSI, MXIC and larger GigaDevice chips need their own driver for quad mode. The advanced example block gets a commented line next to `sram1_as_iram`.

**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#19217

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>
