### PR TITLE
[remote_base] Document pioneer_wyt remote protocol

### DIFF
--- a/src/content/docs/components/remote_receiver.mdx
+++ b/src/content/docs/components/remote_receiver.mdx
@@ -58,7 +58,6 @@ Multiple remote receivers can be configured as a list of dict definitions within
   - **nexa**: Decode and dump Nexa (RF) codes.
   - **panasonic**: Decode and dump Panasonic infrared codes.
   - **pioneer**: Decode and dump Pioneer infrared codes.
-  - **pioneer_wyt**: Decode and dump Pioneer Wyt infrared codes.
   - **pronto**: Print remote code in Pronto form. Useful for using arbitrary protocols.
   - **raw**: Print all remote codes in their raw form. Also useful for using arbitrary protocols.
   - **rc5**: Decode and dump RC5 IR codes.
@@ -245,10 +244,6 @@ To enable signal demodulation, configure the signal carrier frequency and duty c
 
 - **on_pioneer** (*Optional*, [Automation](/automations)): An automation to perform when a
   pioneer remote code has been decoded. A variable `x` of type <APIStruct text="remote_base::PioneerData" path="remote_base::PioneerData" />
-  is passed to the automation for use in lambdas.
-
-- **on_pioneer_wyt** (*Optional*, [Automation](/automations)): An automation to perform when a
-  Pioneer Wyt remote code has been decoded. A variable `x` of type <APIStruct text="remote_base::PioneerWytData" path="remote_base::PioneerWytData" />
   is passed to the automation for use in lambdas.
 
 - **on_pronto** (*Optional*, [Automation](/automations)): An automation to perform when a
@@ -512,10 +507,6 @@ Remote code selection (exactly one of these has to be included):
 - **pioneer**: Trigger on a decoded Pioneer remote code with the given data.
 
   - **rc_code_1** (**Required**, int): The remote control code to trigger on, see dumper output for more details.
-
-- **pioneer_wyt**: Trigger on a decoded Pioneer Wyt remote code with the given data.
-
-  - **code** (**Required**, 13-bytes list): The 13 bytes representing the Pioneer Wyt payload to trigger on.
 
 - **pronto**: Trigger on a Pronto remote code with the given code.
 

--- a/src/content/docs/components/remote_receiver.mdx
+++ b/src/content/docs/components/remote_receiver.mdx
@@ -58,6 +58,7 @@ Multiple remote receivers can be configured as a list of dict definitions within
   - **nexa**: Decode and dump Nexa (RF) codes.
   - **panasonic**: Decode and dump Panasonic infrared codes.
   - **pioneer**: Decode and dump Pioneer infrared codes.
+  - **pioneer_wyt**: Decode and dump Pioneer Wyt infrared codes.
   - **pronto**: Print remote code in Pronto form. Useful for using arbitrary protocols.
   - **raw**: Print all remote codes in their raw form. Also useful for using arbitrary protocols.
   - **rc5**: Decode and dump RC5 IR codes.
@@ -244,6 +245,10 @@ To enable signal demodulation, configure the signal carrier frequency and duty c
 
 - **on_pioneer** (*Optional*, [Automation](/automations)): An automation to perform when a
   pioneer remote code has been decoded. A variable `x` of type <APIStruct text="remote_base::PioneerData" path="remote_base::PioneerData" />
+  is passed to the automation for use in lambdas.
+
+- **on_pioneer_wyt** (*Optional*, [Automation](/automations)): An automation to perform when a
+  Pioneer Wyt remote code has been decoded. A variable `x` of type <APIStruct text="remote_base::PioneerWytData" path="remote_base::PioneerWytData" />
   is passed to the automation for use in lambdas.
 
 - **on_pronto** (*Optional*, [Automation](/automations)): An automation to perform when a
@@ -507,6 +512,10 @@ Remote code selection (exactly one of these has to be included):
 - **pioneer**: Trigger on a decoded Pioneer remote code with the given data.
 
   - **rc_code_1** (**Required**, int): The remote control code to trigger on, see dumper output for more details.
+
+- **pioneer_wyt**: Trigger on a decoded Pioneer Wyt remote code with the given data.
+
+  - **code** (**Required**, array): The 13 bytes representing the Pioneer Wyt payload to trigger on.
 
 - **pronto**: Trigger on a Pronto remote code with the given code.
 

--- a/src/content/docs/components/remote_receiver.mdx
+++ b/src/content/docs/components/remote_receiver.mdx
@@ -515,7 +515,7 @@ Remote code selection (exactly one of these has to be included):
 
 - **pioneer_wyt**: Trigger on a decoded Pioneer Wyt remote code with the given data.
 
-  - **code** (**Required**, array): The 13 bytes representing the Pioneer Wyt payload to trigger on.
+  - **code** (**Required**, 13-bytes list): The 13 bytes representing the Pioneer Wyt payload to trigger on.
 
 - **pronto**: Trigger on a Pronto remote code with the given code.
 

--- a/src/content/docs/components/remote_transmitter.mdx
+++ b/src/content/docs/components/remote_transmitter.mdx
@@ -716,7 +716,7 @@ on_...:
 
 #### Configuration variables
 
-- **code** (*Optional*, list of 13 bytes, [templatable](/automations/templates)): The 13 bytes representing the raw payload.
+- **code** (*Optional*, list of 13 or 14 bytes, [templatable](/automations/templates)): The 13 or 14 bytes representing the raw payload.
 - **type** (*Optional*, string, [templatable](/automations/templates)): The command type to send. One of `GENERAL`, `FAN`, or `BOTH` (default: `BOTH`).
 - **power** (*Optional*, boolean, [templatable](/automations/templates)): Power state of the AC. Defaults to `true`.
 - **mode** (*Optional*, string, [templatable](/automations/templates)): Operation mode. One of `HEAT`, `DRY`, `COOL`, `FAN`, `AUTO`. Defaults to `COOL`.

--- a/src/content/docs/components/remote_transmitter.mdx
+++ b/src/content/docs/components/remote_transmitter.mdx
@@ -697,7 +697,7 @@ are largely shared among devices within a given class.
 
 ### `remote_transmitter.transmit_pioneer_wyt` Action
 
-This [action](/automations/actions#all-actions) sends a Pioneer Wyt infrared remote command to a remote transmitter. It supports sending raw code arrays or specifying individual friendly fields.
+This [action](/automations/actions#all-actions) sends a Pioneer Wyt infrared remote command to a remote transmitter. It supports sending a raw code list or specifying individual friendly fields.
 
 ```yaml
 on_...:

--- a/src/content/docs/components/remote_transmitter.mdx
+++ b/src/content/docs/components/remote_transmitter.mdx
@@ -701,11 +701,11 @@ This [action](/automations/actions#all-actions) sends a Pioneer Wyt infrared rem
 
 ```yaml
 on_...:
-  # Sending via raw code array:
+  # Sending via raw code list:
   - remote_transmitter.transmit_pioneer_wyt:
       code: [0xD3, 0x26, 0x00, 0x01, 0x00, 0x20, 0x00, 0x00, 0x30, 0x00, 0x00, 0x00, 0x00]
 
-  # Sending via friendly fields (default sends both Fan and General commands sequentially):
+  # Sending via friendly fields (default sends both `FAN` and `GENERAL` commands sequentially):
   - remote_transmitter.transmit_pioneer_wyt:
       power: true
       mode: COOL
@@ -716,7 +716,7 @@ on_...:
 
 #### Configuration variables
 
-- **code** (*Optional*, array of 13 hex bytes, [templatable](/automations/templates)): The 13 bytes representing the raw payload.
+- **code** (*Optional*, list of 13 bytes, [templatable](/automations/templates)): The 13 bytes representing the raw payload.
 - **type** (*Optional*, string, [templatable](/automations/templates)): The command type to send. One of `GENERAL`, `FAN`, or `BOTH` (default: `BOTH`).
 - **power** (*Optional*, boolean, [templatable](/automations/templates)): Power state of the AC. Defaults to `true`.
 - **mode** (*Optional*, string, [templatable](/automations/templates)): Operation mode. One of `HEAT`, `DRY`, `COOL`, `FAN`, `AUTO`. Defaults to `COOL`.
@@ -727,7 +727,7 @@ on_...:
 - **turbo** (*Optional*, boolean, [templatable](/automations/templates)): Enable/disable Turbo mode. Defaults to `false`.
 - **sleep** (*Optional*, boolean, [templatable](/automations/templates)): Enable/disable Sleep mode. Defaults to `false`.
 - **follow_me** (*Optional*, boolean, [templatable](/automations/templates)): Enable/disable Follow Me (I-Feel) mode. Defaults to `false`.
-- **remote_temp** (*Optional*, integer, [templatable](/automations/templates)): Current room temperature feedback for Follow Me mode. Defaults to `0`.
+- **remote_temp** (*Optional*, int, [templatable](/automations/templates)): Current room temperature feedback for Follow Me mode. Defaults to `0`.
 - **fan_speed** (*Optional*, string, [templatable](/automations/templates)): The fan speed. One of `AUTO`, `LOW`, `MEDIUM_LOW`, `MEDIUM`, `MEDIUM_HIGH`, `HIGH`. Defaults to `AUTO`.
 - **mute** (*Optional*, boolean, [templatable](/automations/templates)): Enable/disable Silent mode. Defaults to `false`.
 - **vertical_swing** (*Optional*, boolean, [templatable](/automations/templates)): Enable/disable vertical swing. Defaults to `false`.

--- a/src/content/docs/components/remote_transmitter.mdx
+++ b/src/content/docs/components/remote_transmitter.mdx
@@ -693,6 +693,47 @@ At the time this action was created, Pioneer maintained listings of [IR codes](h
 If unable to find your specific device in the documentation, find a device in the same class; the codes
 are largely shared among devices within a given class.
 
+<span id="remote_transmitter-transmit_pioneer_wyt"></span>
+
+### `remote_transmitter.transmit_pioneer_wyt` Action
+
+This [action](/automations/actions#all-actions) sends a Pioneer Wyt infrared remote command to a remote transmitter. It supports sending raw code arrays or specifying individual friendly fields.
+
+```yaml
+on_...:
+  # Sending via raw code array:
+  - remote_transmitter.transmit_pioneer_wyt:
+      code: [0xD3, 0x26, 0x00, 0x01, 0x00, 0x20, 0x00, 0x00, 0x30, 0x00, 0x00, 0x00, 0x00]
+
+  # Sending via friendly fields (default sends both Fan and General commands sequentially):
+  - remote_transmitter.transmit_pioneer_wyt:
+      power: true
+      mode: COOL
+      target_temperature: 22.0
+      fan_speed: HIGH
+      vertical_swing: true
+```
+
+#### Configuration variables
+
+- **code** (*Optional*, array of 13 hex bytes, [templatable](/automations/templates)): The 13 bytes representing the raw payload.
+- **type** (*Optional*, string, [templatable](/automations/templates)): The command type to send. One of `GENERAL`, `FAN`, or `BOTH` (default: `BOTH`).
+- **power** (*Optional*, boolean, [templatable](/automations/templates)): Power state of the AC. Defaults to `true`.
+- **mode** (*Optional*, string, [templatable](/automations/templates)): Operation mode. One of `HEAT`, `DRY`, `COOL`, `FAN`, `AUTO`. Defaults to `COOL`.
+- **target_temperature** (*Optional*, float, [templatable](/automations/templates)): The target temperature in °C. Defaults to `24.0`.
+- **beeper** (*Optional*, boolean, [templatable](/automations/templates)): Enable/disable beeper feedback. Defaults to `true`.
+- **display** (*Optional*, boolean, [templatable](/automations/templates)): Enable/disable the display on the unit. Defaults to `true`.
+- **eco** (*Optional*, boolean, [templatable](/automations/templates)): Enable/disable Eco mode. Defaults to `false`.
+- **turbo** (*Optional*, boolean, [templatable](/automations/templates)): Enable/disable Turbo mode. Defaults to `false`.
+- **sleep** (*Optional*, boolean, [templatable](/automations/templates)): Enable/disable Sleep mode. Defaults to `false`.
+- **follow_me** (*Optional*, boolean, [templatable](/automations/templates)): Enable/disable Follow Me (I-Feel) mode. Defaults to `false`.
+- **remote_temp** (*Optional*, integer, [templatable](/automations/templates)): Current room temperature feedback for Follow Me mode. Defaults to `0`.
+- **fan_speed** (*Optional*, string, [templatable](/automations/templates)): The fan speed. One of `AUTO`, `LOW`, `MEDIUM_LOW`, `MEDIUM`, `MEDIUM_HIGH`, `HIGH`. Defaults to `AUTO`.
+- **mute** (*Optional*, boolean, [templatable](/automations/templates)): Enable/disable Silent mode. Defaults to `false`.
+- **vertical_swing** (*Optional*, boolean, [templatable](/automations/templates)): Enable/disable vertical swing. Defaults to `false`.
+- **horizontal_swing** (*Optional*, boolean, [templatable](/automations/templates)): Enable/disable horizontal swing. Defaults to `false`.
+- All other options from [Remote Transmitter Actions](#remote_transmitter-transmit_action).
+
 <span id="remote_transmitter-transmit_pronto"></span>
 
 ### `remote_transmitter.transmit_pronto` Action


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Supersedes #6841, which was closed by the stale bot and is now locked.

**Related issue (if applicable):** N/A

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):**

- esphome/esphome#17175

## Checklist

- [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.
  or
- [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

- [ ] Link added in `/src/content/docs/components/index.mdx` when creating new documents for new components or cookbook.

<details>
<summary><strong>New Component Images</strong></summary>

If you are adding a new component to ESPHome, you can automatically generate a standardized black and white component name image for the documentation.

**To generate a component image:**

1. Comment on this pull request with the following command, replacing `component_name` with your component name in **lower_case** format with **underscores** (e.g., `bme280`, `sht3x`, `dallas_temp`):

   ```
   @esphomebot generate image component_name
   ```

2. The ESPHome bot will respond with a downloadable ZIP file containing the SVG image.

3. Extract the SVG file and place it in the `/public/images/` folder of this repository.

4. Use the image in your component's index table entry in `/src/content/docs/components/index.mdx`.

**Example:** For a component called "DHT22 Temperature Sensor", use:

```
@esphomebot generate image dht22
```

**Note:** All images used in ImgTable components must be placed in `/public/images/` as the component resolves them to absolute paths.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
