### PR TITLE
[icm20689] Add ICM-20689 Accelerometer/Gyroscope documentation

### DIFF
--- a/src/content/docs/components/index.mdx
+++ b/src/content/docs/components/index.mdx
@@ -549,6 +549,7 @@ Sensors are organized into categories; if a given sensor fits into more than one
   ["APDS9960", "/components/sensor/apds9960/", "apds9960.jpg", "Colour & Gesture"],
   ["BMI160", "/components/sensor/bmi160/", "bmi160.jpg", "Accelerometer & Gyroscope"],
   ["BMI270", "/components/motion/bmi270/", "imu.svg", "Accelerometer & Gyroscope", "dark-invert"],
+  ["ICM-20689", "/components/motion/icm20689/", "imu.svg", "Accelerometer & Gyroscope", "dark-invert"],
   ["LD2410", "/components/sensor/ld2410/", "ld2410.jpg", "Motion & Presence"],
   ["LD2412", "/components/sensor/ld2412/", "ld2412.jpg", "Motion & Presence"],
   ["LD2420", "/components/sensor/ld2420/", "ld2420.jpg", "Motion & Presence"],
@@ -968,6 +969,7 @@ Used for creating infrared (IR) remote control transmitters and/or receivers.
 <ImgTable items={[
   ["Motion Core", "/components/motion/", "imu.svg", "IMU", "dark-invert"],
   ["BMI270", "/components/motion/bmi270/", "imu.svg", "Accelerometer & Gyroscope", "dark-invert"],
+  ["ICM-20689", "/components/motion/icm20689/", "imu.svg", "Accelerometer & Gyroscope", "dark-invert"],
   ["LSM6DS", "/components/motion/lsm6ds/", "imu.svg", "Accelerometer & Gyroscope", "dark-invert"],
   ["QMI8658", "/components/motion/qmi8658/", "imu.svg", "Accelerometer & Gyroscope", "dark-invert"],
 ]} />

--- a/src/content/docs/components/motion/icm20689.mdx
+++ b/src/content/docs/components/motion/icm20689.mdx
@@ -1,0 +1,55 @@
+---
+description: "Instructions for setting up ICM-20689 Accelerometer/Gyroscope sensors."
+title: "ICM-20689 Accelerometer/Gyroscope Sensor"
+---
+
+import APIRef from '@components/APIRef.astro';
+
+The `icm20689` motion platform allows you to use your TDK InvenSense ICM-20689 Accelerometer/Gyroscope
+sensors with ESPHome. The [SPI Bus](/components/spi) is required to be set up in
+your configuration for this sensor to work.
+
+The ICM-20689 is a 6-axis IMU including a 16-bit 3-axis accelerometer and a 16-bit 3-axis gyroscope,
+plus an on-chip temperature sensor.
+
+```yaml
+# Example configuration entry
+spi:
+  - id: spi_bus
+    clk_pin: GPIOXX
+    mosi_pin: GPIOXX
+    miso_pin: GPIOXX
+
+motion:
+  - platform: icm20689
+    cs_pin: GPIOXX
+    accelerometer_range: 4G
+    gyroscope_range: 2000DPS
+
+sensor:
+  - platform: motion
+    type: acceleration_x
+    name: "ICM-20689 Accel X"
+  - platform: motion
+    type: gyroscope_x
+    name: "ICM-20689 Gyro X"
+  - platform: motion
+    type: roll
+    name: "ICM-20689 Roll"
+```
+
+## Configuration variables
+
+- **cs_pin** (**Required**, [Pin Schema](/guides/configuration-types#pin-schema)): The CS pin of the sensor.
+- **accelerometer_range** (*Optional*, string): The full-scale range of the accelerometer. One of
+  `2G`, `4G`, `8G`, `16G`. Defaults to `2G`.
+- **gyroscope_range** (*Optional*, string): The full-scale range of the gyroscope. One of
+  `250DPS`, `500DPS`, `1000DPS`, `2000DPS`. Defaults to `250DPS`.
+
+- All other options from [Motion](/components/motion) and
+  [SPI Device](/components/spi#generic-spi-device-component).
+
+## See Also
+
+- [ICM-20689 Temperature Sensor](/components/sensor/icm20689/)
+- <APIRef text="icm20689.h" path="icm20689/icm20689.h" />

--- a/src/content/docs/components/motion/index.mdx
+++ b/src/content/docs/components/motion/index.mdx
@@ -192,6 +192,7 @@ entry with the resulting matrix in a format suitable for copy-pasting into your 
 
 ## See Also
 
+- [ICM-20689 Accelerometer/Gyroscope platform](/components/motion/icm20689/)
 - [QMI8658 Accelerometer/Gyroscope platform](/components/motion/qmi8658/)
 - [Sensor Filters](/components/sensor#sensor-filters)
 - [BMI270 Accelerometer/Gyroscope platform](/components/motion/bmi270/)

--- a/src/content/docs/components/sensor/icm20689.mdx
+++ b/src/content/docs/components/sensor/icm20689.mdx
@@ -1,0 +1,31 @@
+---
+description: "Instructions for setting up ICM-20689 temperature sensor."
+title: "ICM-20689 Temperature Sensor"
+---
+
+The `icm20689` sensor platform provides access to the temperature sensor in a TDK InvenSense ICM-20689
+Accelerometer/Gyroscope with ESPHome. It requires a [`motion`](/components/motion) component to be configured with
+the `icm20689` platform, which handles the accelerometer and gyroscope data processing and configures the device.
+See that component for more information.
+
+```yaml
+# Example configuration entry
+motion:
+  - platform: icm20689
+    cs_pin: GPIOXX
+
+sensor:
+  - platform: icm20689
+    type: temperature # Optional, temperature is the only supported type for this platform
+    name: "ICM-20689 Temperature"
+```
+
+## Configuration variables
+
+- **type** (*Optional*, string): Must be set to `temperature`, or simply omitted.
+- All other options from [Sensor](/components/sensor).
+
+## See Also
+
+- [Sensor Filters](/components/sensor#sensor-filters)
+- [ICM-20689 Accelerometer/Gyroscope platform](/components/motion/icm20689/)


### PR DESCRIPTION
## Description

Adds documentation for the new `icm20689` component: a `motion` platform for the TDK InvenSense
ICM-20689 6-axis accelerometer/gyroscope (SPI), plus its `sensor` platform for the on-chip temperature
sensor. Registers the component in the component index (`/src/content/docs/components/index.mdx`) and
in the `motion` component's "See Also" list.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#19234

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [x] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)